### PR TITLE
IOT-215 Introduce new REST API to show metrics for topology

### DIFF
--- a/core/src/main/java/com/hortonworks/iotas/common/errors/ConfigException.java
+++ b/core/src/main/java/com/hortonworks/iotas/common/errors/ConfigException.java
@@ -1,9 +1,7 @@
 package com.hortonworks.iotas.common.errors;
 
-import com.hortonworks.iotas.processor.CustomProcessor;
-
 /**
- * Exception class representing a malformed configuration for a {@link CustomProcessor} implementation
+ * Exception class representing a malformed configuration.
  */
 public class ConfigException extends Exception {
 

--- a/core/src/main/java/com/hortonworks/iotas/service/CatalogService.java
+++ b/core/src/main/java/com/hortonworks/iotas/service/CatalogService.java
@@ -25,6 +25,7 @@ import com.hortonworks.iotas.topology.TopologyActions;
 import com.hortonworks.iotas.topology.TopologyComponent;
 import com.hortonworks.iotas.topology.TopologyLayoutConstants;
 import com.hortonworks.iotas.topology.TopologyLayoutValidator;
+import com.hortonworks.iotas.topology.TopologyMetrics;
 import com.hortonworks.iotas.util.CoreUtils;
 import com.hortonworks.iotas.util.JarStorage;
 import com.hortonworks.iotas.util.JsonSchemaValidator;
@@ -70,6 +71,7 @@ public class CatalogService {
 
     private StorageManager dao;
     private TopologyActions topologyActions;
+    private TopologyMetrics topologyMetrics;
     private JarStorage jarStorage;
     private TagService tagService;
 
@@ -118,9 +120,10 @@ public class CatalogService {
         }
     }
 
-    public CatalogService(StorageManager dao, TopologyActions topologyActions, JarStorage jarStorage) {
+    public CatalogService(StorageManager dao, TopologyActions topologyActions, TopologyMetrics topologyMetrics, JarStorage jarStorage) {
         this.dao = dao;
         this.topologyActions = topologyActions;
+        this.topologyMetrics = topologyMetrics;
         this.jarStorage = jarStorage;
         this.tagService = new CatalogTagService(dao);
     }
@@ -543,6 +546,10 @@ public class CatalogService {
 
     public TopologyActions.Status topologyStatus (Topology topology) throws Exception {
         return this.topologyActions.status(topology);
+    }
+
+    public Map<String, TopologyMetrics.ComponentMetric> getTopologyMetrics (Topology topology) throws Exception {
+        return this.topologyMetrics.getMetricsForTopology(topology);
     }
 
     public Collection<TopologyComponent.TopologyComponentType> listTopologyComponentTypes () {

--- a/core/src/main/java/com/hortonworks/iotas/topology/TopologyLayoutConstants.java
+++ b/core/src/main/java/com/hortonworks/iotas/topology/TopologyLayoutConstants.java
@@ -156,6 +156,9 @@ public final class TopologyLayoutConstants {
 
     public static final String STORM_STREAMING_ENGINE = "STORM";
 
+    // metric
+    public static final String STORM_API_ROOT_URL_KEY = "stormApiRootUrl";
+
     // artifact
     public static final String STORM_ARTIFACTS_LOCATION_KEY =
             "stormArtifactsDirectory";

--- a/core/src/main/java/com/hortonworks/iotas/topology/TopologyMetrics.java
+++ b/core/src/main/java/com/hortonworks/iotas/topology/TopologyMetrics.java
@@ -1,0 +1,84 @@
+package com.hortonworks.iotas.topology;
+
+import com.hortonworks.iotas.catalog.Topology;
+import com.hortonworks.iotas.common.errors.ConfigException;
+
+import java.util.Map;
+
+/**
+ * Interface that shows metrics for IoTaS topology.
+ * Each underlying streaming framework should provide implementations to integrate metrics of framework into IoTaS.
+ */
+public interface TopologyMetrics {
+    /**
+     * Initialize method. Any one time initialization is done here.
+     *
+     * @param conf Configuration for implementation of TopologyMetrics.
+     * @throws ConfigException throw when instance can't be initialized with this configuration (misconfigured).
+     */
+    void init (Map<String, String> conf) throws ConfigException;
+
+    /**
+     * Retrieves metrics data for IoTaS topology.
+     *
+     * @param topology topology catalog instance. Implementations should find actual runtime topology with provided topology.
+     * @return pair of (component name, ComponentMetric instance).
+     * Implementations should ensure that component name is same to UI name of component
+     * so that it can be matched to IoTas topology.
+     */
+    Map<String, ComponentMetric> getMetricsForTopology(Topology topology);
+
+    /**
+     * Data structure of Metrics for each component on topology.
+     * Fields are extracted from common metrics among various streaming frameworks.
+     *
+     * Implementors of TopologyMetrics are encouraged to provide fields' value as many as possible.
+     * If field is not available for that streaming framework, implementator can leave it as null or default value.
+     */
+    class ComponentMetric {
+        private String componentName;
+        private Long inputRecords;
+        private Long outputRecords;
+        private Long failedRecords;
+        private Double processedTime;
+
+        /**
+         * Constructor.
+         *
+         * @param componentName 'component name' for IoTaS.
+         *                      If component name for streaming framework is different from component name for IoTas,
+         *                      implementation of TopologyMetrics should match the relation.
+         * @param inputRecords  Count of input records.
+         * @param outputRecords Count of output records.
+         * @param failedRecords Count of failed records.
+         * @param processedTime Latency of processed time (processing one event).
+         */
+        public ComponentMetric(String componentName, Long inputRecords, Long outputRecords, Long failedRecords, Double processedTime) {
+            this.componentName = componentName;
+            this.inputRecords = inputRecords;
+            this.outputRecords = outputRecords;
+            this.failedRecords = failedRecords;
+            this.processedTime = processedTime;
+        }
+
+        public String getComponentName() {
+            return componentName;
+        }
+
+        public Long getInputRecords() {
+            return inputRecords;
+        }
+
+        public Long getOutputRecords() {
+            return outputRecords;
+        }
+
+        public Long getFailedRecords() {
+            return failedRecords;
+        }
+
+        public Double getProcessedTime() {
+            return processedTime;
+        }
+    }
+}

--- a/core/src/main/java/com/hortonworks/iotas/topology/storm/StormMetricsConstant.java
+++ b/core/src/main/java/com/hortonworks/iotas/topology/storm/StormMetricsConstant.java
@@ -1,0 +1,15 @@
+package com.hortonworks.iotas.topology.storm;
+
+public class StormMetricsConstant {
+    private StormMetricsConstant() {
+    }
+
+    public static final String COMPONENT_EXECUTED_TUPLES = "executed";
+    public static final String COMPONENT_EMITTED_TUPLES = "emitted";
+    public static final String COMPONENT_PROCESS_LATENCY = "processLatency";
+    public static final String COMPONENT_FAILED_TUPLES = "failed";
+
+    public static final String TOPOLOGY_SUMMARY_JSON_TOPOLOGIES = "topologies";
+    public static final String TOPOLOGY_SUMMARY_JSON_TOPOLOGY_NAME = "name";
+    public static final String TOPOLOGY_SUMMARY_JSON_TOPOLOGY_ID_ENCODED = "encodedId";
+}

--- a/core/src/main/java/com/hortonworks/iotas/topology/storm/StormTopologyMetricsImpl.java
+++ b/core/src/main/java/com/hortonworks/iotas/topology/storm/StormTopologyMetricsImpl.java
@@ -1,0 +1,121 @@
+package com.hortonworks.iotas.topology.storm;
+
+import com.hortonworks.iotas.catalog.Topology;
+import com.hortonworks.iotas.common.errors.ConfigException;
+import com.hortonworks.iotas.topology.TopologyLayoutConstants;
+import com.hortonworks.iotas.topology.TopologyMetrics;
+import org.glassfish.jersey.client.ClientConfig;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.MediaType;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Storm implementation of the TopologyMetrics interface
+ */
+public class StormTopologyMetricsImpl implements TopologyMetrics {
+    private Client client;
+    private String stormApiRootUrl;
+
+    public StormTopologyMetricsImpl() {
+    }
+
+    @Override
+    public void init(Map<String, String> conf) throws ConfigException {
+        if (conf != null) {
+            stormApiRootUrl = conf.get(TopologyLayoutConstants.STORM_API_ROOT_URL_KEY);
+        }
+        client = ClientBuilder.newClient(new ClientConfig());
+    }
+
+    @Override
+    public Map<String, ComponentMetric> getMetricsForTopology(Topology topology) {
+        String stormTopologyName = getTopologyName(topology);
+
+        Map<String, ComponentMetric> metricMap = new HashMap<>();
+
+        String topologyId = findTopologyId(stormTopologyName);
+        if (topologyId == null) {
+            throw new RuntimeException("Topology not found in Storm Cluster - topology name in Storm: " + stormTopologyName);
+        }
+
+        Map<String, ?> responseMap = client.target(getTopologyUrl(topologyId)).request(MediaType.APPLICATION_JSON_TYPE).get(Map.class);
+
+        List<Map<String, ?>> spouts = (List<Map<String, ?>>) responseMap.get("spouts");
+        for (Map<String, ?> spout : spouts) {
+            String spoutName = (String) spout.get("spoutId");
+            ComponentMetric metric = extractMetric(spoutName, spout);
+            metricMap.put(metric.getComponentName(), metric);
+        }
+
+        List<Map<String, ?>> bolts = (List<Map<String, ?>>) responseMap.get("bolts");
+        for (Map<String, ?> bolt : bolts) {
+            String boltName = (String) bolt.get("boltId");
+            ComponentMetric metric = extractMetric(boltName, bolt);
+            metricMap.put(metric.getComponentName(), metric);
+        }
+
+        return metricMap;
+    }
+
+    private ComponentMetric extractMetric(String componentName, Map<String, ?> componentMap) {
+        Long inputRecords = 0L;
+        Long outputRecords = 0L;
+        Double processedTime = 0.0d;
+        Long failedRecords = 0L;
+
+        if (componentMap.containsKey(StormMetricsConstant.COMPONENT_EXECUTED_TUPLES)) {
+            Number executed = (Number) componentMap.get(StormMetricsConstant.COMPONENT_EXECUTED_TUPLES);
+            inputRecords = executed.longValue();
+        }
+        if (componentMap.containsKey(StormMetricsConstant.COMPONENT_EMITTED_TUPLES)) {
+            Number emitted = (Number) componentMap.get(StormMetricsConstant.COMPONENT_EMITTED_TUPLES);
+            outputRecords = emitted.longValue();
+        }
+        if (componentMap.containsKey(StormMetricsConstant.COMPONENT_PROCESS_LATENCY)) {
+            String processLatencyStr = (String) componentMap.get(StormMetricsConstant.COMPONENT_PROCESS_LATENCY);
+            try {
+                processedTime = Double.parseDouble(processLatencyStr);
+            } catch (NumberFormatException e) {
+                // noop
+            }
+        }
+        if (componentMap.containsKey(StormMetricsConstant.COMPONENT_FAILED_TUPLES)) {
+            Number failed = (Number) componentMap.get(StormMetricsConstant.COMPONENT_FAILED_TUPLES);
+            failedRecords = failed.longValue();
+        }
+
+        return new ComponentMetric(componentName, inputRecords, outputRecords, failedRecords, processedTime);
+    }
+
+    private String findTopologyId(String topologyName) {
+        Map<?, ?> summaryMap = client.target(getTopologySummaryUrl()).request(MediaType.APPLICATION_JSON_TYPE).get(Map.class);
+        List<Map<?, ?>> topologies = (List<Map<?, ?>>) summaryMap.get(StormMetricsConstant.TOPOLOGY_SUMMARY_JSON_TOPOLOGIES);
+        String topologyId = null;
+        for (Map<?, ?> topology : topologies) {
+            String topologyNameForStorm = (String) topology.get(StormMetricsConstant.TOPOLOGY_SUMMARY_JSON_TOPOLOGY_NAME);
+
+            if (topologyNameForStorm.equals(topologyName)) {
+                topologyId = (String) topology.get(StormMetricsConstant.TOPOLOGY_SUMMARY_JSON_TOPOLOGY_ID_ENCODED);
+                break;
+            }
+        }
+        return topologyId;
+    }
+
+    private String getTopologySummaryUrl() {
+        return stormApiRootUrl + "/topology/summary";
+    }
+
+    private String getTopologyUrl(String topologyId) {
+        return stormApiRootUrl + "/topology/" + topologyId;
+    }
+
+    private String getTopologyName(Topology topology) {
+        return "iotas-" + topology.getId() + "-" + topology.getName();
+    }
+
+}

--- a/webservice/conf/iotas-dev.yaml
+++ b/webservice/conf/iotas-dev.yaml
@@ -1,10 +1,12 @@
 brokerList: localhost:9092
 zookeeperHost: localhost:2181
 topologyActionsImpl: com.hortonworks.iotas.topology.storm.StormTopologyActionsImpl
+topologyMetricsImpl: com.hortonworks.iotas.topology.storm.StormTopologyMetricsImpl
 #change the below to the path on your local machine
 iotasStormJar: /tmp/storm-0.1.0-SNAPSHOT.jar
 catalogRootUrl: "http://localhost:8080/api/v1/catalog"
 stormHomeDir: /usr/local/Cellar/storm/0.10.0/
+stormApiRootUrl: "http://localhost:8888/api/v1"
 # Filesystem based jar storage
 #jarStorageConfiguration:
 #  className: "com.hortonworks.iotas.util.FileSystemJarStorage"

--- a/webservice/conf/iotas.yaml
+++ b/webservice/conf/iotas.yaml
@@ -5,6 +5,7 @@ topologyActionsImpl: com.hortonworks.iotas.topology.storm.StormTopologyActionsIm
 iotasStormJar: /tmp/storm-0.1.0-SNAPSHOT.jar
 catalogRootUrl: "http://localhost:8080/api/v1/catalog"
 stormHomeDir: /usr/local/Cellar/storm/0.10.0/
+stormApiRootUrl: "http://localhost:8888/api/v1"
 # Filesystem based jar storage
 #jarStorageConfiguration:
 #  className: "com.hortonworks.iotas.util.FileSystemJarStorage"

--- a/webservice/src/main/java/com/hortonworks/iotas/webservice/IotasConfiguration.java
+++ b/webservice/src/main/java/com/hortonworks/iotas/webservice/IotasConfiguration.java
@@ -35,6 +35,9 @@ public class IotasConfiguration extends Configuration {
     private String topologyActionsImpl;
 
     @NotEmpty
+    private String topologyMetricsImpl;
+
+    @NotEmpty
     private String iotasStormJar;
 
     private Boolean notificationsRestDisable;
@@ -47,6 +50,9 @@ public class IotasConfiguration extends Configuration {
 
     @NotEmpty
     private String stormHomeDir;
+
+    @NotEmpty
+    private String stormApiRootUrl;
 
     @JsonProperty
     public String getBrokerList(){
@@ -146,5 +152,21 @@ public class IotasConfiguration extends Configuration {
 
     public void setCustomProcessorUploadSuccessPath (String customProcessorUploadSuccessPath) {
         this.customProcessorUploadSuccessPath = customProcessorUploadSuccessPath;
+    }
+
+    public String getTopologyMetricsImpl() {
+        return topologyMetricsImpl;
+    }
+
+    public void setTopologyMetricsImpl(String topologyMetricsImpl) {
+        this.topologyMetricsImpl = topologyMetricsImpl;
+    }
+
+    public String getStormApiRootUrl() {
+        return stormApiRootUrl;
+    }
+
+    public void setStormApiRootUrl(String stormApiRootUrl) {
+        this.stormApiRootUrl = stormApiRootUrl;
     }
 }

--- a/webservice/src/main/java/com/hortonworks/iotas/webservice/MetricsResource.java
+++ b/webservice/src/main/java/com/hortonworks/iotas/webservice/MetricsResource.java
@@ -1,0 +1,67 @@
+package com.hortonworks.iotas.webservice;
+
+import com.codahale.metrics.annotation.Timed;
+import com.hortonworks.iotas.catalog.Topology;
+import com.hortonworks.iotas.common.IotasEvent;
+import com.hortonworks.iotas.notification.common.Notification;
+import com.hortonworks.iotas.notification.service.NotificationService;
+import com.hortonworks.iotas.service.CatalogService;
+import com.hortonworks.iotas.topology.TopologyMetrics;
+import com.hortonworks.iotas.webservice.util.WSUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static com.hortonworks.iotas.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND;
+import static com.hortonworks.iotas.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND_FOR_FILTER;
+import static com.hortonworks.iotas.catalog.CatalogResponse.ResponseMessage.EXCEPTION;
+import static com.hortonworks.iotas.catalog.CatalogResponse.ResponseMessage.SUCCESS;
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
+
+/**
+ * REST endpoint for metrics
+ */
+@Path("/api/v1/metrics")
+@Produces(MediaType.APPLICATION_JSON)
+public class MetricsResource {
+    private static final Logger LOG = LoggerFactory.getLogger(MetricsResource.class);
+
+    private CatalogService catalogService;
+
+    public MetricsResource(CatalogService service) {
+        this.catalogService = service;
+    }
+
+    @GET
+    @Path("/topologies/{id}")
+    @Timed
+    public Response getTopologyMetricsById(@PathParam("id") Long id) {
+        try {
+            Topology topology = catalogService.getTopology(id);
+            if (topology != null) {
+                Map<String, TopologyMetrics.ComponentMetric> topologyMetrics = catalogService.getTopologyMetrics(topology);
+                return WSUtils.respond(OK, SUCCESS, topologyMetrics);
+            }
+        } catch (Exception ex) {
+            LOG.error("Got exception", ex);
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
+        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, id.toString());
+    }
+}

--- a/webservice/src/test/resources/iotas-test.yaml
+++ b/webservice/src/test/resources/iotas-test.yaml
@@ -1,10 +1,11 @@
 brokerList: localhost:9092
 zookeeperHost: localhost:2181
 topologyActionsImpl: com.hortonworks.iotas.topology.storm.StormTopologyActionsImpl
+topologyMetricsImpl: com.hortonworks.iotas.topology.storm.StormTopologyMetricsImpl
 iotasStormJar: /tmp/storm-0.1.0-SNAPSHOT.jar
 catalogRootUrl: "http://localhost:8080/api/v1/catalog"
 stormHomeDir: /usr/local/Cellar/storm/0.10.0/
-
+stormApiRootUrl: "http://localhost:8888/api/v1"
 # Filesystem based jar storage
 jarStorageConfiguration:
   className: "com.hortonworks.iotas.util.FileSystemJarStorage"


### PR DESCRIPTION
- Introduce new interface `TopologyMetrics`
  - which is responsible of providing topology metrics for IoTaS
  - implementations are vary with streaming frameworks
  - similar usage of TopologyActions: specify implementation class to iotas.yaml
- Provide Storm ver. implementation of `TopologyMetrics`
- Introduce new REST API `/api/v1/metrics/topology/:topologyId`
  - which retrieves topology metrics from TopologyMetrics and responds

> Snapshot of API response

<img width="326" alt="screenshot-iot-215-v1" src="https://cloud.githubusercontent.com/assets/1317309/13975140/b5a94470-f0f5-11e5-8689-76acd360747b.png">

> Some considerations (which I want to gather opinions)
- Is it better to merge TopologyMetrics into TopologyActions? Or keep them as it is?
- Storm now provides topology metrics with several pre-defined time buckets, which other frameworks seem not. Should TopologyMetrics support querying with time buckets?

Please review and comment. Thanks!
