### PR TITLE
BUG-45998: Fixing mvn warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,18 +75,6 @@
                 <version>${guava.version}</version>
             </dependency>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jmockit</groupId>
-                <artifactId>jmockit</artifactId>
-                <version>${jmockit.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-hdfs</artifactId>
                 <version>${hadoop.version}</version>
@@ -233,6 +221,7 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-jar-plugin</artifactId>
+              <version>${maven-jar-plugin.version}</version>
               <configuration>
                 <archive>
                   <manifest>
@@ -242,6 +231,11 @@
               </configuration>
             </plugin>
             <!-- Test Plugins -->
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <version>${maven-surefire.version}</version>
+            </plugin>
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-report-plugin</artifactId>


### PR DESCRIPTION
`mvn clean install` throws warnings due to duplicate declaration of junit and jmock and version missing in some of the plugin declaration. This PR fixes this.
