### PR TITLE
IOT-172: Fix parser file name conflict

### DIFF
--- a/core/src/main/java/com/hortonworks/iotas/util/FileSystemJarStorage.java
+++ b/core/src/main/java/com/hortonworks/iotas/util/FileSystemJarStorage.java
@@ -8,6 +8,7 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.FileSystems;
+import java.nio.file.Path;
 import java.util.Map;
 
 /**
@@ -36,9 +37,9 @@ public class FileSystemJarStorage implements JarStorage {
      * @throws java
     .io.IOException
      */
-    public void uploadJar (InputStream inputStream, String name) throws java
+    public String uploadJar (InputStream inputStream, String name) throws java
             .io.IOException{
-        java.nio.file.Path path = FileSystems.getDefault().getPath(directory, name);
+        Path path = FileSystems.getDefault().getPath(directory, name);
         File file = path.toFile();
         if (!file.exists()) {
             file.createNewFile();
@@ -46,6 +47,7 @@ public class FileSystemJarStorage implements JarStorage {
         OutputStream outputStream = new FileOutputStream(file);
         ByteStreams.copy(inputStream, outputStream);
         outputStream.close();
+        return path.toString();
     }
 
     /**

--- a/core/src/main/java/com/hortonworks/iotas/util/HdfsJarStorage.java
+++ b/core/src/main/java/com/hortonworks/iotas/util/HdfsJarStorage.java
@@ -53,7 +53,7 @@ public class HdfsJarStorage implements JarStorage {
     }
 
     @Override
-    public void uploadJar(InputStream inputStream, String name) throws IOException {
+    public String uploadJar(InputStream inputStream, String name) throws IOException {
         Path jarPath = new Path(directory, name);
         FSDataOutputStream outputStream = null;
         try {
@@ -64,6 +64,7 @@ public class HdfsJarStorage implements JarStorage {
                 outputStream.close();
             }
         }
+        return jarPath.toString();
     }
 
     @Override

--- a/core/src/main/java/com/hortonworks/iotas/util/JarStorage.java
+++ b/core/src/main/java/com/hortonworks/iotas/util/JarStorage.java
@@ -18,13 +18,13 @@ public interface JarStorage {
     void init(Map<String, String> config);
 
     /**
-     *
      * @param inputStream stream to read the jar content from
-     * @param name identifier of the jar file to be used later to retrieve
-     *             using downloadJar
+     * @param name        identifier of the jar file to be used later to retrieve
+     *                    using downloadJar
+     * @return the path where the file was uploaded
      * @throws java.io.IOException
      */
-    void uploadJar(InputStream inputStream, String name) throws java.io.IOException;
+    String uploadJar(InputStream inputStream, String name) throws java.io.IOException;
 
     /**
      *


### PR DESCRIPTION
Store the parser jar in the jar storage with a unique file name to avoid conflicts.
