### PR TITLE
BUG-44248: Fix iotas jar shading issues and add logging.

### DIFF
--- a/parsers/pom.xml
+++ b/parsers/pom.xml
@@ -15,6 +15,13 @@
             <groupId>com.hortonworks</groupId>
             <artifactId>core</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -31,14 +38,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-protobuf</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -58,5 +57,66 @@
                 <directory>${project.basedir}/src/test/resources</directory>
             </testResource>
         </testResources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.3</version>
+                <configuration>
+                    <createDependencyReducedPom>true</createDependencyReducedPom>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass></mainClass>
+                                </transformer>
+                            </transformers>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson.core</pattern>
+                                    <shadedPattern>com.fasterxml.jackson.parser.core</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson.databind</pattern>
+                                    <shadedPattern>com.fasterxml.jackson.parser.databind</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/parsers/src/main/java/com/hortonworks/iotas/parsers/json/JsonParser.java
+++ b/parsers/src/main/java/com/hortonworks/iotas/parsers/json/JsonParser.java
@@ -50,7 +50,6 @@ public class JsonParser extends BaseParser {
         try {
             return mapper.readValue(data, new TypeReference<Map<String, Object>>(){});
         } catch (IOException e) {
-            LOG.error("Error trying to parse data {}", new String(data, Charset.forName("UTF-8")));
             throw new ParseException("Error trying to parse data.", e);
         }
     }

--- a/storm/pom.xml
+++ b/storm/pom.xml
@@ -125,6 +125,16 @@
                             </excludes>
                         </filter>
                     </filters>
+                    <relocations>
+                        <relocation>
+                            <pattern>com.fasterxml.jackson.core</pattern>
+                            <shadedPattern>com.fasterxml.jackson.iotas.core</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.fasterxml.jackson.databind</pattern>
+                            <shadedPattern>com.fasterxml.jackson.iotas.databind</shadedPattern>
+                        </relocation>
+                    </relocations>
                 </configuration>
                 <executions>
                     <execution>

--- a/storm/src/main/java/com/hortonworks/bolt/ParserBolt.java
+++ b/storm/src/main/java/com/hortonworks/bolt/ParserBolt.java
@@ -96,6 +96,8 @@ public class ParserBolt extends BaseRichBolt {
             collector.emit(input, values);
             collector.ack(input);
         } catch (Exception e) {
+            LOG.warn("Failed to parse a tuple. Saving it using " +
+                    "UnparsedTupleHandler implementation.", e);
             if (this.unparsedTupleHandler != null) {
                 try {
                     this.unparsedTupleHandler.save(failedBytes);


### PR DESCRIPTION
When shading for com.fasterxml.jackson.databind was added to storm
module, the parser class could not be instantiated. Reason was that
ObjectMapper it was using was not packaged in parser jar. Hence had to
add maven-shade-plugin to parser/pom.xml. Once that was added, it was
clashing with storm cores jackson classes. Hence shading in
parsers/pom.xml. Packaging a fat jar for parsers module now was also
bringing in hadoop-client and slf4j-api and slf4j-log4j12. These
dependencies were relying on some other jars to be available at runtime
that was causing issues. Hence they either had to excluded or removed
from dependency.
