### PR TITLE
IOT-261 topology status API can't determine status of topology on Storm

### DIFF
--- a/core/src/main/java/com/hortonworks/iotas/topology/storm/StormTopologyActionsImpl.java
+++ b/core/src/main/java/com/hortonworks/iotas/topology/storm/StormTopologyActionsImpl.java
@@ -133,7 +133,6 @@ public class StormTopologyActionsImpl implements TopologyActions {
         commands.add(stormCliPath);
         commands.add("list");
         String topologyName = getTopologyName(topology);
-        commands.add(topologyName);
         ShellProcessResult result = executeShellProcess(commands);
         int exitValue = result.exitValue;
         if (exitValue != 0) {


### PR DESCRIPTION
- fix for calling to 'storm list' to not adding topology name as parameter

Without fix calling topology status API always shows 'Unknown' and error messages are written to webservice log.

```
DEBUG [2016-05-20 02:20:20,564] com.hortonworks.iotas.topology.storm.StormTopologyActionsImpl: Command output: Exception in thread "main" clojure.lang.ArityException: Wrong number of args (1) passed to: list/-main
        at clojure.lang.AFn.throwArity(AFn.java:429)
        at clojure.lang.AFn.invoke(AFn.java:32)
        at clojure.lang.AFn.applyToHelper(AFn.java:154)
        at clojure.lang.AFn.applyTo(AFn.java:144)
        at org.apache.storm.command.list.main(Unknown Source)

DEBUG [2016-05-20 02:20:20,564] com.hortonworks.iotas.topology.storm.StormTopologyActionsImpl: Command exit status: 1
ERROR [2016-05-20 02:20:20,564] com.hortonworks.iotas.topology.storm.StormTopologyActionsImpl: Topology status could not be fetched for Topology-Name
```
