### PR TITLE
BUG 45814: Fix issues running iotas storm topology after phoenix patch merge

### DIFF
--- a/storm/pom.xml
+++ b/storm/pom.xml
@@ -21,6 +21,13 @@
             <groupId>com.hortonworks</groupId>
             <artifactId>core</artifactId>
             <version>${project.version}</version>
+            <!-- dropwizard and phoenix have conflicts in jersey related dependencies  -->
+            <exclusions>
+              <exclusion>
+                <groupId>org.apache.phoenix</groupId>
+                <artifactId>phoenix-core</artifactId>
+               </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
I am facing issues running storm topology after merging from upstream. Adding the same exclusion that was added in webservice/pom.xml seems to fix it. Please review and merge.
