### PR TITLE
Do not build iotas-dist by default from top level.

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -187,3 +187,33 @@ The following commands must be run from the top-level directory.
 
 If you wish to skip the unit tests you can do this by adding `-DskipTests` to the command line. 
 
+## Create a distribution (packaging)
+
+You can create a _distribution_ as follows.
+
+    # First, build the code.
+    $ mvn clean install # you may skip tests with `-DskipTests=true` to save time
+
+    # Create the binary distribution.
+    $ cd iotas-dist && mvn package
+
+You can also use the maven `dist` profile to build the code and create the distribution in one step.
+
+    $ mvn clean install -P dist
+
+The binaries will be created at:
+
+    iotas-dist/target/hortonworks-iotas-<version>.pom
+    iotas-dist/target/hortonworks-iotas-<version>.tar.gz
+    iotas-dist/target/hortonworks-iotas-<version>.zip
+
+including corresponding `*.asc` digital signature files.
+
+After running `mvn package` you may be asked to enter your GPG/PGP credentials (once for each binary file, in fact).
+This happens because the packaging step will create `*.asc` digital signatures for all the binaries, and in the workflow
+above _your_ GPG private key will be used to create those signatures.
+
+You can verify whether the digital signatures match their corresponding files:
+
+    # Example: Verify the signature of the `.tar.gz` binary.
+    $ gpg --verify iotas-dist/target/hortonworks-iotas-<version>.tar.gz.asc

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
         <module>notification-service</module>
         <module>notifiers</module>
         <module>layout</module>
-	<module>iotas-dist</module>
     </modules>
 
     <properties>
@@ -376,6 +375,18 @@
     </reporting>
 
     <profiles>
+         <profile>
+           <id>dist</id>
+           <properties>
+             <exclude.unit.test.groups>com.hortonworks.iotas.test.IntegrationTest,com.hortonworks.iotas.test.HBaseIntegrationTest</exclude.unit.test.groups>
+             <include.unit.test.groups></include.unit.test.groups>
+             <exclude.integration.test.groups>com.hortonworks.iotas.test.HBaseIntegrationTest</exclude.integration.test.groups>
+             <include.integration.test.groups>com.hortonworks.iotas.test.IntegrationTest</include.integration.test.groups>
+           </properties>
+           <modules>
+             <module>iotas-dist</module>
+           </modules>
+         </profile>    
         <profile>
             <id>dev-tests-basic</id>
             <activation>


### PR DESCRIPTION
This reduces build time. If needed one can go inside iotas-dist and do a "mvn package"
