### PR TITLE
Bug 46405: Retry logic for notifications

### DIFF
--- a/notification-service/src/main/java/com/hortonworks/iotas/notification/common/Notifier.java
+++ b/notification-service/src/main/java/com/hortonworks/iotas/notification/common/Notifier.java
@@ -60,4 +60,10 @@ public interface Notifier {
      * also be specified in the config.
      */
     List<String> getFields();
+
+    /**
+     * Returns the notification context that this notifier is initialized with.
+     *
+     */
+    NotificationContext getContext();
 }

--- a/notification-service/src/main/java/com/hortonworks/iotas/notification/service/NotificationQueueHandler.java
+++ b/notification-service/src/main/java/com/hortonworks/iotas/notification/service/NotificationQueueHandler.java
@@ -1,0 +1,99 @@
+package com.hortonworks.iotas.notification.service;
+
+import com.hortonworks.iotas.notification.common.Notification;
+import com.hortonworks.iotas.notification.common.Notifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Asynchronously delivers notifications to notifiers.
+ */
+public class NotificationQueueHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(NotificationQueueHandler.class);
+    private static final int MAX_THREADS = 10;
+    /**
+     * Track the tasks so that it can be re-submitted in case of retry.
+     */
+    private ConcurrentHashMap<String, NotificationQueueTask> taskMap;
+
+    private static class NotificationQueueTask implements Runnable {
+        Notifier notifier;
+        Notification notification;
+
+        NotificationQueueTask(Notifier notifier, Notification notification) {
+            this.notifier = notifier;
+            this.notification = notification;
+        }
+
+        @Override
+        public void run() {
+            try {
+                notifier.notify(notification);
+            } catch (Throwable th) {
+                LOG.error("Sending notification failed with uncaught exception ", th);
+                // fail so that the framework can retry
+                notifier.getContext().fail(notification.getId());
+                throw th;
+            }
+        }
+    }
+
+    private ExecutorService executorService;
+
+    public NotificationQueueHandler() {
+        this(MAX_THREADS);
+    }
+
+    public NotificationQueueHandler(int nThreads) {
+        // TODO: evaluate ThreadPoolExecuter with bounded queue size
+        executorService = Executors.newFixedThreadPool(nThreads);
+        taskMap = new ConcurrentHashMap<>();
+    }
+
+
+    public void enqueue(Notifier notifier, Notification notification) {
+        NotificationQueueTask task = new NotificationQueueTask(notifier, notification);
+        taskMap.put(notification.getId(), task);
+        executorService.submit(task);
+    }
+
+    /**
+     * Attempt re-delivery of a previously enqueued notification.
+     *
+     * @param notificationId id of a previously submitted notification.
+     */
+    public void resubmit(String notificationId) {
+        NotificationQueueTask task = taskMap.get(notificationId);
+        if (task == null) {
+            throw new NotificationServiceException("Could not find a previously enqueued task" +
+                                                           " for notification id " + notificationId);
+        }
+        executorService.submit(task);
+    }
+
+    public void remove(String notificationId) {
+        taskMap.remove(notificationId);
+    }
+
+    public void shutdown() {
+        LOG.info("Shutting down queue handler");
+        executorService.shutdown();
+        try {
+            if (!executorService.awaitTermination(2, TimeUnit.SECONDS)) {
+                executorService.shutdownNow();
+                if (!executorService.awaitTermination(2, TimeUnit.SECONDS)) {
+                    LOG.info("Executor service failed to shutdown");
+                }
+            }
+        } catch (InterruptedException ex) {
+            LOG.error("Got exception while awaiting termination", ex);
+            executorService.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/notification-service/src/main/java/com/hortonworks/iotas/notification/service/NotificationService.java
+++ b/notification-service/src/main/java/com/hortonworks/iotas/notification/service/NotificationService.java
@@ -83,4 +83,8 @@ public interface NotificationService {
      */
     Notification updateNotificationStatus(String notificationId, Notification.Status status);
 
+    /**
+     * Any clean up goes here
+     */
+    void close();
 }

--- a/notification-service/src/main/java/com/hortonworks/iotas/notification/service/NotificationServiceContext.java
+++ b/notification-service/src/main/java/com/hortonworks/iotas/notification/service/NotificationServiceContext.java
@@ -1,0 +1,90 @@
+package com.hortonworks.iotas.notification.service;
+
+import com.hortonworks.iotas.notification.common.Notification;
+import com.hortonworks.iotas.notification.common.NotificationContext;
+import com.hortonworks.iotas.notification.common.NotifierConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A wrapper context used by the {@link NotificationService} to track the retry attempts
+ * and update the status in the {@link com.hortonworks.iotas.notification.store.NotificationStore}
+ */
+public class NotificationServiceContext implements NotificationContext {
+    private static final Logger LOG = LoggerFactory.getLogger(NotificationServiceContext.class);
+    private static final int DEFAULT_RETRY_COUNT = 3;
+    private static final String PROP_RETRY_COUNT = "maxAttempts";
+
+    private final NotificationContext wrappedContext;
+    private final NotificationQueueHandler queueHandler;
+    private final NotificationService notificationService;
+    private final ConcurrentHashMap<String, AtomicInteger> notificationMap;
+    private final int maxAttempts;
+
+    public NotificationServiceContext(NotificationContext context, NotificationQueueHandler queueHandler,
+                                      NotificationService notificationService) {
+        this.wrappedContext = context;
+        this.queueHandler = queueHandler;
+        this.notificationService = notificationService;
+        this.notificationMap = new ConcurrentHashMap<>();
+        Properties properties = context.getConfig().getProperties();
+        String propRetryCount = null;
+        if (properties != null) {
+            propRetryCount = properties.getProperty(PROP_RETRY_COUNT);
+        }
+        this.maxAttempts = (propRetryCount != null) ? Integer.parseInt(propRetryCount) : DEFAULT_RETRY_COUNT;
+    }
+
+    @Override
+    public NotifierConfig getConfig() {
+        return wrappedContext.getConfig();
+    }
+
+    @Override
+    public void ack(String notificationId) {
+        LOG.debug("Updating status to DELIVERED for notification id {}", notificationId);
+        notificationService.updateNotificationStatus(notificationId, Notification.Status.DELIVERED);
+        notificationMap.remove(notificationId);
+        queueHandler.remove(notificationId);
+        wrappedContext.ack(notificationId);
+    }
+
+    @Override
+    public void fail(String notificationId) {
+        int attempt = currentAttempt(notificationId);
+        LOG.info("Attempt [{}] failed. [{}] retries left.", attempt, maxAttempts - attempt);
+        if (attempt >= maxAttempts) {
+            LOG.info("Updating status to FAILED for notification id {}", notificationId);
+            notificationService.updateNotificationStatus(notificationId, Notification.Status.FAILED);
+            notificationMap.remove(notificationId);
+            queueHandler.remove(notificationId);
+            wrappedContext.fail(notificationId);
+        } else {
+            // queue it again
+            queueHandler.resubmit(notificationId);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "NotificationServiceContext{" +
+                "wrappedContext=" + wrappedContext +
+                ", maxAttempts=" + maxAttempts +
+                '}';
+    }
+
+    private int currentAttempt(String notificationId) {
+        AtomicInteger attempt = notificationMap.get(notificationId);
+        if (attempt == null) {
+            attempt = notificationMap.putIfAbsent(notificationId, new AtomicInteger(1));
+        }
+        if (attempt != null) {
+            return attempt.incrementAndGet();
+        }
+        return 1;
+    }
+}

--- a/notification-service/src/main/java/com/hortonworks/iotas/notification/service/NotificationServiceException.java
+++ b/notification-service/src/main/java/com/hortonworks/iotas/notification/service/NotificationServiceException.java
@@ -1,0 +1,19 @@
+package com.hortonworks.iotas.notification.service;
+
+/**
+ * Indicates a runtime issue in the notification service while processing
+ * a request
+ */
+public class NotificationServiceException extends RuntimeException {
+    public NotificationServiceException(String message) {
+        super(message);
+    }
+
+    public NotificationServiceException(Throwable th) {
+        super(th);
+    }
+
+    public NotificationServiceException(String message, Throwable th) {
+        super(message, th);
+    }
+}

--- a/notification-service/src/test/java/com/hortonworks/iotas/notification/service/NotificationServiceImplTest.java
+++ b/notification-service/src/test/java/com/hortonworks/iotas/notification/service/NotificationServiceImplTest.java
@@ -54,7 +54,7 @@ public class NotificationServiceImplTest {
         new Expectations() {
             {
                 mockCtx.getConfig();
-                times = 2;
+                times = 3;
                 result = mockNotifierConfig;
                 mockNotifierConfig.getClassName();
                 times = 1;
@@ -72,8 +72,10 @@ public class NotificationServiceImplTest {
         assertEquals(mockNotifier, result);
         new Verifications() {
             {
-                mockNotifier.open(mockCtx);
+                NotificationContext ctx;
+                mockNotifier.open(ctx = withCapture());
                 times = 1;
+                assertEquals(NotificationServiceContext.class, ctx.getClass());
             }
         };
     }
@@ -83,7 +85,7 @@ public class NotificationServiceImplTest {
         new Expectations() {
             {
                 mockCtx.getConfig();
-                times = 2;
+                times = 3;
                 result = mockNotifierConfig;
                 mockNotifierConfig.getClassName();
                 times = 1;
@@ -132,7 +134,7 @@ public class NotificationServiceImplTest {
         new Expectations() {
             {
                 mockCtx.getConfig();
-                times = 2;
+                times = 3;
                 result = mockNotifierConfig;
                 mockNotifierConfig.getClassName();
                 times = 1;
@@ -168,7 +170,7 @@ public class NotificationServiceImplTest {
         new Expectations() {
             {
                 mockCtx.getConfig();
-                times = 2;
+                times = 3;
                 result = mockNotifierConfig;
                 mockNotifierConfig.getClassName();
                 times = 1;
@@ -180,6 +182,8 @@ public class NotificationServiceImplTest {
                 result = true;
                 ReflectionHelper.newInstance(anyString);
                 result = mockNotifier;
+                mockNotification.getId(); times = 1;
+                result = "123";
             }
         };
 
@@ -207,7 +211,7 @@ public class NotificationServiceImplTest {
         new Expectations() {
             {
                 mockCtx.getConfig();
-                times = 2;
+                times = 3;
                 result = mockNotifierConfig;
                 mockNotifierConfig.getClassName();
                 times = 1;

--- a/notification-service/src/test/resources/log4j.xml
+++ b/notification-service/src/test/resources/log4j.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+    <appender name="console" class="org.apache.log4j.ConsoleAppender">
+        <param name="Target" value="System.out"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%-5p %c{1} - %m%n"/>
+        </layout>
+    </appender>
+
+    <root>
+        <priority value ="debug" />
+        <appender-ref ref="console" />
+    </root>
+
+</log4j:configuration>

--- a/notifiers/src/main/java/com/hortonworks/iotas/notification/notifiers/ConsoleNotifier.java
+++ b/notifiers/src/main/java/com/hortonworks/iotas/notification/notifiers/ConsoleNotifier.java
@@ -51,4 +51,9 @@ public class ConsoleNotifier implements Notifier {
     public List<String> getFields() {
         return Collections.emptyList();
     }
+
+    @Override
+    public NotificationContext getContext() {
+        return ctx;
+    }
 }

--- a/notifiers/src/main/java/com/hortonworks/iotas/notification/notifiers/EmailNotifier.java
+++ b/notifiers/src/main/java/com/hortonworks/iotas/notification/notifiers/EmailNotifier.java
@@ -172,6 +172,11 @@ public class EmailNotifier implements Notifier, TransportListener {
         return fieldNames;
     }
 
+    @Override
+    public NotificationContext getContext() {
+        return ctx;
+    }
+
     /**
      * Returns a new map containing the values for email message fields from the first map,
      * using values from second map as defaults.

--- a/storm/src/main/java/com/hortonworks/bolt/notification/BoltNotificationContext.java
+++ b/storm/src/main/java/com/hortonworks/bolt/notification/BoltNotificationContext.java
@@ -3,9 +3,7 @@ package com.hortonworks.bolt.notification;
 import backtype.storm.task.OutputCollector;
 import backtype.storm.tuple.Tuple;
 import com.hortonworks.iotas.notification.common.DefaultNotificationContext;
-import com.hortonworks.iotas.notification.common.Notification;
 import com.hortonworks.iotas.notification.common.NotifierConfig;
-import com.hortonworks.iotas.notification.service.NotificationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,13 +17,11 @@ public class BoltNotificationContext extends DefaultNotificationContext {
     private final OutputCollector collector;
     private final ConcurrentHashMap<String, Tuple> tupleMap;
     private static final Logger LOG = LoggerFactory.getLogger(BoltNotificationContext.class);
-    private NotificationService notificationService;
 
-    public BoltNotificationContext(OutputCollector collector, NotifierConfig config, NotificationService notificationService) {
+    public BoltNotificationContext(OutputCollector collector, NotifierConfig config) {
         super(config);
         this.collector = collector;
         this.tupleMap = new ConcurrentHashMap<>();
-        this.notificationService = notificationService;
     }
 
     void track(String notificationId, Tuple tuple) {
@@ -38,7 +34,6 @@ public class BoltNotificationContext extends DefaultNotificationContext {
         Tuple tuple = tupleMap.remove(notificationId);
         if(tuple != null) {
             LOG.debug("Acking tuple {}, notification id {}", tuple, notificationId);
-            notificationService.updateNotificationStatus(notificationId, Notification.Status.DELIVERED);
             collector.ack(tuple);
         } else {
             throw new RuntimeException("Tracked tuple not found for notification id " + notificationId);
@@ -50,7 +45,6 @@ public class BoltNotificationContext extends DefaultNotificationContext {
         Tuple tuple = tupleMap.remove(notificationId);
         if(tuple != null) {
             LOG.debug("Failing tuple {}, notification id {}", tuple, notificationId);
-            notificationService.updateNotificationStatus(notificationId, Notification.Status.FAILED);
             collector.fail(tuple);
         } else {
             throw new RuntimeException("Tracked tuple not found for notification id " + notificationId);

--- a/storm/src/main/resources/flux_iotas_topology_config.yaml
+++ b/storm/src/main/resources/flux_iotas_topology_config.yaml
@@ -6,7 +6,8 @@ config:
   local.notifier.jar.path: ${notifier.jar.path}
   hbase.conf:
     hbase.root.dir: ${hbase.root.dir}
-
+  notification.conf:
+    queuehandler.threads: 10
 components:
   - id: "zkHosts"
     className: "storm.kafka.ZkHosts"


### PR DESCRIPTION
Added retry logic to attempt re-delivery of notifications in case of delivery failures. The retry count is configurable. This relies on the underlying processing frameworks acking mechanism to re-send the messages for at-least once guarantee.

Note: This PR includes changes from https://github.com/hortonworks/IoTaS/pull/45 and should be merged after that.
