### PR TITLE
IOT-104 InMemoryStoragemanager should only increase sequence

### DIFF
--- a/core/src/main/java/com/hortonworks/iotas/storage/impl/memory/InMemoryStorageManager.java
+++ b/core/src/main/java/com/hortonworks/iotas/storage/impl/memory/InMemoryStorageManager.java
@@ -64,9 +64,7 @@ public class InMemoryStorageManager implements StorageManager {
     @Override
     public <T extends Storable> T remove(StorableKey key) throws StorageException {
         if (storageMap.containsKey(key.getNameSpace())) {
-            T oldVal = (T) storageMap.get(key.getNameSpace()).remove(key.getPrimaryKey());
-            decrementIdSequence(key.getNameSpace());
-            return oldVal;
+            return (T) storageMap.get(key.getNameSpace()).remove(key.getPrimaryKey());
         }
         return null;
     }
@@ -160,12 +158,5 @@ public class InMemoryStorageManager implements StorageManager {
             id = 0l;
         }
         this.sequenceMap.put(namespace, ++id);
-    }
-
-    private void decrementIdSequence(String namespace) {
-        Long id = sequenceMap.get(namespace);
-        if (id != null && id > 0) {
-            sequenceMap.put(namespace, --id);
-        }
     }
 }


### PR DESCRIPTION
Since InMemoryStorageManager decreases sequence when item is removed, it can occur duplication of id.

> Step to reproduce
1. Add device 1 from UI
2. Add device 2 from UI
3. Remove device 1 from UI
4. Try to add device 3 from UI (ERROR)

> Error message displayed in UI

```
An exception with message [Another instnace with same id = StorableId{fieldsToVal={{name='id', type=LONG}=3}} exists with different value in namespace datasources Consider using addOrUpdate method if you always want to overwrite.] was thrown while processing request. Please check webservice/ErrorCodes.md for more details.
```

Sequence should always increase sequence, like Oracle.
