### PR TITLE
IOT-86: Added api to query topology status.

### DIFF
--- a/core/src/main/java/com/hortonworks/iotas/service/CatalogService.java
+++ b/core/src/main/java/com/hortonworks/iotas/service/CatalogService.java
@@ -525,6 +525,10 @@ public class CatalogService {
         return;
     }
 
+    public TopologyActions.Status topologyStatus (Topology topology) throws Exception {
+        return this.topologyActions.status(topology);
+    }
+
     public Collection<TopologyComponent.TopologyComponentType> listTopologyComponentTypes () {
         return Arrays.asList(TopologyComponent.TopologyComponentType.values());
     }

--- a/core/src/main/java/com/hortonworks/iotas/topology/StatusImpl.java
+++ b/core/src/main/java/com/hortonworks/iotas/topology/StatusImpl.java
@@ -1,0 +1,27 @@
+package com.hortonworks.iotas.topology;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class StatusImpl implements TopologyActions.Status {
+    String status = "Unknown"; // default
+    Map<String, String> extra = new HashMap<>();
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public void putExtra(String key, String val) {
+        extra.put(key, val);
+    }
+
+    @Override
+    public String getStatus() {
+        return status;
+    }
+
+    @Override
+    public Map<String, String> getExtra() {
+        return extra;
+    }
+}

--- a/core/src/main/java/com/hortonworks/iotas/topology/TopologyActions.java
+++ b/core/src/main/java/com/hortonworks/iotas/topology/TopologyActions.java
@@ -30,4 +30,12 @@ public interface TopologyActions {
     //Resume the json representing the IoTaS based on underlying streaming
     // engine
     void resume (Topology topology) throws Exception;
+
+    // return topology status
+    Status status (Topology topology) throws Exception;
+
+    interface Status {
+        String getStatus();
+        Map<String, String> getExtra();
+    }
 }

--- a/core/src/main/java/com/hortonworks/iotas/topology/storm/StormTopologyActionsImpl.java
+++ b/core/src/main/java/com/hortonworks/iotas/topology/storm/StormTopologyActionsImpl.java
@@ -1,15 +1,25 @@
 package com.hortonworks.iotas.topology.storm;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Joiner;
 import com.hortonworks.iotas.catalog.Topology;
+import com.hortonworks.iotas.topology.StatusImpl;
 import com.hortonworks.iotas.topology.TopologyActions;
 import com.hortonworks.iotas.topology.TopologyLayoutConstants;
 import com.hortonworks.iotas.util.ReflectionHelper;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileWriter;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -20,6 +30,7 @@ import java.util.Map;
  * Storm implementation of the TopologyActions interface
  */
 public class StormTopologyActionsImpl implements TopologyActions {
+    private static final Logger LOG = LoggerFactory.getLogger(StormTopologyActionsImpl.class);
 
     private String stormArtifactsLocation = "/tmp/storm-artifacts/";
     private String stormCliPath = "storm";
@@ -57,7 +68,7 @@ public class StormTopologyActionsImpl implements TopologyActions {
         commands.add("org.apache.storm.flux.Flux");
         commands.add("--remote");
         commands.add(fileName);
-        int exitValue = executeShellProcess(commands);
+        int exitValue = executeShellProcess(commands).exitValue;
         if (exitValue != 0) {
             throw new Exception("Topology could not be deployed " +
                     "successfully.");
@@ -70,7 +81,7 @@ public class StormTopologyActionsImpl implements TopologyActions {
         commands.add(stormCliPath);
         commands.add("kill");
         commands.add(getTopologyName(topology));
-        int exitValue = executeShellProcess(commands);
+        int exitValue = executeShellProcess(commands).exitValue;
         if (exitValue != 0) {
             throw new Exception("Topology could not be killed " +
                     "successfully.");
@@ -91,7 +102,7 @@ public class StormTopologyActionsImpl implements TopologyActions {
         commands.add(stormCliPath);
         commands.add("deactivate");
         commands.add(getTopologyName(topology));
-        int exitValue = executeShellProcess(commands);
+        int exitValue = executeShellProcess(commands).exitValue;
         if (exitValue != 0) {
             throw new Exception("Topology could not be suspended " +
                     "successfully.");
@@ -104,11 +115,40 @@ public class StormTopologyActionsImpl implements TopologyActions {
         commands.add(stormCliPath);
         commands.add("activate");
         commands.add(getTopologyName(topology));
-        int exitValue = executeShellProcess(commands);
+        int exitValue = executeShellProcess(commands).exitValue;
         if (exitValue != 0) {
             throw new Exception("Topology could not be resumed " +
                     "successfully.");
         }
+    }
+
+    @Override
+    public Status status(Topology topology) throws Exception {
+        StatusImpl status = new StatusImpl();
+        List<String> commands = new ArrayList<String>();
+        commands.add(stormCliPath);
+        commands.add("list");
+        String topologyName = getTopologyName(topology);
+        commands.add(topologyName);
+        ShellProcessResult result = executeShellProcess(commands);
+        int exitValue = result.exitValue;
+        if (exitValue != 0) {
+            LOG.error("Topology status could not be fetched for {}", topology.getName());
+        } else {
+            BufferedReader reader = new BufferedReader(new StringReader(result.stdout));
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String[] fields = line.split("\\s+");
+                if (fields[0].equals(topologyName)) {
+                    status.setStatus(fields[1]);
+                    status.putExtra("Num_tasks", fields[2]);
+                    status.putExtra("Num_workers", fields[3]);
+                    status.putExtra("Uptime_secs", fields[4]);
+                    break;
+                }
+            }
+        }
+        return status;
     }
 
     private String createYamlFile (Topology topology) throws
@@ -219,14 +259,27 @@ public class StormTopologyActionsImpl implements TopologyActions {
     }
 
 
-    private int executeShellProcess (List<String> commands) throws  Exception {
+    private ShellProcessResult executeShellProcess (List<String> commands) throws  Exception {
+        LOG.debug("Executing command: {}", Joiner.on(" ").join(commands));
         ProcessBuilder processBuilder = new ProcessBuilder(commands);
-        processBuilder.inheritIO();
+        processBuilder.redirectErrorStream(true);
         Process process = processBuilder.start();
+        StringWriter sw = new StringWriter();
+        IOUtils.copy(process.getInputStream(), sw);
+        String stdout = sw.toString();
         process.waitFor();
         int exitValue = process.exitValue();
-        System.out.println("Exit value from subprocess is :" + exitValue);
-        return exitValue;
+        LOG.debug("Command output: {}", stdout);
+        LOG.debug("Command exit status: {}", exitValue);
+        return new ShellProcessResult(exitValue, stdout);
     }
 
+    private static class ShellProcessResult {
+        private final int exitValue;
+        private final String stdout;
+        ShellProcessResult(int exitValue, String stdout) {
+            this.exitValue = exitValue;
+            this.stdout = stdout;
+        }
+    }
 }

--- a/webservice/src/main/java/com/hortonworks/iotas/webservice/catalog/TopologyCatalogResource.java
+++ b/webservice/src/main/java/com/hortonworks/iotas/webservice/catalog/TopologyCatalogResource.java
@@ -3,6 +3,7 @@ package com.hortonworks.iotas.webservice.catalog;
 import com.codahale.metrics.annotation.Timed;
 import com.hortonworks.iotas.catalog.Topology;
 import com.hortonworks.iotas.service.CatalogService;
+import com.hortonworks.iotas.topology.TopologyActions;
 import com.hortonworks.iotas.topology.TopologyComponent;
 import com.hortonworks.iotas.webservice.util.WSUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -135,6 +136,22 @@ public class TopologyCatalogResource {
         } catch (Exception ex) {
             return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
         }
+    }
+
+    @GET
+    @Path("/topologies/{id}/actions/status")
+    @Timed
+    public Response topologyStatus (@PathParam("id") Long topologyId) {
+        try {
+            Topology result = catalogService.getTopology(topologyId);
+            if (result != null) {
+                TopologyActions.Status status = catalogService.topologyStatus(result);
+                return WSUtils.respond(OK, SUCCESS, status);
+            }
+        } catch (Exception ex) {
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
+        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, topologyId.toString());
     }
 
     @POST


### PR DESCRIPTION
Added api to query topology status. Right now all the IOTAS topology
actions apis are exposed via REST and it directly invokes the storm
command line in the backend. In future we could refactor this to use the storm
REST apis wherever applicable.

Metrics part mentioned in the JIRA is being addressed in https://hwxiot.atlassian.net/browse/IOT-160
