### PR TITLE
IOT-80: Add event header to IotasEvent

### DIFF
--- a/core/src/main/java/com/hortonworks/iotas/common/IotasEvent.java
+++ b/core/src/main/java/com/hortonworks/iotas/common/IotasEvent.java
@@ -17,6 +17,15 @@ public interface IotasEvent {
      */
     Map<String, Object> getFieldsAndValues();
 
+
+    /**
+     * The event header that represents some meta data about
+     * this event. This is optional and by default empty.
+     *
+     * @return the key value map representing the event header
+     */
+    Map<String, Object> getHeader();
+
     /**
      * The unique event id.
      *

--- a/core/src/main/java/com/hortonworks/iotas/common/IotasEventImpl.java
+++ b/core/src/main/java/com/hortonworks/iotas/common/IotasEventImpl.java
@@ -8,7 +8,7 @@ import java.util.UUID;
  * A default implementation of IotasEvent.
  */
 public class IotasEventImpl implements IotasEvent {
-
+    private final Map<String, Object> header;
     private final Map<String, Object> fieldsAndValues;
     private final String dataSourceId;
     private final String id;
@@ -21,10 +21,28 @@ public class IotasEventImpl implements IotasEvent {
         this(keyValues, dataSourceId, UUID.randomUUID().toString());
     }
 
+    /**
+     * Creates an IotasEvent with given keyValues, dataSourceId and id.
+     */
     public IotasEventImpl(Map<String, Object> keyValues, String dataSourceId, String id) {
+        this(keyValues, dataSourceId, id, Collections.<String, Object>emptyMap());
+    }
+
+    /**
+     * Creates an IotasEvent with given keyValues, dataSourceId and header.
+     */
+    public IotasEventImpl(Map<String, Object> keyValues, String dataSourceId, Map<String, Object> header) {
+        this(keyValues, dataSourceId, UUID.randomUUID().toString(), header);
+    }
+
+    /**
+     * Creates an IotasEvent with given keyValues, dataSourceId, id and header.
+     */
+    public IotasEventImpl(Map<String, Object> keyValues, String dataSourceId, String id, Map<String, Object> header) {
         this.fieldsAndValues = keyValues;
         this.dataSourceId = dataSourceId;
         this.id = id;
+        this.header = header;
     }
 
     @Override
@@ -42,6 +60,10 @@ public class IotasEventImpl implements IotasEvent {
         return dataSourceId;
     }
 
+    @Override
+    public Map<String, Object> getHeader() {
+        return Collections.unmodifiableMap(header);
+    }
 
     @Override
     public boolean equals(Object o) {


### PR DESCRIPTION
Header field is a Map<String,Object> which carries event metadata. This is needed to pass the metadata like rule_id, datasourceId to from RulesBolt to NotificationBolt. This can be extended to other use cases in future.
