### PR TITLE
IOT-33: Fixed logging dependency issues for core and storm modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,8 +111,8 @@
                 <version>${hadoop.version}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-log4j12</artifactId>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>com.sun.jersey</groupId>

--- a/storm/pom.xml
+++ b/storm/pom.xml
@@ -27,6 +27,10 @@
                 <groupId>org.apache.phoenix</groupId>
                 <artifactId>phoenix-core</artifactId>
                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
- Excluded log4j/log4j dependency instead of org.slf4j/slf4j-log4j12 in hadoop-client module of root pom. hadoop-client is used by core module and it depends on slf4j-log4j12 for logging but it is currently excluded by dependency of hadoop-client. 
- Excluded org.slf4j/slf4j-log4j12 iotas/core dependency of iotas/storm module. storm module already has dependency on log4j and it's dependency on core gets slf4j-log4j12 module which raises duplicated log binding. So, org.slf4j/slf4j-log4j12 dependency is excluded from core dependency.
