### PR TITLE
Trying to fix storm topology that fails to run after merge

### DIFF
--- a/parsers/pom.xml
+++ b/parsers/pom.xml
@@ -67,7 +67,6 @@
             </testResource>
         </testResources>
 
-        <pluginManagement>
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -134,6 +133,5 @@
                     <artifactId>maven-surefire-report-plugin</artifactId>
                 </plugin>
             </plugins>
-        </pluginManagement>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,10 @@
                         <groupId>org.apache.zookeeper</groupId>
                         <artifactId>zookeeper</artifactId>
                     </exclusion>
+                    <exclusion>
+                      <groupId>org.slf4j</groupId>
+                      <artifactId>log4j-over-slf4j</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -138,6 +142,12 @@
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-core</artifactId>
                 <version>${dropwizard.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
             </dependency>
             <!-- Test dependencies -->
             <!-- JMockit dependency must appear before JUnit dependency -->

--- a/storm/pom.xml
+++ b/storm/pom.xml
@@ -21,6 +21,13 @@
             <groupId>com.hortonworks</groupId>
             <artifactId>core</artifactId>
             <version>${project.version}</version>
+            <!-- storm uses log4j-over-slf4j so slf4j-log4j2 has to be excluded -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.hortonworks</groupId>
@@ -104,6 +111,10 @@
                 <exclusion>
                     <groupId>com.sun.jersey</groupId>
                     <artifactId>jersey-json</artifactId>
+                </exclusion>
+                <exclusion>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-common</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Still storm topology fails with error,

$ /Users/aiyer/storm/apache-storm-0.10.0-SNAPSHOT/bin/storm jar ./storm/target/storm-0.1-SNAPSHOT.jar org.apache.storm.flux.Flux --local --sleep 120000 --filter ./storm/src/main/resources/flux_iotas_topology.properties ./storm/src/main/resources/flux_iotas_topology_config.yaml

7849 [Thread-13-HBaseBolt] INFO  b.s.d.executor - Prepared bolt HBaseBolt:(1)
8101 [Thread-11-ParserBolt] ERROR b.s.util - Async loop died!
java.lang.IncompatibleClassChangeError: Implementing class
    at java.lang.ClassLoader.defineClass1(Native Method) ~[?:1.7.0_79]
    at java.lang.ClassLoader.defineClass(ClassLoader.java:800) ~[?:1.7.0_79]
    at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142) ~[?:1.7.0_79]
    at java.net.URLClassLoader.defineClass(URLClassLoader.java:449) ~[?:1.7.0_79]
    at java.net.URLClassLoader.access$100(URLClassLoader.java:71) ~[?:1.7.0_79]
    at java.net.URLClassLoader$1.run(URLClassLoader.java:361) ~[?:1.7.0_79]
    at java.net.URLClassLoader$1.run(URLClassLoader.java:355) ~[?:1.7.0_79]
    at java.security.AccessController.doPrivileged(Native Method) ~[?:1.7.0_79]
    at java.net.URLClassLoader.findClass(URLClassLoader.java:354) ~[?:1.7.0_79]
    at java.lang.ClassLoader.loadClass(ClassLoader.java:425) ~[?:1.7.0_79]
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:308) ~[?:1.7.0_79]
    at java.lang.ClassLoader.loadClass(ClassLoader.java:358) ~[?:1.7.0_79]
    at com.hortonworks.iotas.util.ReflectionHelper.loadAllClassesFromJar(ReflectionHelper.java:55) ~[storm-0.1-SNAPSHOT.jar:0.1-SNAPSHOT]
    at com.hortonworks.iotas.util.ReflectionHelper.loadJarAndAllItsClasses(ReflectionHelper.java:34) ~[storm-0.1-SNAPSHOT.jar:0.1-SNAPSHOT]

The fix for which needs to be figured out.
