### PR TITLE
IOT-248 Integration tests for Notification Service

### DIFF
--- a/notification-service/pom.xml
+++ b/notification-service/pom.xml
@@ -11,21 +11,16 @@
 
     <artifactId>notification-service</artifactId>
 
+    <properties>
+        <hamcrest.version>1.3</hamcrest.version>
+    </properties>
+
+
     <dependencies>
         <dependency>
             <groupId>com.hortonworks.iotas</groupId>
             <artifactId>core</artifactId>
             <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jmockit</groupId>
-            <artifactId>jmockit</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -45,5 +40,45 @@
             <groupId>com.esotericsoftware.kryo</groupId>
             <artifactId>kryo</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <!-- Test plugins -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-report-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/notification-service/src/main/java/com/hortonworks/iotas/notification/common/NotificationImpl.java
+++ b/notification-service/src/main/java/com/hortonworks/iotas/notification/common/NotificationImpl.java
@@ -154,4 +154,38 @@ public class NotificationImpl implements Notification {
                 ", timestamp=" + timestamp +
                 '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof NotificationImpl)) return false;
+
+        NotificationImpl that = (NotificationImpl) o;
+
+        if (timestamp != that.timestamp) return false;
+        if (getId() != null ? !getId().equals(that.getId()) : that.getId() != null) return false;
+        if (getFieldsAndValues() != null ? !getFieldsAndValues().equals(that.getFieldsAndValues()) : that.getFieldsAndValues() != null)
+            return false;
+        if (getEventIds() != null ? !getEventIds().equals(that.getEventIds()) : that.getEventIds() != null)
+            return false;
+        if (getDataSourceIds() != null ? !getDataSourceIds().equals(that.getDataSourceIds()) : that.getDataSourceIds() != null)
+            return false;
+        if (getRuleId() != null ? !getRuleId().equals(that.getRuleId()) : that.getRuleId() != null) return false;
+        if (getStatus() != that.getStatus()) return false;
+        return getNotifierName() != null ? getNotifierName().equals(that.getNotifierName()) : that.getNotifierName() == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getId() != null ? getId().hashCode() : 0;
+        result = 31 * result + (getFieldsAndValues() != null ? getFieldsAndValues().hashCode() : 0);
+        result = 31 * result + (getEventIds() != null ? getEventIds().hashCode() : 0);
+        result = 31 * result + (getDataSourceIds() != null ? getDataSourceIds().hashCode() : 0);
+        result = 31 * result + (getRuleId() != null ? getRuleId().hashCode() : 0);
+        result = 31 * result + (getStatus() != null ? getStatus().hashCode() : 0);
+        result = 31 * result + (getNotifierName() != null ? getNotifierName().hashCode() : 0);
+        result = 31 * result + (int) (timestamp ^ (timestamp >>> 32));
+        return result;
+    }
 }

--- a/notification-service/src/main/java/com/hortonworks/iotas/notification/store/hbase/mappers/DatasourceNotificationMapper.java
+++ b/notification-service/src/main/java/com/hortonworks/iotas/notification/store/hbase/mappers/DatasourceNotificationMapper.java
@@ -1,8 +1,6 @@
 package com.hortonworks.iotas.notification.store.hbase.mappers;
 
 import com.hortonworks.iotas.notification.common.Notification;
-import com.hortonworks.iotas.notification.store.NotificationStoreException;
-import org.apache.hadoop.hbase.client.Put;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,8 +25,6 @@ public class DatasourceNotificationMapper extends NotificationIndexMapper {
         List<byte[]> rowKeys = new ArrayList<>();
         for (String dataSourceId : notification.getDataSourceIds()) {
             rowKeys.add(new StringBuilder(dataSourceId)
-                                .append(ROWKEY_SEP)
-                                .append(notification.getTs())
                                 .append(ROWKEY_SEP)
                                 .append(getIndexSuffix(notification))
                                 .toString().getBytes(CHARSET));

--- a/notification-service/src/main/java/com/hortonworks/iotas/notification/store/hbase/mappers/DatasourceStatusNotificationMapper.java
+++ b/notification-service/src/main/java/com/hortonworks/iotas/notification/store/hbase/mappers/DatasourceStatusNotificationMapper.java
@@ -26,10 +26,6 @@ public class DatasourceStatusNotificationMapper extends NotificationStatusIndexM
         for (String dataSourceId : notification.getDataSourceIds()) {
             rowKeys.add(new StringBuilder(dataSourceId)
                                 .append(ROWKEY_SEP)
-                                .append(notification.getStatus())
-                                .append(ROWKEY_SEP)
-                                .append(notification.getTs())
-                                .append(ROWKEY_SEP)
                                 .append(getIndexSuffix(notification))
                                 .toString().getBytes(CHARSET));
         }

--- a/notification-service/src/main/java/com/hortonworks/iotas/notification/store/hbase/mappers/NotificationIndexMapper.java
+++ b/notification-service/src/main/java/com/hortonworks/iotas/notification/store/hbase/mappers/NotificationIndexMapper.java
@@ -1,15 +1,9 @@
 package com.hortonworks.iotas.notification.store.hbase.mappers;
 
 import com.hortonworks.iotas.notification.common.Notification;
-import com.hortonworks.iotas.notification.store.hbase.mappers.AbstractNotificationMapper;
-import com.hortonworks.iotas.notification.store.hbase.mappers.TableMutation;
-import com.hortonworks.iotas.notification.store.hbase.mappers.TableMutationImpl;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.util.Bytes;
-
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * A base class for Notification index table mappers.
@@ -35,13 +29,23 @@ public abstract class NotificationIndexMapper extends AbstractNotificationMapper
         return Bytes.toString(result.getFamilyMap(CF_NOTIFICATION_ID).firstEntry().getKey());
     }
 
+    /**
+     * Returns suffix for notification index.
+     */
+    protected String getIndexSuffix(Notification notification) {
+        return new StringBuilder()
+                .append(notification.getTs())
+                .append(ROWKEY_SEP)
+                .append(getUniqueIndexSuffix(notification))
+                .toString();
+    }
 
     /**
      * Returns the last INDEX_KEY_SUFFIX_LEN chars of notification.id
      * This is added as a suffix in the index table so that
      * notifications with same ts ends up as unique row in the index table.
      */
-    protected final String getIndexSuffix(Notification notification) {
+    protected final String getUniqueIndexSuffix(Notification notification) {
         int startIndex = Math.max(0, notification.getId().length() - INDEX_KEY_SUFFIX_LEN);
         return notification.getId().substring(startIndex, notification.getId().length());
     }

--- a/notification-service/src/main/java/com/hortonworks/iotas/notification/store/hbase/mappers/NotificationStatusIndexMapper.java
+++ b/notification-service/src/main/java/com/hortonworks/iotas/notification/store/hbase/mappers/NotificationStatusIndexMapper.java
@@ -28,4 +28,12 @@ public abstract class NotificationStatusIndexMapper extends NotificationIndexMap
         LOG.trace("TableMutations for status update {}", tableMutations);
         return tableMutations;
     }
+
+    protected String getIndexSuffix(Notification notification) {
+        return new StringBuilder()
+                .append(notification.getStatus())
+                .append(ROWKEY_SEP)
+                .append(super.getIndexSuffix(notification))
+                .toString();
+    }
 }

--- a/notification-service/src/main/java/com/hortonworks/iotas/notification/store/hbase/mappers/NotifierNotificationMapper.java
+++ b/notification-service/src/main/java/com/hortonworks/iotas/notification/store/hbase/mappers/NotifierNotificationMapper.java
@@ -1,7 +1,6 @@
 package com.hortonworks.iotas.notification.store.hbase.mappers;
 
 import com.hortonworks.iotas.notification.common.Notification;
-import com.hortonworks.iotas.notification.store.hbase.mappers.NotificationIndexMapper;
 
 import java.util.Arrays;
 import java.util.List;
@@ -24,8 +23,6 @@ public class NotifierNotificationMapper extends NotificationIndexMapper {
     @Override
     protected List<byte[]> getRowKeys(Notification notification) {
         return Arrays.asList(new StringBuilder(notification.getNotifierName())
-                                     .append(ROWKEY_SEP)
-                                     .append(notification.getTs())
                                      .append(ROWKEY_SEP)
                                      .append(getIndexSuffix(notification))
                                      .toString().getBytes(CHARSET));

--- a/notification-service/src/main/java/com/hortonworks/iotas/notification/store/hbase/mappers/NotifierStatusNotificationMapper.java
+++ b/notification-service/src/main/java/com/hortonworks/iotas/notification/store/hbase/mappers/NotifierStatusNotificationMapper.java
@@ -1,11 +1,6 @@
 package com.hortonworks.iotas.notification.store.hbase.mappers;
 
 import com.hortonworks.iotas.notification.common.Notification;
-import com.hortonworks.iotas.notification.common.NotificationImpl;
-import org.apache.hadoop.hbase.client.Delete;
-import org.apache.hadoop.hbase.client.Put;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.List;
@@ -27,10 +22,6 @@ public class NotifierStatusNotificationMapper extends NotificationStatusIndexMap
     @Override
     protected List<byte[]> getRowKeys(Notification notification) {
         return Arrays.asList(new StringBuilder(notification.getNotifierName())
-                                     .append(ROWKEY_SEP)
-                                     .append(notification.getStatus())
-                                     .append(ROWKEY_SEP)
-                                     .append(notification.getTs())
                                      .append(ROWKEY_SEP)
                                      .append(getIndexSuffix(notification))
                                      .toString().getBytes(CHARSET));

--- a/notification-service/src/main/java/com/hortonworks/iotas/notification/store/hbase/mappers/RuleNotificationMapper.java
+++ b/notification-service/src/main/java/com/hortonworks/iotas/notification/store/hbase/mappers/RuleNotificationMapper.java
@@ -1,7 +1,6 @@
 package com.hortonworks.iotas.notification.store.hbase.mappers;
 
 import com.hortonworks.iotas.notification.common.Notification;
-import com.hortonworks.iotas.notification.store.hbase.mappers.NotificationIndexMapper;
 
 import java.util.Arrays;
 import java.util.List;
@@ -24,8 +23,6 @@ public class RuleNotificationMapper extends NotificationIndexMapper {
     @Override
     protected List<byte[]> getRowKeys(Notification notification) {
         return Arrays.asList(new StringBuilder(notification.getRuleId())
-                        .append(ROWKEY_SEP)
-                        .append(notification.getTs())
                         .append(ROWKEY_SEP)
                         .append(getIndexSuffix(notification))
                         .toString().getBytes(CHARSET));

--- a/notification-service/src/main/java/com/hortonworks/iotas/notification/store/hbase/mappers/RuleStatusNotificationMapper.java
+++ b/notification-service/src/main/java/com/hortonworks/iotas/notification/store/hbase/mappers/RuleStatusNotificationMapper.java
@@ -22,10 +22,6 @@ public class RuleStatusNotificationMapper extends NotificationStatusIndexMapper 
     protected List<byte[]> getRowKeys(Notification notification) {
         return Arrays.asList(new StringBuilder(notification.getRuleId())
                                      .append(ROWKEY_SEP)
-                                     .append(notification.getStatus())
-                                     .append(ROWKEY_SEP)
-                                     .append(notification.getTs())
-                                     .append(ROWKEY_SEP)
                                      .append(getIndexSuffix(notification))
                                      .toString().getBytes(CHARSET));
     }

--- a/notification-service/src/main/java/com/hortonworks/iotas/notification/store/hbase/mappers/TimestampNotificationMapper.java
+++ b/notification-service/src/main/java/com/hortonworks/iotas/notification/store/hbase/mappers/TimestampNotificationMapper.java
@@ -2,7 +2,6 @@ package com.hortonworks.iotas.notification.store.hbase.mappers;
 
 import com.hortonworks.iotas.notification.common.Notification;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -22,11 +21,7 @@ public class TimestampNotificationMapper extends NotificationIndexMapper {
 
     @Override
     protected List<byte[]> getRowKeys(Notification notification) {
-        return Arrays.asList(new StringBuilder()
-                                     .append(notification.getTs())
-                                     .append(ROWKEY_SEP)
-                                     .append(getIndexSuffix(notification))
-                                     .toString().getBytes(CHARSET));
+        return Arrays.asList(getIndexSuffix(notification).getBytes(CHARSET));
 
     }
 

--- a/notification-service/src/test/java/com/hortonworks/iotas/notification/store/hbase/HBaseNotificationStoreIntegrationTest.java
+++ b/notification-service/src/test/java/com/hortonworks/iotas/notification/store/hbase/HBaseNotificationStoreIntegrationTest.java
@@ -1,0 +1,234 @@
+package com.hortonworks.iotas.notification.store.hbase;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.hortonworks.iotas.notification.common.Notification;
+import com.hortonworks.iotas.notification.store.CriteriaImpl;
+import com.hortonworks.iotas.notification.store.hbase.mappers.DatasourceNotificationMapper;
+import com.hortonworks.iotas.notification.store.hbase.mappers.DatasourceStatusNotificationMapper;
+import com.hortonworks.iotas.notification.store.hbase.mappers.NotificationMapper;
+import com.hortonworks.iotas.notification.store.hbase.mappers.NotifierStatusNotificationMapper;
+import com.hortonworks.iotas.notification.store.hbase.mappers.RuleNotificationMapper;
+import com.hortonworks.iotas.notification.store.hbase.mappers.RuleStatusNotificationMapper;
+import com.hortonworks.iotas.notification.store.hbase.mappers.TableMutation;
+import com.hortonworks.iotas.notification.store.hbase.mappers.TimestampNotificationMapper;
+import com.hortonworks.iotas.notification.util.NotificationTestObjectFactory;
+import com.hortonworks.iotas.test.HBaseIntegrationTest;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.Table;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@Category(HBaseIntegrationTest.class)
+public class HBaseNotificationStoreIntegrationTest {
+
+    public static final Charset UTF_8 = StandardCharsets.UTF_8;
+    private static Connection connection;
+
+    private static Map<String, List<String>> tableToCfs;
+
+    static List<String> newList(String ...strings) {
+        return Lists.newArrayList(strings);
+    }
+
+    static {
+        tableToCfs = Maps.newHashMap();
+        tableToCfs.put("Notification", newList("d", "f", "s", "e", "r", "nn", "ts"));
+        tableToCfs.put("Timestamp_Notification", newList("ni", "d", "f", "s", "e", "r", "nn", "ts"));
+        tableToCfs.put("Rule_Notification", newList("ni", "d", "f", "s", "e", "r", "nn", "ts"));
+        tableToCfs.put("Rule_Status_Notification", newList("ni", "d", "f", "s", "e", "r", "nn", "ts"));
+        tableToCfs.put("Datasource_Notification", newList("ni", "d", "f", "s", "e", "r", "nn", "ts"));
+        tableToCfs.put("Datasource_Status_Notification", newList("ni", "d", "f", "s", "e", "r", "nn", "ts"));
+        tableToCfs.put("Notifier_Notification", newList("ni", "d", "f", "s", "e", "r", "nn", "ts"));
+        tableToCfs.put("Notifier_Status_Notification", newList("ni", "d", "f", "s", "e", "r", "nn", "ts"));
+    }
+
+    private HBaseNotificationStore sut;
+    private NotificationMapper notificationMapper;
+
+    @BeforeClass
+    public static void setUpClass() throws IOException {
+        connection = ConnectionFactory.createConnection();
+        Admin admin = connection.getAdmin();
+
+        for (Map.Entry<String, List<String>> tableInfo : tableToCfs.entrySet()) {
+            TableName tableName = TableName.valueOf(tableInfo.getKey());
+            if (!admin.tableExists(tableName)) {
+                // table not found, creating
+                HTableDescriptor tableDescriptor = new HTableDescriptor(tableName);
+                for (String columnFamily : tableInfo.getValue()) {
+                    tableDescriptor.addFamily(new HColumnDescriptor(columnFamily));
+                }
+                admin.createTable(tableDescriptor);
+            }
+        }
+    }
+
+    @Before
+    public void setUp() throws IOException {
+        try (Admin admin = connection.getAdmin()) {
+            for (String tableNameStr : tableToCfs.keySet()) {
+                TableName tableName = TableName.valueOf(tableNameStr);
+                assertTrue(admin.tableExists(tableName));
+
+                // full scan and delete: faster than 'disable and truncate' since we insert a little
+                try (Table table = connection.getTable(tableName)) {
+                    for (Result result : table.getScanner(new Scan())) {
+                        table.delete(new Delete(result.getRow()));
+                    }
+                }
+            }
+        }
+
+        // testing with default Hbase config
+        sut = new HBaseNotificationStore();
+
+        // it should be same as NotificationMapper in sut
+        notificationMapper = new NotificationMapper(Lists.newArrayList(
+                new NotifierStatusNotificationMapper(),
+                new RuleNotificationMapper(),
+                new RuleStatusNotificationMapper(),
+                new DatasourceNotificationMapper(),
+                new DatasourceStatusNotificationMapper(),
+                new TimestampNotificationMapper()));
+    }
+
+    @Test
+    public void testStoreNotification() throws IOException {
+        Notification notification = NotificationTestObjectFactory.getOne();
+
+        sut.store(notification);
+
+        // rely on result of tableMutations() to avoid checking manually
+        // didn't check each cell's value but comparing will be covered by testGetNotification()
+        List<TableMutation> expectedMutations = notificationMapper.tableMutations(notification);
+        checkMutationsReflectToHBase(expectedMutations);
+    }
+
+    @Test
+    public void testGetNotification() throws IOException {
+        Notification notification = NotificationTestObjectFactory.getOne();
+
+        // covered by testStoreNotification()
+        sut.store(notification);
+
+        Notification fetchedNotification = sut.getNotification(notification.getId());
+        assertEquals(notification, fetchedNotification);
+    }
+
+    @Test
+    public void testGetNotifications() throws Exception {
+        List<Notification> notifications = NotificationTestObjectFactory.getMany(10);
+
+        for (Notification notification : notifications) {
+            sut.store(notification);
+        }
+
+        List<Notification> fetchedNotifications = sut.getNotifications(
+                Lists.transform(notifications, new Function<Notification, String>() {
+            @Nullable
+            @Override
+            public String apply(@Nullable Notification notification) {
+                return notification.getId();
+            }
+        }));
+
+        assertEquals(notifications, fetchedNotifications);
+    }
+
+    @Test
+    public void testFindEntities() throws Exception {
+        List<Notification> notifications = NotificationTestObjectFactory.getManyWithRandomTimestamp(10);
+
+        for (Notification notification : notifications) {
+            sut.store(notification);
+        }
+
+        Collections.sort(notifications, new Comparator<Notification>() {
+            @Override
+            public int compare(Notification o1, Notification o2) {
+                return Long.valueOf(o1.getTs() - o2.getTs()).intValue();
+            }
+        });
+
+        CriteriaImpl<Notification> criteria = new CriteriaImpl<>(Notification.class);
+        criteria.setStartTs(notifications.get(2).getTs());
+        criteria.setEndTs(notifications.get(6).getTs());
+        // take less than range
+        criteria.setNumRows(3);
+        criteria.setDescending(true);
+
+        // 5, 4, 3
+        List<Notification> expectedList = notifications.subList(3, 6);
+        Collections.sort(expectedList, new Comparator<Notification>() {
+            @Override
+            public int compare(Notification o1, Notification o2) {
+                return Long.valueOf(o2.getTs() - o1.getTs()).intValue();
+            }
+        });
+
+        List<Notification> fetchedNotifications = sut.findEntities(criteria);
+        assertEquals(expectedList, fetchedNotifications);
+
+    }
+
+    @Test
+    public void testUpdateNotificationStatus() throws Exception {
+        Notification notification = NotificationTestObjectFactory.getOne();
+
+        sut.store(notification);
+
+        Notification.Status newStatus = Notification.Status.FAILED;
+        Notification fetchedNotification = sut.updateNotificationStatus(notification.getId(), newStatus);
+
+        assertEquals(fetchedNotification.getId(), notification.getId());
+        assertEquals(fetchedNotification.getStatus(), newStatus);
+
+        // rely on result of status() to avoid checking manually
+        List<TableMutation> expectedMutations = notificationMapper.status(notification, newStatus);
+        checkMutationsReflectToHBase(expectedMutations);
+    }
+
+    private void checkMutationsReflectToHBase(List<TableMutation> expectedMutations) throws IOException {
+        for (TableMutation tableMutation : expectedMutations) {
+            String tableName = tableMutation.tableName();
+            try (Table hTable = connection.getTable(TableName.valueOf(tableName))) {
+                for (Put put : tableMutation.updates()) {
+                    // checks only rowkey
+                    assertTrue(hTable.exists(new Get(put.getRow())));
+                }
+
+                for (Delete delete : tableMutation.deletes()) {
+                    // checks only rowkey
+                    assertFalse(hTable.exists(new Get(delete.getRow())));
+                }
+            }
+        }
+    }
+}

--- a/notification-service/src/test/java/com/hortonworks/iotas/notification/store/hbase/mappers/NotificationIndexMappersTest.java
+++ b/notification-service/src/test/java/com/hortonworks/iotas/notification/store/hbase/mappers/NotificationIndexMappersTest.java
@@ -1,0 +1,179 @@
+package com.hortonworks.iotas.notification.store.hbase.mappers;
+
+import com.google.common.collect.Lists;
+import com.hortonworks.iotas.notification.common.Notification;
+import com.hortonworks.iotas.notification.util.NotificationTestObjectFactory;
+import com.hortonworks.iotas.util.ReflectionHelper;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.hortonworks.iotas.notification.store.hbase.mappers.AbstractNotificationMapper.CHARSET;
+import static com.hortonworks.iotas.notification.store.hbase.mappers.Mapper.ROWKEY_SEP;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class NotificationIndexMappersTest {
+    private static final Logger LOG = LoggerFactory.getLogger(NotificationIndexMappersTest.class);
+
+    private List<NotificationIndexMapper> testObjects = Lists.newArrayList(
+            new DatasourceNotificationMapper(),
+            new DatasourceStatusNotificationMapper(),
+            new NotifierNotificationMapper(),
+            new NotifierStatusNotificationMapper(),
+            new RuleNotificationMapper(),
+            new RuleStatusNotificationMapper());
+
+    @Test
+    public void testGetRowKeys() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        Map<String, Object> fieldAndValues = new HashMap<>();
+        fieldAndValues.put("one", "A");
+
+        // assume test notification has one datasource and one event id
+        // for simplicity
+        Notification notification = NotificationTestObjectFactory.getOne();
+        assertEquals(1, notification.getDataSourceIds().size());
+        assertEquals(1, notification.getEventIds().size());
+
+        for (NotificationIndexMapper testObject : testObjects) {
+            LOG.info("testing mapper: {}", testObject.getClass().getCanonicalName());
+
+            StringBuilder expectedRowKey = new StringBuilder();
+
+            for (String indexedField : testObject.getIndexedFieldNames()) {
+                Object value = null;
+
+                try {
+                    value = getValue(notification, indexedField);
+                } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                    try {
+                        value = getValue(notification, indexedField + "s");
+                    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e2) {
+                        fail("getter not found for indexed field " + indexedField + "(s)");
+                    }
+                }
+
+                assertNotNull(value);
+                expectedRowKey.append(value);
+                expectedRowKey.append(ROWKEY_SEP);
+            }
+
+            expectedRowKey.append(generateExpectedIndexSuffix(notification, testObject));
+
+            byte[] expectedRowKeyBytes = expectedRowKey.toString().getBytes(CHARSET);
+            assertArrayEquals("getRowKeys() doesn't contain expected rowkey", expectedRowKeyBytes,
+                    testObject.getRowKeys(notification).get(0));
+        }
+
+        // for exception case: TimestampNotificationMapper
+        TimestampNotificationMapper testObject = new TimestampNotificationMapper();
+        LOG.info("testing mapper: {}", testObject.getClass().getCanonicalName());
+        assertArrayEquals(
+                "getRowKeys() doesn't contain expected rowkey",
+                generateExpectedIndexSuffix(notification, testObject).getBytes(CHARSET),
+                testObject.getRowKeys(notification).get(0));
+    }
+
+    @Test
+    public void testTableMutations() {
+        // assume test notification has one datasource and one event id
+        // for simplicity
+        Notification notification = NotificationTestObjectFactory.getOne();
+        assertEquals(1, notification.getDataSourceIds().size());
+        assertEquals(1, notification.getEventIds().size());
+
+        for (NotificationIndexMapper testObject : testObjects) {
+            LOG.info("testing mapper: {}", testObject.getClass().getCanonicalName());
+
+            List<byte[]> rowKeys = testObject.getRowKeys(notification);
+            List<TableMutation> tableMutations = testObject.tableMutations(notification);
+            assertEquals(rowKeys.size(), tableMutations.size());
+            assertEquals(1, rowKeys.size());
+
+            byte[] rowKey = rowKeys.get(0);
+            TableMutation tableMutation = tableMutations.get(0);
+            assertEquals(1, tableMutation.updates().size());
+            assertTrue(tableMutation.deletes().isEmpty());
+
+            assertArrayEquals(rowKey, tableMutation.updates().get(0).getRow());
+        }
+    }
+
+    @Test
+    public void testUpdateStatus() {
+        // assume test notification has one datasource and one event id
+        // for simplicity
+        Notification notification = NotificationTestObjectFactory.getOne();
+        assertEquals(1, notification.getDataSourceIds().size());
+        assertEquals(1, notification.getEventIds().size());
+
+        for (NotificationIndexMapper testObject : testObjects) {
+            LOG.info("testing mapper: {}", testObject.getClass().getCanonicalName());
+
+            List<byte[]> rowKeys = testObject.getRowKeys(notification);
+            assertEquals(1, rowKeys.size());
+
+            List<TableMutation> tableMutations = testObject.status(notification, Notification.Status.FAILED);
+
+            Notification appliedStatus = NotificationTestObjectFactory.applyStatus(notification, Notification.Status.FAILED);
+
+            List<byte[]> newRowKeys = testObject.getRowKeys(appliedStatus);
+            assertEquals(1, newRowKeys.size());
+
+            if (testObject instanceof NotificationStatusIndexMapper) {
+                assertEquals(2, tableMutations.size());
+
+                for (TableMutation tableMutation : tableMutations) {
+                    if (!tableMutation.updates().isEmpty()) {
+                        assertEquals(1, tableMutation.updates().size());
+                        assertTrue(tableMutation.deletes().isEmpty());
+
+                        // should add row with rowkey which reflects new status
+                        assertArrayEquals(newRowKeys.get(0), tableMutation.updates().get(0).getRow());
+                    } else if (!tableMutation.deletes().isEmpty()) {
+                        assertTrue(tableMutation.updates().isEmpty());
+                        assertEquals(1, tableMutation.deletes().size());
+
+                        // should delete row with rowkey which reflects old status
+                        assertArrayEquals(rowKeys.get(0), tableMutation.deletes().get(0).getRow());
+                    } else {
+                        fail("should have any updates or deletes");
+                    }
+                }
+            } else {
+                assertEquals(1, tableMutations.size());
+
+                TableMutation tableMutation = tableMutations.get(0);
+                assertEquals(1, tableMutation.updates().size());
+                assertArrayEquals(newRowKeys.get(0), tableMutation.updates().get(0).getRow());
+
+                assertTrue(tableMutation.deletes().isEmpty());
+            }
+        }
+    }
+
+    private String generateExpectedIndexSuffix(Notification notification, NotificationIndexMapper testObject) {
+        // common rule for NotificationMapper
+        return new StringBuilder().append(notification.getTs())
+                .append(ROWKEY_SEP)
+                .append(testObject.getUniqueIndexSuffix(notification)).toString();
+    }
+
+    private Object getValue(Notification notification, String indexedField) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Object value = ReflectionHelper.invokeGetter(indexedField, notification);
+        if (value instanceof List) {
+            assertEquals(1, ((List) value).size());
+            value = ((List)value).get(0);
+        }
+        return value;
+    }
+
+}

--- a/notification-service/src/test/java/com/hortonworks/iotas/notification/util/NotificationTestObjectFactory.java
+++ b/notification-service/src/test/java/com/hortonworks/iotas/notification/util/NotificationTestObjectFactory.java
@@ -1,0 +1,70 @@
+package com.hortonworks.iotas.notification.util;
+
+import com.google.common.collect.Lists;
+import com.hortonworks.iotas.notification.common.Notification;
+import com.hortonworks.iotas.notification.common.NotificationImpl;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+public class NotificationTestObjectFactory {
+    private NotificationTestObjectFactory() {
+
+    }
+
+    public static Notification getOne() {
+        return getOne(null);
+    }
+
+    public static Notification getOne(Long timestamp) {
+        Map<String, Object> fieldAndValues = new HashMap<>();
+        fieldAndValues.put("one", "A");
+
+        NotificationImpl.Builder builder = new NotificationImpl.Builder(fieldAndValues)
+                .dataSourceIds(Arrays.asList("dsrcid-1"))
+                .eventIds(Arrays.asList("eventid-1"))
+                .notifierName("test-notifier")
+                .ruleId("rule-1")
+                .status(Notification.Status.DELIVERED);
+
+        if (timestamp != null) {
+            builder.timestamp(timestamp);
+        }
+
+        return builder.build();
+    }
+
+    public static Notification applyStatus(Notification notification, Notification.Status newStatus) {
+        return new NotificationImpl.Builder(notification.getFieldsAndValues())
+                .id(notification.getId())
+                .dataSourceIds(notification.getDataSourceIds())
+                .eventIds(notification.getEventIds())
+                .notifierName(notification.getNotifierName())
+                .ruleId(notification.getRuleId())
+                .timestamp(notification.getTs())
+                .status(newStatus)
+                .build();
+    }
+
+    public static List<Notification> getMany(int count) {
+        List<Notification> notifications = Lists.newArrayList();
+        for (int i = 0 ; i < count ; i++) {
+            notifications.add(getOne());
+        }
+        return notifications;
+    }
+
+    public static List<Notification> getManyWithRandomTimestamp(int count) {
+        Random random = new Random();
+
+        List<Notification> notifications = Lists.newArrayList();
+        for (int i = 0 ; i < count ; i++) {
+            // should have same digit since it should be compared to dictionary order which we don't want
+            notifications.add(getOne(System.currentTimeMillis() - random.nextInt(10000)));
+        }
+        return notifications;
+    }
+}


### PR DESCRIPTION
- add HBaseNotificationStoreIntegrationTest which collaborates with HBase
- add NotificationIndexMappersTest which tests various Mappers in same way
- also done some refactoring

NOTE: version of guava is set to 12.0.1 since hbase client throws exception if it uses higher version, same reason for phoenix.

Something in mind:
- Do we need to create NotificationServiceImplIntegrationTest to test whole components are collaborating properly, or we feel OK to having mock test? IMO latter is fine since it covers logic paths so I don't create new test. But sure I'm happy to go forward when we want to have another test.
- Do we want to have integration test with email notifier? It has been covered by mock unit test so I guess we don't strictly need to, but if we want to have it, I'll give it a try with [greenmail](http://www.icegreen.com/greenmail/).
