### PR TITLE
IOT-63 scriptEngine.eval(scriptText) is run for every tuple which is heavy and it should be avoided

### DIFF
--- a/layout/src/main/java/com/hortonworks/iotas/layout/runtime/script/GroovyScript.java
+++ b/layout/src/main/java/com/hortonworks/iotas/layout/runtime/script/GroovyScript.java
@@ -25,8 +25,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.script.Bindings;
-import javax.script.ScriptContext;
+import javax.script.Compilable;
+import javax.script.CompiledScript;
 import javax.script.ScriptException;
+import javax.script.SimpleBindings;
 import java.util.Map;
 
 /**
@@ -36,6 +38,8 @@ import java.util.Map;
  */
 public class GroovyScript<O> extends Script<IotasEvent, O, javax.script.ScriptEngine> {
     private static final Logger LOG = LoggerFactory.getLogger(GroovyScript.class);
+
+    private CompiledScript compiledScript;
 
     public GroovyScript(String expression,
                         ScriptEngine<javax.script.ScriptEngine> scriptEngine) {
@@ -48,32 +52,28 @@ public class GroovyScript<O> extends Script<IotasEvent, O, javax.script.ScriptEn
         LOG.debug("Evaluating [{}] with [{}]", expression, iotasEvent);
         O evaluatedResult = null;
 
-        try {
-            if (iotasEvent != null) {
-                final Map<String, Object> fieldsToValues = iotasEvent.getFieldsAndValues();
-                if (fieldsToValues != null) {
-                    getEngineScopeBindings().putAll(fieldsToValues);
-                    LOG.debug("Set script binding to [{}]", fieldsToValues);
-
-                    evaluatedResult = (O) scriptEngine.eval(expression);
-
-                    LOG.debug("Expression [{}] evaluated to [{}]", expression, evaluatedResult);
-                }
-            }
-        } finally {
-            // It is absolutely necessary to clear the bindings. Otherwise the old values of a key will be used
-            // to evaluate the expression when the iotasEvent doesn't have such key
-            clearBindings();
+        // lazy compilation
+        if (compiledScript == null && scriptEngine instanceof Compilable) {
+            compiledScript = ((Compilable) scriptEngine).compile(expression);
         }
+
+        if (iotasEvent != null) {
+            final Map<String, Object> fieldsToValues = iotasEvent.getFieldsAndValues();
+            if (fieldsToValues != null) {
+                Bindings bindings = new SimpleBindings();
+                bindings.putAll(fieldsToValues);
+                LOG.debug("Use script binding to [{}]", fieldsToValues);
+
+                if (compiledScript != null) {
+                    evaluatedResult = (O) compiledScript.eval(bindings);
+                } else {
+                    evaluatedResult = (O) scriptEngine.eval(expression, bindings);
+                }
+
+                LOG.debug("Expression [{}] evaluated to [{}]", expression, evaluatedResult);
+            }
+        }
+
         return evaluatedResult;
-    }
-
-    private Bindings getEngineScopeBindings() {
-        return scriptEngine.getBindings(ScriptContext.ENGINE_SCOPE);
-    }
-
-    private void clearBindings() {
-        getEngineScopeBindings().clear();
-        LOG.debug("Script binding reset to empty binding");
     }
 }

--- a/layout/src/test/java/com/hortonworks/iotas/layout/runtime/script/GroovyScriptTest.java
+++ b/layout/src/test/java/com/hortonworks/iotas/layout/runtime/script/GroovyScriptTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.iotas.layout.runtime.script;
+
+import com.hortonworks.iotas.common.IotasEventImpl;
+import com.hortonworks.iotas.layout.runtime.script.engine.GroovyScriptEngine;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.script.ScriptException;
+import java.util.HashMap;
+
+public class GroovyScriptTest {
+    @Test
+    public void testBindingsAreBoundOnlyWhenEvaluation() {
+        GroovyScriptEngine groovyScriptEngine = new GroovyScriptEngine();
+        String groovyExpression = "temperature > 10 && humidity < 30";
+
+        GroovyScript<Boolean> groovyScript = new GroovyScript<Boolean>(groovyExpression, groovyScriptEngine);
+        HashMap<String, Object> fieldsAndValue = new HashMap<>();
+        fieldsAndValue.put("temperature", 20);
+        fieldsAndValue.put("humidity", 10);
+        try {
+            groovyScript.evaluate(new IotasEventImpl(fieldsAndValue, "1"));
+        } catch (ScriptException e) {
+            e.printStackTrace();
+            Assert.fail("It shouldn't throw ScriptException");
+        }
+
+        fieldsAndValue.clear();
+        fieldsAndValue.put("no_related_field", 3);
+        try {
+            groovyScript.evaluate(new IotasEventImpl(fieldsAndValue, "1"));
+            Assert.fail("It should not evaluate correctly");
+        } catch (ScriptException e) {
+            // no-op, that's what we want
+        }
+    }
+}

--- a/storm/src/main/java/com/hortonworks/iotas/layout/runtime/rule/GroovyRuleRuntimeBuilder.java
+++ b/storm/src/main/java/com/hortonworks/iotas/layout/runtime/rule/GroovyRuleRuntimeBuilder.java
@@ -62,7 +62,7 @@ public class GroovyRuleRuntimeBuilder implements RuleRuntimeBuilder<Tuple, Outpu
                 try {
                     evaluates =  super.evaluate(iotasEvent);
                 } catch (ScriptException e) {
-                    if (e.getCause() != null && e.getCause().getCause() instanceof groovy.lang.MissingPropertyException) {
+                    if (e.getCause() != null && e.getCause() instanceof groovy.lang.MissingPropertyException) {
                         // Occurs when not all the properties required for evaluating the script are set. This can happen for example
                         // when receiving an IotasEvent that does not have all the fields required to evaluate the expression
                         LOG.debug("Missing property required to evaluate expression. {}", e.getCause().getMessage());


### PR DESCRIPTION
Since GroovyScriptEngineImpl is Compilable and expression never changes, we can compile expression (lazily or not) and evaluate with Bindings later.
I also modify to pass Bindings when calling script(engine).eval() so that we don't need to restore(clear) binding explicitly. UT included to test this behavior.
