### PR TITLE
Fixing unit test failure in ParserBoltTest & ParserOutputHBaseMapperTest

### DIFF
--- a/storm/src/test/java/com/hortonworks/bolt/MockParser.java
+++ b/storm/src/test/java/com/hortonworks/bolt/MockParser.java
@@ -1,6 +1,8 @@
 package com.hortonworks.bolt;
 
 import com.google.common.collect.Lists;
+import com.hortonworks.iotas.common.IotasEvent;
+import com.hortonworks.iotas.common.IotasEventImpl;
 import com.hortonworks.iotas.common.Schema;
 import com.hortonworks.iotas.parser.ParseException;
 import com.hortonworks.iotas.parser.Parser;
@@ -18,6 +20,8 @@ public class MockParser implements Parser {
     public static final Map<String, Object> PARSER_OUTPUT = new HashMap<String, Object>() {{
         put("a","b");
     }};
+
+    public static final IotasEvent IOTAS_EVENT = new IotasEventImpl(PARSER_OUTPUT, "dsrcid");
 
     @Override
     public String version() {

--- a/storm/src/test/java/com/hortonworks/bolt/ParserBoltTest.java
+++ b/storm/src/test/java/com/hortonworks/bolt/ParserBoltTest.java
@@ -8,23 +8,28 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Charsets;
 import com.hortonworks.client.RestClient;
 import com.hortonworks.iotas.catalog.ParserInfo;
+import com.hortonworks.iotas.common.IotasEvent;
+import com.hortonworks.iotas.common.IotasEventImpl;
 import com.hortonworks.iotas.model.IotasMessage;
 import mockit.Expectations;
 import mockit.Mocked;
 import mockit.Tested;
 import mockit.VerificationsInOrder;
+import mockit.integration.junit4.JMockit;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.io.ByteArrayInputStream;
 
+@RunWith(JMockit.class)
 public class ParserBoltTest {
 
     private static final Long PARSER_ID = 1l;
     private static final String DEVICE_ID = "1";
     private static final Long VERSION = 1l;
     private static final byte[] DATA = "test".getBytes(Charsets.UTF_8);
-    private static final Values VALUES = new Values(MockParser.PARSER_OUTPUT);
+    private static final Values VALUES = new Values(MockParser.IOTAS_EVENT);
 
     private IotasMessage msg;
     private @Tested ParserBolt parserBolt;
@@ -96,7 +101,7 @@ public class ParserBoltTest {
 
         if(isSuccess) {
             new VerificationsInOrder() {{
-                mockOutputCollector.emit(mockTuple, VALUES);
+                mockOutputCollector.emit(mockTuple, withAny(VALUES));
                 mockOutputCollector.ack(mockTuple);
             }};
 

--- a/storm/src/test/java/com/hortonworks/hbase/ParserOutputHBaseMapperTest.java
+++ b/storm/src/test/java/com/hortonworks/hbase/ParserOutputHBaseMapperTest.java
@@ -3,12 +3,16 @@ package com.hortonworks.hbase;
 import backtype.storm.tuple.Tuple;
 import com.google.common.base.Charsets;
 import com.hortonworks.bolt.ParserBolt;
+import com.hortonworks.iotas.common.IotasEvent;
+import com.hortonworks.iotas.common.IotasEventImpl;
 import mockit.Expectations;
 import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
 import org.apache.storm.hbase.common.ColumnList;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -16,24 +20,25 @@ import java.util.Map;
 
 import static com.google.common.base.Charsets.UTF_8;
 
+@RunWith(JMockit.class)
 public class ParserOutputHBaseMapperTest {
 
     private static final String ROW_KEY_FIELD = "rowKey";
     private static final String COLUMN_FAMILY= "columnFamily";
     private static final String COLUMN_FIELD= "columnField";
     private static final Map<String, Object> TEST_PARSED_MAP = new HashMap<String, Object>() {{
-       put(ROW_KEY_FIELD, ROW_KEY_FIELD);
        put(COLUMN_FIELD, COLUMN_FIELD);
     }};
+    private static final IotasEvent TEST_EVENT = new IotasEventImpl(TEST_PARSED_MAP, "dsrcid1", ROW_KEY_FIELD);
 
 
-    private ParserOutputHBaseMapper mapper = new ParserOutputHBaseMapper(ROW_KEY_FIELD, COLUMN_FAMILY);
+    private ParserOutputHBaseMapper mapper = new ParserOutputHBaseMapper(COLUMN_FAMILY);
     private @Mocked Tuple mockTuple;
 
     @Before
     public void setup() {
         new Expectations() {{
-            mockTuple.getValueByField(ParserBolt.PARSED_FIELDS); returns(TEST_PARSED_MAP);
+            mockTuple.getValueByField(ParserBolt.IOTAS_EVENT); returns(TEST_EVENT);
         }};
     }
 


### PR DESCRIPTION
New tests ParserBoltTest & ParserOutputHBaseMapperTest  got merged via another PR which is not aware of IotasEvent. Fixing them.
