### PR TITLE
IOT-174 Improve parser upload experience

### DIFF
--- a/core/src/main/java/com/hortonworks/iotas/util/FileUtil.java
+++ b/core/src/main/java/com/hortonworks/iotas/util/FileUtil.java
@@ -1,0 +1,41 @@
+package com.hortonworks.iotas.util;
+
+import com.google.common.io.ByteStreams;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.UUID;
+
+public class FileUtil {
+
+    /**
+     * Utility method: write input stream to temporary file
+     *
+     * @param inputStream input stream
+     * @return File object which points temporary file being made
+     * @throws IOException
+     */
+    public static File writeInputStreamToTempFile(InputStream inputStream, String fileNameSuffix)
+            throws IOException {
+        OutputStream outputStream = null;
+        try {
+            File tmpFile = File.createTempFile(UUID.randomUUID().toString(), fileNameSuffix);
+            tmpFile.deleteOnExit();
+            outputStream = new FileOutputStream(tmpFile);
+            ByteStreams.copy(inputStream, outputStream);
+            return tmpFile;
+        } finally {
+            try {
+                if (outputStream != null) {
+                    outputStream.close();
+                }
+            } catch (IOException ex) {
+                // swallow
+            }
+        }
+    }
+
+}

--- a/core/src/main/java/com/hortonworks/iotas/util/JarReader.java
+++ b/core/src/main/java/com/hortonworks/iotas/util/JarReader.java
@@ -1,0 +1,73 @@
+package com.hortonworks.iotas.util;
+
+import com.google.common.collect.Lists;
+import com.google.common.io.ByteStreams;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+public class JarReader {
+
+    /**
+     * Extract all class names from Jar input stream
+     *
+     * @param inputStream input stream which contains Jar
+     * @return list of class name
+     * @throws IOException
+     */
+    public static List<String> extractClassNames(InputStream inputStream) throws IOException {
+        List<String> classNames = new ArrayList<>();
+        ZipInputStream zip = new ZipInputStream(inputStream);
+        for (ZipEntry entry = zip.getNextEntry(); entry != null; entry = zip.getNextEntry()) {
+            if (!entry.isDirectory() && entry.getName().endsWith(".class")) {
+                // This ZipEntry represents a class. Now, what class does it represent?
+                String className = entry.getName().replace('/', '.'); // including ".class"
+                classNames.add(className.substring(0, className.length() - ".class".length()));
+            }
+        }
+        return classNames;
+    }
+
+    /**
+     * Find subtype of classes from file , and return their names
+     *
+     * @param jarFile File object which points Jar file
+     * @param superTypeClass type of class which is
+     * @return list of class name
+     * @throws IOException
+     */
+    public static List<String> findSubtypeOfClasses(File jarFile, Class superTypeClass) throws IOException {
+        try (InputStream tmpFileInputStream = new FileInputStream(jarFile)) {
+            List<String> classNames = JarReader.extractClassNames(tmpFileInputStream);
+
+            URLClassLoader urlClassLoader = new URLClassLoader(
+                    new URL[] {new URL("file://" + jarFile.getAbsolutePath())},
+                    Thread.currentThread().getContextClassLoader());
+
+            List<String> subTypeClasses = Lists.newArrayList();
+            for (String className : classNames) {
+                try {
+                    Class<?> candidate = Class.forName(className, false, urlClassLoader);
+                    if (superTypeClass.isAssignableFrom(candidate)) {
+                        subTypeClasses.add(candidate.getCanonicalName());
+                    }
+                } catch (Throwable ex) {
+                    // noop...
+                }
+            }
+            return subTypeClasses;
+        }
+    }
+
+}

--- a/webservice/README.md
+++ b/webservice/README.md
@@ -742,6 +742,36 @@ DELETE /api/v1/catalog/parsers/ID
 }
 ```
 
+### Verify uploading parser
+GET /api/v1/catalog/parsers/verify-upload
+
+    curl -X POST -i -F parserJar=@parsers-0.1.0-SNAPSHOT.jar http://localhost:8080/api/v1/catalog/parsers/upload-verify
+    
+*Success Response*
+
+    HTTP/1.1 100 Continue
+    
+    HTTP/1.1 200 OK
+    Date: Mon, 14 Mar 2016 01:08:01 GMT
+    Content-Type: application/json
+    Content-Length: 158
+    
+    {"responseCode":1000,"responseMessage":"Success","entities":["com.hortonworks.iotas.parsers.json.JsonParser","com.hortonworks.iotas.parsers.nest.NestParser"]}%
+    
+*Error Response*
+
+    *Error Response*
+    
+        HTTP/1.1 500 Internal Server Error
+        Content-Type: application/json
+        
+    ```json    
+    {
+     "responseCode": 1102,
+     "responseMessage": "An exception with message [msg] was thrown while processing request."
+    }
+    ```
+
 ### Download Jar
 GET /api/v1/catalog/parsers/download/ID
 

--- a/webservice/src/main/java/com/hortonworks/iotas/webservice/catalog/ParserInfoCatalogResource.java
+++ b/webservice/src/main/java/com/hortonworks/iotas/webservice/catalog/ParserInfoCatalogResource.java
@@ -2,21 +2,26 @@ package com.hortonworks.iotas.webservice.catalog;
 
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
 import com.google.common.io.ByteStreams;
 import com.hortonworks.iotas.catalog.ParserInfo;
 import com.hortonworks.iotas.common.Schema;
 import com.hortonworks.iotas.parser.Parser;
 import com.hortonworks.iotas.service.CatalogService;
+import com.hortonworks.iotas.util.FileUtil;
 import com.hortonworks.iotas.util.JarStorage;
 import com.hortonworks.iotas.util.ProxyUtil;
 import com.hortonworks.iotas.util.ReflectionHelper;
 import com.hortonworks.iotas.webservice.IotasConfiguration;
+import com.hortonworks.iotas.util.JarReader;
 import com.hortonworks.iotas.webservice.util.WSUtils;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -37,6 +42,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 
 import static com.hortonworks.iotas.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND;
@@ -174,6 +180,34 @@ public class ParserInfoCatalogResource {
             }
         }
         return result;
+    }
+
+    //Test curl command curl -X POST -i -F parserJar=@parsers-0.1.0-SNAPSHOT.jar http://localhost:8080/api/v1/catalog/parsers/upload-verify
+    @Timed
+    @POST
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Path("/parsers/upload-verify")
+    public Response verifyParserUpload(@FormDataParam("parserJar") final InputStream inputStream) {
+        try {
+            final File tmpFile = FileUtil.writeInputStreamToTempFile(inputStream, ".jar");
+            List<String> parserClasses = JarReader.findSubtypeOfClasses(tmpFile, Parser.class);
+            Collection<String> availableParserClasses = Collections2.filter(parserClasses, new Predicate<String>() {
+                @Override
+                public boolean apply(@Nullable String s) {
+                    try {
+                        parserProxyUtil.loadClassFromJar(tmpFile.getAbsolutePath(), s);
+                        return true;
+                    } catch (Throwable ex) {
+                        LOG.warn("class {} is subtype of Parser, but it can't be initialized.", s);
+                        return false;
+                    }
+                }
+            });
+
+            return WSUtils.respond(Response.Status.OK, SUCCESS, availableParserClasses);
+        } catch (Exception ex) {
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
     }
 
     //Test curl command curl -X POST -i -F parserJar=@original-webservice-0.1.0-SNAPSHOT.jar -F parserInfo='{"parserName":"TestParser","className":"some.test.parserClass","version":0}' http://localhost:8080/api/v1/catalog/parsers


### PR DESCRIPTION
- introduce new API: /catalog/parsers/classes
  - which takes jar content as input stream (parserJar)
  - and returns all class names which implements Parser

Run output: 

```
curl -X POST -i -F parserJar=@parsers-0.1.0-SNAPSHOT.jar http://localhost:8080/api/v1/catalog/parsers/classes
HTTP/1.1 100 Continue

HTTP/1.1 200 OK
Date: Fri, 11 Mar 2016 08:10:54 GMT
Content-Type: application/json
Content-Length: 214

{"responseCode":1000,"responseMessage":"Success","entities":["com.hortonworks.iotas.parsers.json.JsonParser","com.hortonworks.iotas.parsers.nest.NestParser","com.hortonworks.iotas.parsers.protobuf.ProtobufParser"]}%
```

I'm not sure `/parsers/classes` is OK for us, especially it should use POST as method...
Please let me know if you have better API path.

I don't have an idea we also want to fix the UI in this PR, so I didn't fix it.
@harshach Let me know if we want to address that in this PR.
Thanks!
