### PR TITLE
IOT-180 Provide a feature of storing metric datas

### DIFF
--- a/core/src/main/java/com/hortonworks/iotas/metric/MetricsWriter.java
+++ b/core/src/main/java/com/hortonworks/iotas/metric/MetricsWriter.java
@@ -1,0 +1,40 @@
+package com.hortonworks.iotas.metric;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Interface for storing metric point to time-series external storages.
+ *
+ * Features of Point are defined by extracting common features of point from OpenTSDB, InfluxDB, Graphite.
+ */
+public interface MetricsWriter {
+    /**
+     * Initialize any necessary resources needed for the implementation
+     * @param config
+     */
+    void initialize(Map<String, Object> config);
+
+    /**
+     * write metric point to storage
+     *
+     * @param metricName metric name
+     * @param value metric value
+     * @param tags key-value pair of tags
+     * @param timestamp timestamp, millisecond resolution
+     * @throws IOException
+     */
+    void writePoint(String metricName, float value, Map<String, String> tags, long timestamp) throws IOException;
+
+    /**
+     * write metric point to storage
+     *
+     * @param metricName metric name
+     * @param value metric value
+     * @param tags key-value pair of tags
+     * @param timestamp timestamp, millisecond resolution
+     * @throws IOException
+     */
+    void writePoint(String metricName, int value, Map<String, String> tags, long timestamp) throws IOException;
+
+}

--- a/metric/pom.xml
+++ b/metric/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>iotas</artifactId>
+        <groupId>com.hortonworks.iotas</groupId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>metric</artifactId>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <httpclient.fluent.version>4.5.2</httpclient.fluent.version>
+        <wiremock.version>1.58</wiremock.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.hortonworks.iotas</groupId>
+            <artifactId>core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>fluent-hc</artifactId>
+            <version>${httpclient.fluent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>${wiremock.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/metric/src/main/java/com/hortonworks/iotas/metric/HttpAPIWithStringBodyBasedMetricsWriter.java
+++ b/metric/src/main/java/com/hortonworks/iotas/metric/HttpAPIWithStringBodyBasedMetricsWriter.java
@@ -1,0 +1,46 @@
+package com.hortonworks.iotas.metric;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.client.HttpResponseException;
+import org.apache.http.client.fluent.Executor;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.entity.ContentType;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+
+import java.io.IOException;
+
+public abstract class HttpAPIWithStringBodyBasedMetricsWriter implements MetricsWriter {
+    private static final int DEFAULT_TIMEOUT = 2000;
+
+    protected int connectTimeout = DEFAULT_TIMEOUT;
+    protected int socketTimeout = DEFAULT_TIMEOUT;
+
+    protected final Executor executor;
+
+    public HttpAPIWithStringBodyBasedMetricsWriter() {
+        PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
+        CloseableHttpClient client = HttpClients.custom()
+                .setConnectionManager(cm)
+                .build();
+        cm.setDefaultMaxPerRoute(15);
+        executor = Executor.newInstance(client);
+    }
+
+    protected abstract Request requestForPut();
+    protected abstract boolean isError(StatusLine statusLine);
+
+    protected void doPutRequest(String requestBody, ContentType contentType) throws IOException {
+        Request request = requestForPut();
+        request = request.connectTimeout(connectTimeout).socketTimeout(socketTimeout)
+                .bodyString(requestBody, contentType);
+        HttpResponse httpResponse = executor.execute(request).returnResponse();
+
+        StatusLine statusLine = httpResponse.getStatusLine();
+        if (isError(statusLine)) {
+            throw new HttpResponseException(statusLine.getStatusCode(), statusLine.getReasonPhrase());
+        }
+    }
+}

--- a/metric/src/main/java/com/hortonworks/iotas/metric/influxdb/InfluxDBMetricsWriter.java
+++ b/metric/src/main/java/com/hortonworks/iotas/metric/influxdb/InfluxDBMetricsWriter.java
@@ -1,0 +1,90 @@
+package com.hortonworks.iotas.metric.influxdb;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
+import com.hortonworks.iotas.metric.HttpAPIWithStringBodyBasedMetricsWriter;
+import org.apache.http.Consts;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.client.HttpResponseException;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.entity.ContentType;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Metrics Writer for InfluxDB
+ */
+public class InfluxDBMetricsWriter extends HttpAPIWithStringBodyBasedMetricsWriter {
+    private static final String PUT_API_PATH = "/write";
+    private static final ContentType CONTENT_TYPE = ContentType.create("text/plain", Consts.UTF_8);
+
+    private String apiPath;
+
+    @Override
+    public void initialize(Map<String, Object> config) {
+        String host = (String) config.get("host");
+        int port = ((Number)config.get("port")).intValue();
+        String dbName = (String) config.get("dbName");
+
+        Number connTimeout = (Number) config.get("connectTimeout");
+        Number sockTimeout = (Number) config.get("socketTimeout");
+
+        if (connTimeout != null) {
+            connectTimeout = connTimeout.intValue();
+        }
+
+        if (sockTimeout != null) {
+            socketTimeout = sockTimeout.intValue();
+        }
+
+        apiPath = createPathForPut(host, port, dbName);
+    }
+
+    @Override
+    public void writePoint(String metricName, float value, Map<String, String> tags, long timestamp) throws IOException {
+        doPutRequest(buildRequestLineProtocol(metricName, String.valueOf(value), tags, timestamp), CONTENT_TYPE);
+    }
+
+    @Override
+    public void writePoint(String metricName, int value, Map<String, String> tags, long timestamp) throws IOException {
+        doPutRequest(buildRequestLineProtocol(metricName, String.valueOf(value), tags, timestamp), CONTENT_TYPE);
+    }
+
+    @Override
+    protected Request requestForPut() {
+        if (apiPath == null) {
+            throw new IllegalStateException("Seems like request occurred before initializing");
+        }
+
+        return Request.Post(apiPath);
+    }
+
+    @Override
+    protected boolean isError(StatusLine statusLine) {
+        // if operation is succeed, it returns 204 and no content is returned
+        // otherwise it returns 400
+        // it may be other codes, but we don't need to care about cause it indicates failed operation anyway
+        return statusLine.getStatusCode() != 204;
+    }
+
+    private String createPathForPut(String host, int port, String dbName) {
+        // Note: timestamp will have millisecond precision, where influxdb itself supports microsecond as default
+        return String.format("http://%s:%d%s?db=%s&precision=ms", host, port, PUT_API_PATH, dbName);
+    }
+
+    private String buildRequestLineProtocol(String metricName, String valueStr, Map<String, String> tags, long timestamp) {
+        List<String> seriesComponents = Lists.newArrayList();
+        seriesComponents.add(metricName);
+
+        for (Map.Entry<String, String> tagEntry : tags.entrySet()) {
+            seriesComponents.add(tagEntry.getKey() + "=" + tagEntry.getValue());
+        }
+
+        String seriesName = Joiner.on(",").join(seriesComponents);
+
+        return String.format("%s value=%s %d", seriesName, valueStr, timestamp);
+    }
+}

--- a/metric/src/main/java/com/hortonworks/iotas/metric/opentsdb/OpenTSDBMetricsWriter.java
+++ b/metric/src/main/java/com/hortonworks/iotas/metric/opentsdb/OpenTSDBMetricsWriter.java
@@ -1,0 +1,90 @@
+package com.hortonworks.iotas.metric.opentsdb;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hortonworks.iotas.metric.HttpAPIWithStringBodyBasedMetricsWriter;
+import org.apache.http.StatusLine;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.entity.ContentType;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Metrics Writer for OpenTSDB.
+ *
+ * It uses /api/put API which is supported via starting 2.0, So you should use at least OpenTSDB 2.0 to use this implementation.
+ */
+public class OpenTSDBMetricsWriter extends HttpAPIWithStringBodyBasedMetricsWriter {
+    private static final String PUT_API_PATH = "/api/put";
+
+    private final ObjectMapper mapper;
+
+    private String apiPath;
+
+    public OpenTSDBMetricsWriter() {
+        mapper = new ObjectMapper();
+    }
+
+    @Override
+    public void initialize(Map<String, Object> config) {
+        String host = (String) config.get("host");
+        int port = ((Number)config.get("port")).intValue();
+
+        Number connTimeout = (Number) config.get("connectTimeout");
+        Number sockTimeout = (Number) config.get("socketTimeout");
+
+        if (connTimeout != null) {
+            connectTimeout = connTimeout.intValue();
+        }
+
+        if (sockTimeout != null) {
+            socketTimeout = sockTimeout.intValue();
+        }
+
+        apiPath = createPathForPut(host, port);
+    }
+
+    @Override
+    public void writePoint(String metricName, float value, Map<String, String> tags, long timestamp) throws IOException {
+        doPutRequest(buildRequestJson(metricName, String.valueOf(value), tags, timestamp), ContentType.APPLICATION_JSON);
+    }
+
+    @Override
+    public void writePoint(String metricName, int value, Map<String, String> tags, long timestamp) throws IOException {
+        doPutRequest(buildRequestJson(metricName, String.valueOf(value), tags, timestamp), ContentType.APPLICATION_JSON);
+    }
+
+    @Override
+    protected Request requestForPut() {
+        if (apiPath == null) {
+            throw new IllegalStateException("Seems like request occurred before initializing");
+        }
+
+        return Request.Post(apiPath);
+    }
+
+    @Override
+    protected boolean isError(StatusLine statusLine) {
+        // if operation is succeed, it returns 204 and no content is returned
+        // otherwise it returns 400
+        // it may be other codes, but we don't need to care about cause it indicates failed operation anyway
+        return statusLine.getStatusCode() != 204;
+    }
+
+    private String createPathForPut(String host, int port) {
+        return String.format("http://%s:%d%s", host, port, PUT_API_PATH);
+    }
+
+    private String buildRequestJson(String metricName, String valueStr, Map<String, String> tags, long timestamp)
+            throws JsonProcessingException {
+        Map<String, Object> requestData = new HashMap<>();
+        requestData.put("metric", metricName);
+        requestData.put("timestamp", timestamp);
+        requestData.put("value", valueStr);
+        requestData.put("tags", tags);
+
+        return mapper.writeValueAsString(requestData);
+    }
+}

--- a/metric/src/test/java/com/hortonworks/iotas/metric/influxdb/InfluxDBMetricsWriterTest.java
+++ b/metric/src/test/java/com/hortonworks/iotas/metric/influxdb/InfluxDBMetricsWriterTest.java
@@ -1,0 +1,57 @@
+package com.hortonworks.iotas.metric.influxdb;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+
+public class InfluxDBMetricsWriterTest {
+    private static final int WIREMOCK_PORT = 8089;
+    private static final String DB_NAME = "mydb";
+
+    @ClassRule
+    public static WireMockRule wireMockRule = new WireMockRule(WIREMOCK_PORT);
+
+    @Test
+    public void testWritePoint() throws IOException {
+        stubFor(post(urlPathEqualTo("/write"))
+                .withQueryParam("db", equalTo(DB_NAME))
+                .withQueryParam("precision", equalTo("ms"))
+                .willReturn(aResponse().withStatus(204)));
+
+        InfluxDBMetricsWriter writer = new InfluxDBMetricsWriter();
+        HashMap<String, Object> config = new HashMap<>();
+        config.put("host", "localhost");
+        config.put("port", WIREMOCK_PORT);
+        config.put("dbName", DB_NAME);
+
+        writer.initialize(config);
+
+        HashMap<String, String> tags = new HashMap<>();
+        tags.put("tag1", "tagvalue1");
+        tags.put("tag2", "tagvalue2");
+
+        long timestamp = System.currentTimeMillis();
+        writer.writePoint("hello", 0.1f, tags, timestamp);
+
+        String expectedRequestBodyRegex = "hello,tag1=tagvalue1,tag2=tagvalue2 value=0\\.1 " + timestamp;
+        String expectedRequestContentType = "text/plain; charset=UTF-8";
+
+        verify(postRequestedFor(urlPathEqualTo("/write"))
+                .withQueryParam("db", equalTo(DB_NAME))
+                .withQueryParam("precision", equalTo("ms"))
+                .withRequestBody(matching(expectedRequestBodyRegex))
+                .withHeader("Content-Type", matching(expectedRequestContentType)));
+    }
+}

--- a/metric/src/test/java/com/hortonworks/iotas/metric/opentsdb/OpenTSDBMetricsWriterTest.java
+++ b/metric/src/test/java/com/hortonworks/iotas/metric/opentsdb/OpenTSDBMetricsWriterTest.java
@@ -1,0 +1,56 @@
+package com.hortonworks.iotas.metric.opentsdb;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+
+public class OpenTSDBMetricsWriterTest {
+    private static final int WIREMOCK_PORT = 8089;
+
+    @ClassRule
+    public static WireMockRule wireMockRule = new WireMockRule(WIREMOCK_PORT);
+
+    @Test
+    public void testWritePoint() throws IOException {
+        String urlPath = "/api/put";
+        stubFor(post(urlPathEqualTo(urlPath))
+                .willReturn(aResponse()
+                        .withStatus(204)));
+
+        OpenTSDBMetricsWriter writer = new OpenTSDBMetricsWriter();
+        HashMap<String, Object> config = new HashMap<>();
+        config.put("host", "localhost");
+        config.put("port", WIREMOCK_PORT);
+
+        writer.initialize(config);
+
+        HashMap<String, String> tags = new HashMap<>();
+        tags.put("tag1", "tagvalue1");
+        tags.put("tag2", "tagvalue2");
+
+        long timestamp = System.currentTimeMillis();
+        writer.writePoint("hello", 0.1f, tags, timestamp);
+
+        String expectedRequestContentType = "application/json; charset=UTF-8";
+
+        String expectedRequestBodyJson = "{\"metric\":\"hello\",\"value\":\"0.1\",\"timestamp\":" +
+                timestamp + ",\"tags\":{\"tag1\":\"tagvalue1\",\"tag2\":\"tagvalue2\"}}";
+
+        verify(postRequestedFor(urlPathEqualTo(urlPath))
+                .withRequestBody(equalToJson(expectedRequestBodyJson))
+                .withHeader("Content-Type", matching(expectedRequestContentType)));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,8 @@
         <module>notification-service</module>
         <module>notifiers</module>
         <module>layout</module>
-	<module>iotas-dist</module>
+        <module>metric</module>
+        <module>iotas-dist</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
- introduce MetricsWriter : common interface to write metrics datas to external storage
- add new module: metric
- add implementation of MetricsWriter: OpenTSDB, InfluxDB
  - also address UTs

I also installed OpenTSDB and InfluxDB to my local and tested.

We may also want to apply bulk insert, but it can be addressed later when we can determine how frequently we log metric point.
