### PR TITLE
IOT-274 Introduce REST API: Time-series DB querier

### DIFF
--- a/core/src/main/java/com/hortonworks/iotas/metrics/TimeSeriesQuerier.java
+++ b/core/src/main/java/com/hortonworks/iotas/metrics/TimeSeriesQuerier.java
@@ -1,0 +1,52 @@
+package com.hortonworks.iotas.metrics;
+
+import com.hortonworks.iotas.common.errors.ConfigException;
+
+import java.util.Map;
+
+/**
+ * Interface for querying to Time-series DB.
+ * <p/>
+ * Implementation of this interface should convert metric name streaming framework and actual stored metric name.
+ * Since metric name depends on metrics sink so implementation may want to be coupled with specific metrics sink.
+ */
+public interface TimeSeriesQuerier {
+    /**
+     * Initialize method. Any one time initialization is done here.
+     *
+     * @param conf Configuration for implementation of TopologyMetrics.
+     * @throws ConfigException throw when instance can't be initialized with this configuration (misconfigured).
+     */
+    void init (Map<String, String> conf) throws ConfigException;
+
+    /**
+     * Query metrics to time-series DB.
+     *
+     * @param topologyName  topology name (not ID)
+     * @param componentId   component id
+     * @param metricName    metric name
+     * @param aggrFunction  function to apply while aggregating task level series
+     * @param from          beginning of the time period: timestamp (in milliseconds)
+     * @param to            end of the time period: timestamp (in milliseconds)
+     * @return Map of data points which are paired to (timestamp, value)
+     */
+    Map<Long, Double> getMetrics(String topologyName, String componentId, String metricName, AggregateFunction aggrFunction, long from, long to);
+
+    /**
+     * Query metrics without modification (raw) to time-series DB.
+     *
+     * @param metricName    metric name
+     * @param parameters    parameters separated by ',', and represented as 'key=value'
+     * @param from          beginning of the time period: timestamp (in milliseconds)
+     * @param to            end of the time period: timestamp (in milliseconds)
+     * @return Map of metric name and Map of data points which are paired to (timestamp, value)
+     */
+    Map<String, Map<Long, Double>> getRawMetrics(String metricName, String parameters, long from, long to);
+
+    /**
+     * Function to apply while aggregating multiple series
+     */
+    enum AggregateFunction {
+        SUM, AVG, MIN, MAX
+    }
+}

--- a/core/src/main/java/com/hortonworks/iotas/service/CatalogService.java
+++ b/core/src/main/java/com/hortonworks/iotas/service/CatalogService.java
@@ -650,7 +650,23 @@ public class CatalogService {
         return this.topologyMetrics.getMetricsForTopology(topology);
     }
 
-    public Collection<TopologyComponentDefinition.TopologyComponentType> listTopologyComponentTypes () {
+    public Map<Long, Double> getCompleteLatency (Topology topology, String sourceId, long from, long to) throws Exception {
+        return this.topologyMetrics.getCompleteLatency(topology, sourceId, from, to);
+    }
+
+    public Map<String, Map<Long, Double>> getComponentStats(Topology topology, String sourceId, Long from, Long to) {
+        return this.topologyMetrics.getComponentStats(topology, sourceId, from, to);
+    }
+
+    public Map<String, Map<Long, Double>> getKafkaTopicOffsets(Topology topology, String sourceId, Long from, Long to) {
+        return this.topologyMetrics.getkafkaTopicOffsets(topology, sourceId, from, to);
+    }
+
+    public Map<String, Map<Long, Double>> getMetrics(String metricName, String parameters, Long from, Long to) {
+        return this.topologyMetrics.getTimeSeriesQuerier().getRawMetrics(metricName, parameters, from, to);
+    }
+
+    public Collection<TopologyComponentDefinition.TopologyComponentType> listTopologyComponentTypes() {
         return Arrays.asList(TopologyComponentDefinition.TopologyComponentType.values());
     }
 

--- a/core/src/main/java/com/hortonworks/iotas/topology/TopologyMetrics.java
+++ b/core/src/main/java/com/hortonworks/iotas/topology/TopologyMetrics.java
@@ -7,9 +7,12 @@ import java.util.Map;
 
 /**
  * Interface that shows metrics for IoTaS topology.
+ * <p/>
  * Each underlying streaming framework should provide implementations to integrate metrics of framework into IoTaS.
+ * <p/>
+ * Note that this interface also extends TopologyTimeSeriesMetrics, which is for querying topology metrics from time-series DB.
  */
-public interface TopologyMetrics {
+public interface TopologyMetrics extends TopologyTimeSeriesMetrics {
     /**
      * Initialize method. Any one time initialization is done here.
      *

--- a/core/src/main/java/com/hortonworks/iotas/topology/TopologyTimeSeriesMetrics.java
+++ b/core/src/main/java/com/hortonworks/iotas/topology/TopologyTimeSeriesMetrics.java
@@ -1,0 +1,71 @@
+package com.hortonworks.iotas.topology;
+
+import com.hortonworks.iotas.catalog.Topology;
+import com.hortonworks.iotas.metrics.TimeSeriesQuerier;
+
+import java.util.Map;
+
+/**
+ * Interface which defines methods for querying topology metrics from time-series DB.
+ * <p/>
+ * Implementation of this interface should convert metric name between IoTaS and streaming framework.
+ * Converted metric name will be converted once again from TimeSeriesQuerier to perform actual query to time-series DB.
+ */
+public interface TopologyTimeSeriesMetrics {
+    /**
+     * Set instance of TimeSeriesQuerier. This method should be called before calling any requests for metrics.
+     */
+    void setTimeSeriesQuerier(TimeSeriesQuerier timeSeriesQuerier);
+
+    /**
+     * Retrieve "complete latency" on source.
+     *
+     * @param topology  topology catalog instance
+     * @param sourceId  source id (same to component id)
+     * @param from      beginning of the time period: timestamp (in milliseconds)
+     * @param to        end of the time period: timestamp (in milliseconds)
+     * @return Map of data points which are paired to (timestamp, value)
+     */
+    Map<Long, Double> getCompleteLatency(Topology topology, String sourceId, long from, long to);
+
+    /**
+     * Retrieve "kafka topic offsets" on source.
+     * <p/>
+     * This method retrieves three metrics,<br/>
+     * 1) "logsize": sum of partition's available offsets for all partitions<br/>
+     * 2) "offset": sum of source's current offsets for all partitions<br/>
+     * 3) "lag": sum of lags (available offset - current offset) for all partitions<br/>
+     * <p/>
+     * That source should be "KAFKA" type and have topic name from configuration.
+     *
+     * @param topology  topology catalog instance
+     * @param sourceId  source id (same to component id)
+     * @param from      beginning of the time period: timestamp (in milliseconds)
+     * @param to        end of the time period: timestamp (in milliseconds)
+     * @return Map of metric name and Map of data points which are paired to (timestamp, value).
+     */
+    Map<String, Map<Long, Double>> getkafkaTopicOffsets(Topology topology, String sourceId, long from, long to);
+
+    /**
+     * Retrieve "component stats" on component.
+     * <p/>
+     * This method retrieves five metrics,<br/>
+     * 1) "inputRecords": Count of input records<br/>
+     * 2) "outputRecords": Count of output records<br/>
+     * 3) "failedRecords": Count of failed records<br/>
+     * 4) "processedTime": Latency of processed time (processing one event)<br/>
+     * 5) "recordsInWaitQueue": Count of records waiting in queue<br/>
+     *
+     * @param topology      topology catalog instance
+     * @param componentId   component id
+     * @param from          beginning of the time period: timestamp (in milliseconds)
+     * @param to            end of the time period: timestamp (in milliseconds)
+     * @return Map of metric name and Map of data points which are paired to (timestamp, value).
+     */
+    Map<String, Map<Long, Double>> getComponentStats(Topology topology, String componentId, long from, long to);
+
+    /**
+     * Get instance of TimeSeriesQuerier.
+     */
+    TimeSeriesQuerier getTimeSeriesQuerier();
+}

--- a/core/src/main/java/com/hortonworks/iotas/topology/storm/StormMappedMetric.java
+++ b/core/src/main/java/com/hortonworks/iotas/topology/storm/StormMappedMetric.java
@@ -1,0 +1,37 @@
+package com.hortonworks.iotas.topology.storm;
+
+import com.hortonworks.iotas.metrics.TimeSeriesQuerier;
+
+/**
+ * Metric name conversion table between IoTaS and Storm. It also contains function information for aggregation.
+ */
+enum StormMappedMetric {
+    completeLatency("__complete-latency", TimeSeriesQuerier.AggregateFunction.AVG),
+    inputRecords("__execute-count", TimeSeriesQuerier.AggregateFunction.SUM),
+    outputRecords("__emit-count", TimeSeriesQuerier.AggregateFunction.SUM),
+    failedRecords("__fail-count", TimeSeriesQuerier.AggregateFunction.SUM),
+    processedTime("__process-latency", TimeSeriesQuerier.AggregateFunction.AVG),
+    recordsInWaitQueue("__receive.population", TimeSeriesQuerier.AggregateFunction.AVG),
+
+    // Kafka related metrics are already partitions aggregated value so actually don't need to have aggregate function
+    // but they need topic name to be queried
+    logsize("kafkaOffset.%s/totalLatestTimeOffset", TimeSeriesQuerier.AggregateFunction.AVG),
+    offset("kafkaOffset.%s/totalLatestCompletedOffset", TimeSeriesQuerier.AggregateFunction.AVG),
+    lag("kafkaOffset.%s/totalSpoutLag", TimeSeriesQuerier.AggregateFunction.AVG);
+
+    private String stormMetricName;
+    private final TimeSeriesQuerier.AggregateFunction aggregateFunction;
+
+    StormMappedMetric(String stormMetricName, TimeSeriesQuerier.AggregateFunction aggregateFunction) {
+        this.stormMetricName = stormMetricName;
+        this.aggregateFunction = aggregateFunction;
+    }
+
+    public String getStormMetricName() {
+        return stormMetricName;
+    }
+
+    public TimeSeriesQuerier.AggregateFunction getAggregateFunction() {
+        return aggregateFunction;
+    }
+}

--- a/core/src/main/java/com/hortonworks/iotas/topology/storm/StormTopologyTimeSeriesMetricsImpl.java
+++ b/core/src/main/java/com/hortonworks/iotas/topology/storm/StormTopologyTimeSeriesMetricsImpl.java
@@ -1,0 +1,136 @@
+package com.hortonworks.iotas.topology.storm;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hortonworks.iotas.catalog.Topology;
+import com.hortonworks.iotas.metrics.TimeSeriesQuerier;
+import com.hortonworks.iotas.topology.TopologyLayoutConstants;
+import com.hortonworks.iotas.topology.TopologyTimeSeriesMetrics;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * Storm implementation of the TopologyTimeSeriesMetrics interface
+ */
+public class StormTopologyTimeSeriesMetricsImpl implements TopologyTimeSeriesMetrics {
+    private TimeSeriesQuerier timeSeriesQuerier;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public void setTimeSeriesQuerier(TimeSeriesQuerier timeSeriesQuerier) {
+        this.timeSeriesQuerier = timeSeriesQuerier;
+    }
+
+    @Override
+    public TimeSeriesQuerier getTimeSeriesQuerier() {
+        return timeSeriesQuerier;
+    }
+
+    @Override
+    public Map<Long, Double> getCompleteLatency(Topology topology, String sourceId, long from, long to) {
+        assertTimeSeriesQuerierIsSet();
+
+        String stormTopologyName = getTopologyName(topology);
+
+        return queryMetrics(stormTopologyName, sourceId, StormMappedMetric.completeLatency, from, to);
+    }
+
+    @Override
+    public Map<String, Map<Long, Double>> getkafkaTopicOffsets(Topology topology, String sourceId, long from, long to) {
+        assertTimeSeriesQuerierIsSet();
+
+        String stormTopologyName = getTopologyName(topology);
+
+        String topicName = findKafkaTopicName(topology, sourceId);
+        if (topicName == null) {
+            throw new IllegalStateException("Cannot find Kafka topic name from source config - topology name: " +
+                    topology.getName() + " / source : " + sourceId);
+        }
+
+        StormMappedMetric[] metrics = { StormMappedMetric.logsize, StormMappedMetric.offset, StormMappedMetric.lag };
+
+        Map<String, Map<Long, Double>> kafkaOffsets = new HashMap<>();
+        for (StormMappedMetric metric : metrics) {
+            kafkaOffsets.put(metric.name(), queryKafkaMetrics(stormTopologyName, sourceId, metric, topicName, from, to));
+        }
+
+        return kafkaOffsets;
+    }
+
+    @Override
+    public Map<String, Map<Long, Double>> getComponentStats(Topology topology, String componentId, long from, long to) {
+        assertTimeSeriesQuerierIsSet();
+
+        String stormTopologyName = getTopologyName(topology);
+
+        StormMappedMetric[] metrics = { StormMappedMetric.inputRecords, StormMappedMetric.outputRecords,
+                StormMappedMetric.failedRecords, StormMappedMetric.processedTime, StormMappedMetric.recordsInWaitQueue };
+
+        Map<String, Map<Long, Double>> componentStats = new HashMap<>();
+        for (StormMappedMetric metric : metrics) {
+            componentStats.put(metric.name(), queryMetrics(stormTopologyName, componentId, metric, from, to));
+        }
+
+        return componentStats;
+    }
+
+    private void assertTimeSeriesQuerierIsSet() {
+        if (timeSeriesQuerier == null) {
+            throw new IllegalStateException("Time series querier is not set!");
+        }
+    }
+
+    private String getTopologyName(Topology topology) {
+        return "iotas-" + topology.getId() + "-" + topology.getName();
+    }
+
+    private String findKafkaTopicName(Topology topology, String sourceId) {
+        String kafkaTopicName = null;
+        try {
+            Map<String, Object> topologyConfig = mapper.readValue(topology.getConfig(), new TypeReference<Map<String, Object>>(){});
+            List<Map<String, Object>> dataSources = (List<Map<String, Object>>) topologyConfig.get(TopologyLayoutConstants.JSON_KEY_DATA_SOURCES);
+
+            for (Map<String, Object> dataSource : dataSources) {
+                // UINAME and TYPE are mandatory fields for dataSource, so skip checking null
+                String uiName = (String) dataSource.get(TopologyLayoutConstants.JSON_KEY_UINAME);
+                String type = (String) dataSource.get(TopologyLayoutConstants.JSON_KEY_TYPE);
+
+                if (!uiName.equals(sourceId)) {
+                    continue;
+                }
+
+                if (!type.equalsIgnoreCase("KAFKA")) {
+                    throw new IllegalStateException("Type of datasource should be KAFKA");
+                }
+
+                // config is a mandatory field for dataSource, so skip checking null
+                Map<String, Object> dataSourceConfig = (Map<String, Object>) dataSource.get(TopologyLayoutConstants.JSON_KEY_CONFIG);
+                kafkaTopicName = (String) dataSourceConfig.get(TopologyLayoutConstants.JSON_KEY_TOPIC);
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to parse topology configuration.");
+        }
+
+        return kafkaTopicName;
+    }
+
+    private Map<Long, Double> queryMetrics(String stormTopologyName, String sourceId, StormMappedMetric mappedMetric, long from, long to) {
+        Map<Long, Double> metrics = timeSeriesQuerier.getMetrics(stormTopologyName, sourceId, mappedMetric.getStormMetricName(),
+                mappedMetric.getAggregateFunction(), from, to);
+        return new TreeMap<>(metrics);
+    }
+
+
+    private Map<Long, Double> queryKafkaMetrics(String stormTopologyName, String sourceId, StormMappedMetric mappedMetric,
+                                                  String kafkaTopic, long from, long to) {
+        Map<Long, Double> metrics = timeSeriesQuerier.getMetrics(stormTopologyName, sourceId, String.format(mappedMetric.getStormMetricName(), kafkaTopic),
+                mappedMetric.getAggregateFunction(), from, to);
+        return new TreeMap<>(metrics);
+    }
+
+}

--- a/core/src/test/java/com/hortonworks/iotas/topology/storm/StormTopologyTimeSeriesMetricsImplTest.java
+++ b/core/src/test/java/com/hortonworks/iotas/topology/storm/StormTopologyTimeSeriesMetricsImplTest.java
@@ -1,0 +1,239 @@
+package com.hortonworks.iotas.topology.storm;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hortonworks.iotas.catalog.Topology;
+import com.hortonworks.iotas.metrics.TimeSeriesQuerier;
+import com.hortonworks.iotas.topology.TopologyLayoutConstants;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class StormTopologyTimeSeriesMetricsImplTest {
+    private StormTopologyTimeSeriesMetricsImpl stormTopologyTimeSeriesMetrics;
+
+    @Mocked
+    private TimeSeriesQuerier mockTimeSeriesQuerier;
+    private Random random = new Random();
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Before
+    public void setUp() {
+        stormTopologyTimeSeriesMetrics = new StormTopologyTimeSeriesMetricsImpl();
+        stormTopologyTimeSeriesMetrics.setTimeSeriesQuerier(mockTimeSeriesQuerier);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testWithoutAssigningTimeSeriesQuerier() {
+        stormTopologyTimeSeriesMetrics.setTimeSeriesQuerier(null);
+
+        final Topology topology = new Topology();
+        topology.setId(1L);
+        topology.setName("topology");
+
+        final String sourceId = "device";
+
+        final long from = 1L;
+        final long to = 3L;
+
+        stormTopologyTimeSeriesMetrics.getCompleteLatency(topology, sourceId, from, to);
+        fail("It should throw Exception!");
+    }
+
+    @Test
+    public void testGetCompleteLatency() throws Exception {
+        final Topology topology = new Topology();
+        topology.setId(1L);
+        topology.setName("topology");
+
+        final String sourceId = "device";
+
+        final long from = 1L;
+        final long to = 3L;
+
+        final Map<Long, Double> expected = generateTestPointsMap();
+
+        // also verification
+        new Expectations() {{
+            mockTimeSeriesQuerier.getMetrics(
+                    withEqual("iotas-" + topology.getId() + "-" + topology.getName()),
+                    withEqual(sourceId),
+                    withEqual(StormMappedMetric.completeLatency.getStormMetricName()),
+                    withEqual(StormMappedMetric.completeLatency.getAggregateFunction()),
+                    withEqual(from), withEqual(to)
+            );
+
+            result = expected;
+        }};
+
+        Map<Long, Double> actual = stormTopologyTimeSeriesMetrics.getCompleteLatency(topology, sourceId, from, to);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void getKafkaTopicOffsets() throws Exception {
+        final Topology topology = new Topology();
+        topology.setId(1L);
+        topology.setName("topology");
+
+        final String sourceId = "device";
+        final String topicName = "topic";
+
+        Map<String, Object> configurations = buildTopologyConfigWithKafkaDataSource(sourceId, topicName);
+
+        topology.setConfig(mapper.writeValueAsString(configurations));
+
+        final long from = 1L;
+        final long to = 3L;
+
+        final Map<String, Map<Long, Double>> expected = new HashMap<>();
+
+        expected.put(StormMappedMetric.logsize.name(), generateTestPointsMap());
+        expected.put(StormMappedMetric.offset.name(), generateTestPointsMap());
+        expected.put(StormMappedMetric.lag.name(), generateTestPointsMap());
+
+        // also verification
+        new Expectations() {{
+            mockTimeSeriesQuerier.getMetrics(
+                    withEqual("iotas-" + topology.getId() + "-" + topology.getName()),
+                    withEqual(sourceId),
+                    withEqual(String.format(StormMappedMetric.logsize.getStormMetricName(), topicName)),
+                    withEqual(StormMappedMetric.logsize.getAggregateFunction()),
+                    withEqual(from), withEqual(to)
+            );
+
+            result = expected.get(StormMappedMetric.logsize.name());
+
+            mockTimeSeriesQuerier.getMetrics(
+                    withEqual("iotas-" + topology.getId() + "-" + topology.getName()),
+                    withEqual(sourceId),
+                    withEqual(String.format(StormMappedMetric.offset.getStormMetricName(), topicName)),
+                    withEqual(StormMappedMetric.offset.getAggregateFunction()),
+                    withEqual(from), withEqual(to)
+            );
+
+            result = expected.get(StormMappedMetric.offset.name());
+
+            mockTimeSeriesQuerier.getMetrics(
+                    withEqual("iotas-" + topology.getId() + "-" + topology.getName()),
+                    withEqual(sourceId),
+                    withEqual(String.format(StormMappedMetric.lag.getStormMetricName(), topicName)),
+                    withEqual(StormMappedMetric.lag.getAggregateFunction()),
+                    withEqual(from), withEqual(to)
+            );
+
+            result = expected.get(StormMappedMetric.lag.name());
+        }};
+
+        Map<String, Map<Long, Double>> actual = stormTopologyTimeSeriesMetrics.getkafkaTopicOffsets(topology, sourceId, from, to);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void getComponentStats() throws Exception {
+        final Topology topology = new Topology();
+        topology.setId(1L);
+        topology.setName("topology");
+
+        final String sourceId = "device";
+
+        final long from = 1L;
+        final long to = 3L;
+
+        final Map<String, Map<Long, Double>> expected = new HashMap<>();
+
+        expected.put(StormMappedMetric.inputRecords.name(), generateTestPointsMap());
+        expected.put(StormMappedMetric.outputRecords.name(), generateTestPointsMap());
+        expected.put(StormMappedMetric.failedRecords.name(), generateTestPointsMap());
+        expected.put(StormMappedMetric.processedTime.name(), generateTestPointsMap());
+        expected.put(StormMappedMetric.recordsInWaitQueue.name(), generateTestPointsMap());
+
+        new Expectations() {{
+            mockTimeSeriesQuerier.getMetrics(
+                    withEqual("iotas-" + topology.getId() + "-" + topology.getName()),
+                    withEqual(sourceId),
+                    withEqual(StormMappedMetric.inputRecords.getStormMetricName()),
+                    withEqual(StormMappedMetric.inputRecords.getAggregateFunction()),
+                    withEqual(from), withEqual(to)
+            );
+
+            result = expected.get(StormMappedMetric.inputRecords.name());
+
+            mockTimeSeriesQuerier.getMetrics(
+                    withEqual("iotas-" + topology.getId() + "-" + topology.getName()),
+                    withEqual(sourceId),
+                    withEqual(StormMappedMetric.outputRecords.getStormMetricName()),
+                    withEqual(StormMappedMetric.outputRecords.getAggregateFunction()),
+                    withEqual(from), withEqual(to)
+            );
+
+            result = expected.get(StormMappedMetric.outputRecords.name());
+
+            mockTimeSeriesQuerier.getMetrics(
+                    withEqual("iotas-" + topology.getId() + "-" + topology.getName()),
+                    withEqual(sourceId),
+                    withEqual(StormMappedMetric.failedRecords.getStormMetricName()),
+                    withEqual(StormMappedMetric.failedRecords.getAggregateFunction()),
+                    withEqual(from), withEqual(to)
+            );
+
+            result = expected.get(StormMappedMetric.failedRecords.name());
+
+            mockTimeSeriesQuerier.getMetrics(
+                    withEqual("iotas-" + topology.getId() + "-" + topology.getName()),
+                    withEqual(sourceId),
+                    withEqual(StormMappedMetric.processedTime.getStormMetricName()),
+                    withEqual(StormMappedMetric.processedTime.getAggregateFunction()),
+                    withEqual(from), withEqual(to)
+            );
+
+            result = expected.get(StormMappedMetric.processedTime.name());
+
+            mockTimeSeriesQuerier.getMetrics(
+                    withEqual("iotas-" + topology.getId() + "-" + topology.getName()),
+                    withEqual(sourceId),
+                    withEqual(StormMappedMetric.recordsInWaitQueue.getStormMetricName()),
+                    withEqual(StormMappedMetric.recordsInWaitQueue.getAggregateFunction()),
+                    withEqual(from), withEqual(to)
+            );
+
+            result = expected.get(StormMappedMetric.recordsInWaitQueue.name());
+        }};
+
+        Map<String, Map<Long, Double>> actual = stormTopologyTimeSeriesMetrics.getComponentStats(topology, sourceId, from, to);
+        assertEquals(expected, actual);
+    }
+
+    private Map<String, Object> buildTopologyConfigWithKafkaDataSource(String sourceId, String topicName) {
+        Map<String, Object> configurations = new HashMap<>();
+
+        Map<String, Object> dataSource = new HashMap<>();
+        dataSource.put(TopologyLayoutConstants.JSON_KEY_UINAME, sourceId);
+        dataSource.put(TopologyLayoutConstants.JSON_KEY_TYPE, "KAFKA");
+
+        Map<String, Object> dataSourceConfig = new HashMap<>();
+        dataSourceConfig.put(TopologyLayoutConstants.JSON_KEY_TOPIC, topicName);
+        dataSource.put(TopologyLayoutConstants.JSON_KEY_CONFIG, dataSourceConfig);
+
+        configurations.put(TopologyLayoutConstants.JSON_KEY_DATA_SOURCES, Collections.singletonList(dataSource));
+        return configurations;
+    }
+
+    private Map<Long, Double> generateTestPointsMap() {
+        Map<Long, Double> ret = new HashMap<>();
+        int count = random.nextInt(5);
+        for (int i = 0 ; i < count ; i++) {
+            ret.put(random.nextLong(), random.nextDouble());
+        }
+
+        return ret;
+    }
+}

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>iotas</artifactId>
+        <groupId>com.hortonworks.iotas</groupId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>metrics</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.hortonworks.iotas</groupId>
+            <artifactId>core</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jetty</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jetty-sslengine</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jsp-2.1</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jsp-api-2.1</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>servlet-api-2.5</artifactId>
+                </exclusion>
+
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-multipart</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-jackson</artifactId>
+            <version>${jersey-media-multipart.version}</version>
+        </dependency>
+
+        <!-- test dependency -->
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>2.0.9-beta</version>
+            <scope>test</scope>
+
+            <!-- Include everything below here if you have dependency conflicts -->
+            <!--
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jetty</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.skyscreamer</groupId>
+                    <artifactId>jsonassert</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xmlunit</groupId>
+                    <artifactId>xmlunit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.jayway.jsonpath</groupId>
+                    <artifactId>json-path</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.sf.jopt-simple</groupId>
+                    <artifactId>jopt-simple</artifactId>
+                </exclusion>
+            </exclusions>
+            -->
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/metrics/src/main/java/com/hortonworks/iotas/metrics/AbstractTimeSeriesQuerier.java
+++ b/metrics/src/main/java/com/hortonworks/iotas/metrics/AbstractTimeSeriesQuerier.java
@@ -1,0 +1,33 @@
+package com.hortonworks.iotas.metrics;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Base class for implementations of TimeSeriesQuerier
+ */
+public abstract class AbstractTimeSeriesQuerier implements TimeSeriesQuerier {
+    protected Map<String, String> parseParameters(String parameters) {
+        Map<String, String> parsed = new HashMap<>();
+        if (parameters != null && !parameters.trim().isEmpty()) {
+            String[] splittedParams = parameters.split(",");
+            for (String splittedParam : splittedParams) {
+                String[] keyValue = splittedParam.split("=");
+                if (keyValue.length < 2) {
+                    throw new IllegalArgumentException("parameters contain broken key-value pair: " + splittedParam);
+                }
+
+                StringBuilder sb = new StringBuilder();
+                for (int idx = 1 ; idx < keyValue.length ; idx++) {
+                    if (idx != 1) {
+                        sb.append('=');
+                    }
+                    sb.append(keyValue[idx].trim());
+                }
+
+                parsed.put(keyValue[0], sb.toString());
+            }
+        }
+        return parsed;
+    }
+}

--- a/metrics/src/main/java/com/hortonworks/iotas/metrics/storm/ambari/AmbariMetricsServiceWithStormQuerier.java
+++ b/metrics/src/main/java/com/hortonworks/iotas/metrics/storm/ambari/AmbariMetricsServiceWithStormQuerier.java
@@ -1,0 +1,164 @@
+package com.hortonworks.iotas.metrics.storm.ambari;
+
+import com.google.common.collect.Lists;
+import com.hortonworks.iotas.common.errors.ConfigException;
+import com.hortonworks.iotas.metrics.AbstractTimeSeriesQuerier;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.uri.internal.JerseyUriBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.MediaType;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Implementation of TimeSeriesQuerier for Ambari Metric Service (AMS) with Storm.
+ * <p/>
+ * This class assumes that metrics for Storm is pushed to AMS via Ambari Storm Metrics Sink.
+ * appId is 'topology name', and metric name is composed to '[component name].[task id].[metric name](.[key of the value map])'.
+ * <p/>
+ * Please note that this class requires Ambari 2.4 or above.
+ * <p/>
+ * TODO: confirm AMBARI-16946 is merged and included to Ambari 2.4.0 since this rule will be introduced as these issues. <br/>
+ * TODO: also confirm AMBARI-16949 and AMBARI-17027, and AMBARI-17133 are included to Ambari 2.4.0 as well. <br/>
+ * TODO: if any of them cannot be included as Ambari 2.4, we should modify compatible version. <br/>
+ */
+public class AmbariMetricsServiceWithStormQuerier extends AbstractTimeSeriesQuerier {
+    private static final Logger log = LoggerFactory.getLogger(AmbariMetricsServiceWithStormQuerier.class);
+
+    // the configuration keys
+    static final String COLLECTOR_API_URL = "collectorApiUrl";
+
+    // these metrics need '.%' as postfix to aggregate values for each stream
+    private static final List<String> METRICS_NEED_AGGREGATION_ON_STREAMS = Lists.newArrayList(
+            "__complete-latency", "__emit-count", "__ack-count", "__fail-count",
+            "__process-latency", "__execute-count", "__execute-latency"
+    );
+
+    private Client client;
+    private URI collectorApiUri;
+
+    public AmbariMetricsServiceWithStormQuerier() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void init(Map<String, String> conf) throws ConfigException {
+        if (conf != null) {
+            try {
+                collectorApiUri = new URI(conf.get(COLLECTOR_API_URL));
+            } catch (URISyntaxException e) {
+                throw new ConfigException(e);
+            }
+        }
+        client = ClientBuilder.newClient(new ClientConfig());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<Long, Double> getMetrics(String topologyName, String componentId, String metricName, AggregateFunction aggrFunction,
+                                          long from, long to) {
+        URI targetUri = composeQueryParameters(topologyName, componentId, metricName, aggrFunction, from, to);
+
+        log.debug("Calling {} for querying metric", targetUri.toString());
+
+        Map<String, ?> responseMap = client.target(targetUri).request(MediaType.APPLICATION_JSON_TYPE).get(Map.class);
+        List<Map<String, ?>> metrics = (List<Map<String, ?>>) responseMap.get("metrics");
+
+        if (metrics.size() > 0) {
+            Map<String, Number> points = (Map<String, Number>) metrics.get(0).get("metrics");
+            Map<Long, Double> ret = new HashMap<>(points.size());
+
+            for (Map.Entry<String, Number> timestampToValue : points.entrySet()) {
+                ret.put(Long.valueOf(timestampToValue.getKey()), timestampToValue.getValue().doubleValue());
+            }
+
+            return ret;
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, Map<Long, Double>> getRawMetrics(String metricName, String parameters, long from, long to) {
+        Map<String, String> queryParams = parseParameters(parameters);
+        URI targetUri = composeRawQueryParameters(metricName, queryParams, from, to);
+
+        log.debug("Calling {} for querying metric", targetUri.toString());
+
+        Map<String, ?> responseMap = client.target(targetUri).request(MediaType.APPLICATION_JSON_TYPE).get(Map.class);
+        List<Map<String, ?>> metrics = (List<Map<String, ?>>) responseMap.get("metrics");
+
+
+        if (metrics.size() > 0) {
+            Map<String, Map<Long, Double>> ret = new HashMap<>(metrics.size());
+            for (Map<String, ?> metric : metrics) {
+                String retrievedMetricName = (String) metric.get("metricname");
+                Map<String, Number> retrievedPoints = (Map<String, Number>) metric.get("metrics");
+
+                Map<Long, Double> pointsForOutput = new HashMap<>(retrievedPoints.size());
+                for (Map.Entry<String, Number> timestampToValue : retrievedPoints.entrySet()) {
+                    pointsForOutput.put(Long.valueOf(timestampToValue.getKey()), timestampToValue.getValue().doubleValue());
+                }
+
+                ret.put(retrievedMetricName, pointsForOutput);
+            }
+
+            return ret;
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    private URI composeRawQueryParameters(String metricName, Map<String, String> queryParams, long from, long to) {
+        JerseyUriBuilder uriBuilder = new JerseyUriBuilder().uri(collectorApiUri);
+        for (Map.Entry<String, String> pair : queryParams.entrySet()) {
+            uriBuilder = uriBuilder.queryParam(pair.getKey(), pair.getValue());
+        }
+
+        // force replacing values for metricNames, startTime, endTime with parameters
+        return uriBuilder.replaceQueryParam("metricNames", metricName)
+                .replaceQueryParam("startTime", String.valueOf(from))
+                .replaceQueryParam("endTime", String.valueOf(to))
+                .build();
+    }
+
+    private URI composeQueryParameters(String topologyName, String componentId, String metricName, AggregateFunction aggrFunction,
+                                       long from, long to) {
+        String actualMetricName = buildMetricName(componentId, metricName);
+        JerseyUriBuilder uriBuilder = new JerseyUriBuilder();
+        return uriBuilder.uri(collectorApiUri)
+                .queryParam("appId", topologyName)
+                .queryParam("hostname", "")
+                .queryParam("metricNames", actualMetricName)
+                .queryParam("startTime", String.valueOf(from))
+                .queryParam("precision", "seconds")
+                .queryParam("endTime", String.valueOf(to))
+                .queryParam("seriesAggregateFunction", aggrFunction.name())
+                .build();
+    }
+
+    private String buildMetricName(String componentId, String metricName) {
+        String actualMetricName = componentId + ".%." + metricName;
+
+        if (METRICS_NEED_AGGREGATION_ON_STREAMS.contains(metricName)) {
+            actualMetricName = actualMetricName + ".%";
+        }
+
+        return actualMetricName.replace('_', '-');
+    }
+}

--- a/metrics/src/main/java/com/hortonworks/iotas/metrics/storm/graphite/GraphiteWithStormQuerier.java
+++ b/metrics/src/main/java/com/hortonworks/iotas/metrics/storm/graphite/GraphiteWithStormQuerier.java
@@ -1,0 +1,207 @@
+package com.hortonworks.iotas.metrics.storm.graphite;
+
+import com.google.common.collect.Lists;
+import com.hortonworks.iotas.common.errors.ConfigException;
+import com.hortonworks.iotas.metrics.AbstractTimeSeriesQuerier;
+import org.apache.commons.lang.BooleanUtils;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.uri.internal.JerseyUriBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.MediaType;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Implementation of TimeSeriesQuerier for Graphite with Storm.
+ * <p/>
+ * This class assumes that metrics for Storm is pushed to Graphite via verisign/storm-graphite.
+ * https://github.com/verisign/storm-graphite
+ * <p/>
+ * appId is 'topology name', and metric name is composed to '[component name].[task id].[metric name](.[key of the value map])'.
+ *
+ * FIXME: Improve verisign/storm-graphite to escape dot(.) characters on worker host and remove option useFQDN.
+ */
+public class GraphiteWithStormQuerier extends AbstractTimeSeriesQuerier {
+    private static final Logger log = LoggerFactory.getLogger(GraphiteWithStormQuerier.class);
+
+    // the configuration keys
+    static final String RENDER_API_URL = "renderApiUrl";
+    static final String METRIC_NAME_PREFIX = "metricNamePrefix";
+    static final String USE_FQDN = "useFQDN";
+
+    // these metrics need '.%' as postfix to aggregate values for each stream
+    private static final List<String> METRICS_NEED_AGGREGATION_ON_STREAMS = Lists.newArrayList(
+            "__complete-latency", "__emit-count", "__ack-count", "__fail-count",
+            "__process-latency", "__execute-count", "__execute-latency"
+    );
+
+    private Client client;
+    private URI renderApiUrl;
+    private String metricNamePrefix;
+    private boolean useFQDN;
+
+    public GraphiteWithStormQuerier() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void init(Map<String, String> conf) throws ConfigException {
+        if (conf != null) {
+            try {
+                renderApiUrl = new URI(conf.get(RENDER_API_URL));
+                metricNamePrefix = conf.get(METRIC_NAME_PREFIX);
+                useFQDN = BooleanUtils.toBoolean(conf.get(USE_FQDN));
+            } catch (URISyntaxException e) {
+                throw new ConfigException(e);
+            }
+        }
+        client = ClientBuilder.newClient(new ClientConfig());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<Long, Double> getMetrics(String topologyName, String componentId, String metricName, AggregateFunction aggrFunction,
+                                        long from, long to) {
+        URI targetUri = composeQueryParameters(topologyName, componentId, metricName, aggrFunction, from, to);
+
+        log.debug("Calling {} for querying metric", targetUri.toString());
+
+        List<Map<String, ?>> responseList = client.target(targetUri).request(MediaType.APPLICATION_JSON_TYPE).get(List.class);
+        if (responseList.size() <= 0) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, ?> metrics = responseList.get(0);
+        List<List<Number>> dataPoints = (List<List<Number>>) metrics.get("datapoints");
+        return formatDataPointsFromGraphiteToMap(dataPoints);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, Map<Long, Double>> getRawMetrics(String metricName, String parameters, long from, long to) {
+        Map<String, String> queryParams = parseParameters(parameters);
+        URI targetUri = composeRawQueryParameters(metricName, queryParams, from, to);
+
+        log.debug("Calling {} for querying metric", targetUri.toString());
+
+        List<Map<String, ?>> responseList = client.target(targetUri).request(MediaType.APPLICATION_JSON_TYPE).get(List.class);
+        if (responseList.size() > 0) {
+            Map<String, Map<Long, Double>> ret = new HashMap<>(responseList.size());
+            for (Map<String, ?> metric : responseList) {
+                String target = (String) metric.get("target");
+                List<List<Number>> dataPoints = (List<List<Number>>) metric.get("datapoints");
+                Map<Long, Double> pointsForOutput = formatDataPointsFromGraphiteToMap(dataPoints);
+                ret.put(target, pointsForOutput);
+            }
+
+            return ret;
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    private URI composeQueryParameters(String topologyName, String componentId, String metricName, AggregateFunction aggrFunction,
+                                       long from, long to) {
+        String actualMetricName = buildMetricName(topologyName, componentId, metricName, aggrFunction);
+        JerseyUriBuilder uriBuilder = new JerseyUriBuilder();
+        return uriBuilder.uri(renderApiUrl)
+                .queryParam("target", actualMetricName)
+                .queryParam("format", "json")
+                .queryParam("from", String.valueOf((int) (from / 1000)))
+                .queryParam("until", String.valueOf((int) (to / 1000)))
+                .build();
+    }
+
+    private URI composeRawQueryParameters(String metricName, Map<String, String> queryParams, long from, long to) {
+        JerseyUriBuilder uriBuilder = new JerseyUriBuilder().uri(renderApiUrl);
+        for (Map.Entry<String, String> pair : queryParams.entrySet()) {
+            uriBuilder = uriBuilder.queryParam(pair.getKey(), pair.getValue());
+        }
+
+        // force replacing values for target, format, from, until with parameters
+        return uriBuilder.replaceQueryParam("target", metricName)
+                .queryParam("format", "json")
+                .queryParam("from", String.valueOf((int) (from / 1000)))
+                .queryParam("until", String.valueOf((int) (to / 1000)))
+                .build();
+    }
+
+    private Map<Long, Double> formatDataPointsFromGraphiteToMap(List<List<Number>> dataPoints) {
+        Map<Long, Double> pointsForOutput = new HashMap<>();
+
+        if (dataPoints != null && dataPoints.size() > 0) {
+            for (List<Number> dataPoint : dataPoints) {
+                // ex. [2940.0, 1465803540] -> 1465803540000, 2940.0
+                Number valueNum = dataPoint.get(0);
+                Number timestampNum = dataPoint.get(1);
+                if (valueNum == null) {
+                    continue;
+                }
+                pointsForOutput.put(timestampNum.longValue() * 1000, valueNum.doubleValue());
+            }
+        }
+        return pointsForOutput;
+    }
+
+    private String buildMetricName(String topologyName, String componentId, String metricName, AggregateFunction aggrFunction) {
+        // Example: http://localhost:9999/render/?target=sumSeries(storm.production.spout.*.*.*.*.*.*.__emit-count.*)&format=json&from=1465802460&until=1465803540
+        // prefix.topologyName.componentId.hostname.port.taskId.metricName.field
+        // we use wildcard on hostname, port, taskId, and field (stream)
+        String actualMetricNameFormat = "%s(%s.%s.%s.%s.*.*.%s)";
+
+        // worker host could be IP or fqdn, but storm-graphite doesn't apply escape on IP
+        // Graphite doesn't support wildcard across multiple buckets so we should know about this in order to apply wildcard...
+        // So applying workaround instead
+        String hostName;
+        if (useFQDN) {
+            // assuming FQDN doesn't have dot
+            hostName = "*";
+        } else {
+            // assuming hostname is represented as IP
+            hostName = "*.*.*.*";
+        }
+
+        String metricNameForAggregation = metricName;
+
+        if (METRICS_NEED_AGGREGATION_ON_STREAMS.contains(metricName)) {
+            metricNameForAggregation = metricName + ".*";
+        }
+        // verisign/storm-kafka replaces '/' to '.'
+        metricNameForAggregation = metricNameForAggregation.replace('/', '.');
+
+        String functionName;
+        switch (aggrFunction) {
+            case SUM:
+                functionName = "sumSeries";
+                break;
+            case AVG:
+                functionName = "averageSeries";
+                break;
+            case MIN:
+                functionName = "minSeries";
+                break;
+            case MAX:
+                functionName = "maxSeries";
+                break;
+            default:
+                throw new IllegalArgumentException("Aggregate function should be one of [sum / avg / min / max]");
+        }
+
+        return String.format(actualMetricNameFormat, functionName, metricNamePrefix, topologyName, componentId, hostName,
+                metricNameForAggregation);
+    }
+}

--- a/metrics/src/main/java/com/hortonworks/iotas/metrics/storm/opentsdb/OpenTSDBWithStormQuerier.java
+++ b/metrics/src/main/java/com/hortonworks/iotas/metrics/storm/opentsdb/OpenTSDBWithStormQuerier.java
@@ -1,0 +1,117 @@
+package com.hortonworks.iotas.metrics.storm.opentsdb;
+
+import com.google.common.base.Joiner;
+import com.hortonworks.iotas.common.errors.ConfigException;
+import com.hortonworks.iotas.metrics.AbstractTimeSeriesQuerier;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.uri.internal.JerseyUriBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.MediaType;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Implementation of TimeSeriesQuerier for OpenTSDB with Storm.
+ * <p/>
+ * Since there's no well-known metrics consumer for OpenTSDB, this class only supports raw query (getRawMetrics) for now.
+ * (getMetrics will throw UnsupportedOperationException unless implemented)
+ */
+public class OpenTSDBWithStormQuerier extends AbstractTimeSeriesQuerier {
+    private static final Logger log = LoggerFactory.getLogger(OpenTSDBWithStormQuerier.class);
+
+    // the configuration keys
+    public static final String QUERY_API_URL = "queryApiUrl";
+
+    private Client client;
+    private URI queryApiUri;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void init(Map<String, String> conf) throws ConfigException {
+        if (conf != null) {
+            try {
+                queryApiUri = new URI(conf.get(QUERY_API_URL));
+            } catch (URISyntaxException e) {
+                throw new ConfigException(e);
+            }
+        }
+        client = ClientBuilder.newClient(new ClientConfig());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<Long, Double> getMetrics(String topologyName, String componentId, String metricName, AggregateFunction aggrFunction, long from, long to) {
+        throw new UnsupportedOperationException("OpenTSDBWithStormQuerier only supports raw query");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, Map<Long, Double>> getRawMetrics(String metricName, String parameters, long from, long to) {
+        Map<String, String> queryParams = parseParameters(parameters);
+        URI targetUri = composeRawQueryParameters(metricName, queryParams, from, to);
+
+        log.debug("Calling {} for querying metric", targetUri.toString());
+
+        List<Map<String, ?>> responseList = client.target(targetUri).request(MediaType.APPLICATION_JSON_TYPE).get(List.class);
+        if (responseList.size() <= 0) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, Map<Long, Double>> ret = new HashMap<>(responseList.size());
+        for (Map<String, ?> responseMap : responseList) {
+            String retrievedMetricName = buildMetricNameFromResp(responseMap);
+            Map<String, Number> retrievedPoints = (Map<String, Number>) responseMap.get("dps");
+
+            Map<Long, Double> pointsForOutput = new HashMap<>(retrievedPoints.size());
+            for (Map.Entry<String, Number> timestampToValue : retrievedPoints.entrySet()) {
+                pointsForOutput.put(Long.valueOf(timestampToValue.getKey()), timestampToValue.getValue().doubleValue());
+            }
+
+            ret.put(retrievedMetricName, pointsForOutput);
+        }
+        return ret;
+    }
+
+    private URI composeRawQueryParameters(String metricName, Map<String, String> queryParams, long from, long to) {
+        JerseyUriBuilder uriBuilder = new JerseyUriBuilder().uri(queryApiUri);
+        for (Map.Entry<String, String> pair : queryParams.entrySet()) {
+            uriBuilder = uriBuilder.queryParam(pair.getKey(), pair.getValue());
+        }
+
+        // force replacing values for m, start, end with parameters
+        return uriBuilder.replaceQueryParam("m", metricName)
+                .replaceQueryParam("start", String.valueOf(from))
+                .replaceQueryParam("end", String.valueOf(to))
+                .build();
+    }
+
+    private String buildMetricNameFromResp(Map<String, ?> responseMap) {
+        String metricName = (String) responseMap.get("metric");
+        Map<String, ?> tags = (Map<String, ?>) responseMap.get("tags");
+        if (tags.size() <= 0) {
+            return metricName;
+        }
+
+        List<String> tagReprList = new ArrayList<>();
+        for (Map.Entry<String, ?> tag : tags.entrySet()) {
+            tagReprList.add(tag.getKey() + "=" + tag.getValue().toString());
+        }
+
+        return metricName + "[" + Joiner.on(",").join(tagReprList) + "]";
+    }
+}

--- a/metrics/src/test/java/com/hortonworks/iotas/metrics/storm/ambari/AmbariMetricsServiceWithStormQuerierTest.java
+++ b/metrics/src/test/java/com/hortonworks/iotas/metrics/storm/ambari/AmbariMetricsServiceWithStormQuerierTest.java
@@ -1,0 +1,133 @@
+package com.hortonworks.iotas.metrics.storm.ambari;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.hortonworks.iotas.metrics.TimeSeriesQuerier;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.hortonworks.iotas.metrics.storm.ambari.AmbariMetricsServiceWithStormQuerier.COLLECTOR_API_URL;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class AmbariMetricsServiceWithStormQuerierTest {
+    private final String TEST_COLLECTOR_API_PATH = "/ws/v1/timeline/metrics";
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(18089);
+    private AmbariMetricsServiceWithStormQuerier querier;
+
+    @Before
+    public void setUp() throws Exception {
+        querier = new AmbariMetricsServiceWithStormQuerier();
+
+        Map<String, String> conf = new HashMap<>();
+        conf.put(COLLECTOR_API_URL, "http://localhost:18089" + TEST_COLLECTOR_API_PATH);
+
+        querier.init(conf);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+    }
+
+    @Test
+    public void getMetrics() throws Exception {
+        stubMetricUrl();
+
+        String topologyName = "testTopology";
+        String componentId = "testComponent";
+        String metricName = "__test.metric.name";
+        TimeSeriesQuerier.AggregateFunction aggrFunction = TimeSeriesQuerier.AggregateFunction.SUM;
+        long from = 1234L;
+        long to = 5678L;
+
+        Map<Long, Double> metrics = querier.getMetrics(topologyName, componentId, metricName, aggrFunction, from, to);
+        assertResult(metrics);
+
+        verify(getRequestedFor(urlPathEqualTo(TEST_COLLECTOR_API_PATH))
+                .withQueryParam("appId", equalTo("testTopology"))
+                .withQueryParam("hostname", equalTo(""))
+                .withQueryParam("metricNames", equalTo("testComponent.%.--test.metric.name"))
+                .withQueryParam("startTime", equalTo("1234"))
+                .withQueryParam("precision", equalTo("seconds"))
+                .withQueryParam("endTime", equalTo("5678"))
+                .withQueryParam("seriesAggregateFunction", equalTo("SUM")));
+    }
+
+    @Test
+    public void getMetricsWithStreamAggregation() throws Exception {
+        stubMetricUrl();
+
+        String topologyName = "testTopology";
+        String componentId = "testComponent";
+        // this is one of metric which needs stream aggregation
+        String metricName = "__complete-latency";
+        TimeSeriesQuerier.AggregateFunction aggrFunction = TimeSeriesQuerier.AggregateFunction.AVG;
+        long from = 1234L;
+        long to = 5678L;
+
+        Map<Long, Double> metrics = querier.getMetrics(topologyName, componentId, metricName, aggrFunction, from, to);
+        assertResult(metrics);
+
+        verify(getRequestedFor(urlPathEqualTo(TEST_COLLECTOR_API_PATH))
+                .withQueryParam("appId", equalTo("testTopology"))
+                .withQueryParam("hostname", equalTo(""))
+                .withQueryParam("metricNames", equalTo("testComponent.%.--complete-latency.%"))
+                .withQueryParam("startTime", equalTo("1234"))
+                .withQueryParam("precision", equalTo("seconds"))
+                .withQueryParam("endTime", equalTo("5678"))
+                .withQueryParam("seriesAggregateFunction", equalTo("AVG")));
+    }
+
+    @Test
+    public void getRawMetrics() throws Exception {
+        stubMetricUrl();
+
+        String metricName = "metric";
+        String parameters = "precision=seconds,appId=testTopology";
+        long from = 1234L;
+        long to = 5678L;
+
+        Map<String, Map<Long, Double>> metrics = querier.getRawMetrics(metricName, parameters, from, to);
+        assertResult(metrics.get("metric"));
+
+        verify(getRequestedFor(urlPathEqualTo(TEST_COLLECTOR_API_PATH))
+                .withQueryParam("appId", equalTo("testTopology"))
+                .withQueryParam("metricNames", equalTo("metric"))
+                .withQueryParam("startTime", equalTo("1234"))
+                .withQueryParam("endTime", equalTo("5678"))
+                .withQueryParam("precision", equalTo("seconds")));
+    }
+
+
+    private void stubMetricUrl() {
+        stubFor(get(urlPathEqualTo(TEST_COLLECTOR_API_PATH))
+                .withHeader("Accept", equalTo("application/json"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"metrics\": [ {\"metricname\": \"metric\", \"metrics\": { \"123456\": 456.789, \"567890\": 890.123 } } ] }")));
+    }
+
+    private void assertResult(Map<Long, Double> metrics) {
+        assertTrue(metrics.containsKey(123456L));
+        assertEquals(456.789, metrics.get(123456L), 0.00001);
+        assertEquals(890.123, metrics.get(567890L), 0.00001);
+    }
+
+}

--- a/metrics/src/test/java/com/hortonworks/iotas/metrics/storm/graphite/GraphiteWithStormQuerierTest.java
+++ b/metrics/src/test/java/com/hortonworks/iotas/metrics/storm/graphite/GraphiteWithStormQuerierTest.java
@@ -1,0 +1,127 @@
+package com.hortonworks.iotas.metrics.storm.graphite;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.hortonworks.iotas.metrics.TimeSeriesQuerier;
+import org.apache.hadoop.metrics2.sink.GraphiteSink;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class GraphiteWithStormQuerierTest {
+    private final String TEST_RENDER_API_PATH = "/render";
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(18089);
+    private GraphiteWithStormQuerier querier;
+
+    @Before
+    public void setUp() throws Exception {
+        querier = new GraphiteWithStormQuerier();
+
+        Map<String, String> conf = new HashMap<>();
+        conf.put(GraphiteWithStormQuerier.RENDER_API_URL, "http://localhost:18089" + TEST_RENDER_API_PATH);
+        conf.put(GraphiteWithStormQuerier.METRIC_NAME_PREFIX, "storm");
+        conf.put(GraphiteWithStormQuerier.USE_FQDN, "false");
+
+        querier.init(conf);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+    }
+
+    @Test
+    public void getMetrics() throws Exception {
+        stubMetricUrl();
+
+        String topologyName = "testTopology";
+        String componentId = "testComponent";
+        String metricName = "__test.metric.name";
+        TimeSeriesQuerier.AggregateFunction aggrFunction = TimeSeriesQuerier.AggregateFunction.SUM;
+        long from = 1234000L;
+        long to = 5678000L;
+
+        Map<Long, Double> metrics = querier.getMetrics(topologyName, componentId, metricName, aggrFunction, from, to);
+        assertResult(metrics);
+
+        verify(getRequestedFor(urlPathEqualTo(TEST_RENDER_API_PATH))
+                .withQueryParam("target", equalTo("sumSeries(storm.testTopology.testComponent.*.*.*.*.*.*.__test.metric.name)"))
+                .withQueryParam("format", equalTo("json"))
+                .withQueryParam("from", equalTo("1234"))
+                .withQueryParam("until", equalTo("5678")));
+    }
+
+    @Test
+    public void getMetricsWithStreamAggregation() throws Exception {
+        stubMetricUrl();
+
+        String topologyName = "testTopology";
+        String componentId = "testComponent";
+        // this is one of metric which needs stream aggregation
+        String metricName = "__complete-latency";
+        TimeSeriesQuerier.AggregateFunction aggrFunction = TimeSeriesQuerier.AggregateFunction.AVG;
+        long from = 1234000L;
+        long to = 5678000L;
+
+        Map<Long, Double> metrics = querier.getMetrics(topologyName, componentId, metricName, aggrFunction, from, to);
+        assertResult(metrics);
+
+        verify(getRequestedFor(urlPathEqualTo(TEST_RENDER_API_PATH))
+                .withQueryParam("target", equalTo("averageSeries(storm.testTopology.testComponent.*.*.*.*.*.*.__complete-latency.*)"))
+                .withQueryParam("format", equalTo("json"))
+                .withQueryParam("from", equalTo("1234"))
+                .withQueryParam("until", equalTo("5678")));
+    }
+
+    @Test
+    public void getRawMetrics() throws Exception {
+        stubMetricUrl();
+
+        String metricName = "metric";
+        String parameters = "";
+        long from = 1234000L;
+        long to = 5678000L;
+
+        Map<String, Map<Long, Double>> metrics = querier.getRawMetrics(metricName, parameters, from, to);
+        assertResult(metrics.get("metric"));
+
+        verify(getRequestedFor(urlPathEqualTo(TEST_RENDER_API_PATH))
+                .withQueryParam("target", equalTo("metric"))
+                .withQueryParam("format", equalTo("json"))
+                .withQueryParam("from", equalTo("1234"))
+                .withQueryParam("until", equalTo("5678")));
+    }
+
+    private void stubMetricUrl() {
+        stubFor(get(urlPathEqualTo(TEST_RENDER_API_PATH))
+                .withHeader("Accept", equalTo("application/json"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[{\"target\": \"metric\", \"datapoints\": [[456.789, 2345], [890.123, 3456]]}]")));
+    }
+
+    private void assertResult(Map<Long, Double> metrics) {
+        assertTrue(metrics.containsKey(2345000L));
+        assertEquals(456.789, metrics.get(2345000L), 0.00001);
+        assertEquals(890.123, metrics.get(3456000L), 0.00001);
+    }
+
+}

--- a/metrics/src/test/java/com/hortonworks/iotas/metrics/storm/opentsdb/OpenTSDBWithStormQuerierTest.java
+++ b/metrics/src/test/java/com/hortonworks/iotas/metrics/storm/opentsdb/OpenTSDBWithStormQuerierTest.java
@@ -1,0 +1,92 @@
+package com.hortonworks.iotas.metrics.storm.opentsdb;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.hortonworks.iotas.metrics.TimeSeriesQuerier;
+import com.hortonworks.iotas.metrics.storm.opentsdb.OpenTSDBWithStormQuerier;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.hortonworks.iotas.metrics.storm.opentsdb.OpenTSDBWithStormQuerier.QUERY_API_URL;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class OpenTSDBWithStormQuerierTest {
+    // FIXME: add tests like other querier tests
+    private final String TEST_QUERY_API_PATH = "/api/query";
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(18089);
+    private OpenTSDBWithStormQuerier querier;
+
+
+    @Before
+    public void setUp() throws Exception {
+        querier = new OpenTSDBWithStormQuerier();
+
+        Map<String, String> conf = new HashMap<>();
+        conf.put(QUERY_API_URL, "http://localhost:18089" + TEST_QUERY_API_PATH);
+
+        querier.init(conf);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void getMetrics() throws Exception {
+        String topologyName = "testTopology";
+        String componentId = "testComponent";
+        String metricName = "__test.metric.name";
+        TimeSeriesQuerier.AggregateFunction aggrFunction = TimeSeriesQuerier.AggregateFunction.SUM;
+        long from = 1234L;
+        long to = 5678L;
+
+        querier.getMetrics(topologyName, componentId, metricName, aggrFunction, from, to);
+        fail("Shouldn't be reached here");
+    }
+
+
+    @Test
+    public void getRawMetrics() throws Exception {
+        stubMetricUrl();
+
+        String metricName = "sum:sys.cpu.user[host=web01]";
+        String parameters = "";
+        long from = 1234L;
+        long to = 5678L;
+
+        Map<String, Map<Long, Double>> metrics = querier.getRawMetrics(metricName, parameters, from, to);
+        assertResult(metrics.get("sys.cpu.user[host=web01]"));
+
+        verify(getRequestedFor(urlPathEqualTo(TEST_QUERY_API_PATH))
+                .withQueryParam("m", equalTo("sum:sys.cpu.user[host=web01]"))
+                .withQueryParam("start", equalTo("1234"))
+                .withQueryParam("end", equalTo("5678")));
+    }
+
+    private void stubMetricUrl() {
+        stubFor(get(urlPathEqualTo(TEST_QUERY_API_PATH))
+                .withHeader("Accept", equalTo("application/json"))
+                .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody("[{\"metric\":\"sys.cpu.user\",\"tags\":{\"host\":\"web01\"},\"aggregateTags\":[\"cpu\"],\"dps\":{\"123456\":456.789, \"567890\":890.123}}]")));
+    }
+
+
+    private void assertResult(Map<Long, Double> metrics) {
+        assertTrue(metrics.containsKey(123456L));
+        assertEquals(456.789, metrics.get(123456L), 0.00001);
+        assertEquals(890.123, metrics.get(567890L), 0.00001);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <module>notification-service</module>
         <module>notifiers</module>
         <module>layout</module>
+        <module>metrics</module>
     </modules>
 
     <properties>

--- a/webservice/conf/iotas-dev.yaml
+++ b/webservice/conf/iotas-dev.yaml
@@ -55,6 +55,12 @@ storageProviderConfiguration:
 #customProcessorUploadFailPath: "/tmp/failed"
 #customProcessorUploadSuccessPath: "/tmp/uploaded"
 
+# Time series DB querier configuration
+#timeSeriesDBConfiguration:
+#  className: "com.hortonworks.iotas.metrics.storm.ambari.AmbariMetricsServiceWithStormQuerier"
+#  properties:
+#    - collectorApiUrl: "http://localhost:6188/ws/v1/timeline/metrics"
+
 #
 # Use this to turn on/off notifications rest api in dev env
 # default is on

--- a/webservice/conf/iotas.yaml
+++ b/webservice/conf/iotas.yaml
@@ -57,6 +57,12 @@ storageProviderConfiguration:
 #customProcessorUploadFailPath: "/tmp/failed"
 #customProcessorUploadSuccessPath: "/tmp/uploaded"
 
+# Time series DB querier configuration
+#timeSeriesDBConfiguration:
+#  className: "com.hortonworks.iotas.metrics.storm.ambari.AmbariMetricsServiceWithStormQuerier"
+#  properties:
+#    - collectorApiUrl: "http://localhost:6188/ws/v1/timeline/metrics"
+
 #
 # Use this to turn on/off notifications rest api
 #

--- a/webservice/pom.xml
+++ b/webservice/pom.xml
@@ -78,6 +78,25 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.hortonworks.iotas</groupId>
+            <artifactId>metrics</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>${kafkaArtifact}</artifactId>
             <exclusions>

--- a/webservice/src/main/java/com/hortonworks/iotas/webservice/IotasApplication.java
+++ b/webservice/src/main/java/com/hortonworks/iotas/webservice/IotasApplication.java
@@ -26,6 +26,7 @@ import com.hortonworks.iotas.cache.writer.StorageWriter;
 import com.hortonworks.iotas.common.CustomProcessorUploadHandler;
 import com.hortonworks.iotas.common.FileEventHandler;
 import com.hortonworks.iotas.common.errors.ConfigException;
+import com.hortonworks.iotas.metrics.TimeSeriesQuerier;
 import com.hortonworks.iotas.notification.service.NotificationServiceImpl;
 import com.hortonworks.iotas.service.CatalogService;
 import com.hortonworks.iotas.service.FileWatcher;
@@ -173,6 +174,12 @@ public class IotasApplication extends Application<IotasConfiguration> {
         Map<String, String> conf = new HashMap<>();
         conf.put(TopologyLayoutConstants.STORM_API_ROOT_URL_KEY, configuration.getStormApiRootUrl());
         topologyMetrics.init(conf);
+
+        TimeSeriesQuerier timeSeriesQuerier = getTimeSeriesQuerier(configuration);
+        if (timeSeriesQuerier != null) {
+            topologyMetrics.setTimeSeriesQuerier(timeSeriesQuerier);
+        }
+
         return topologyMetrics;
     }
 
@@ -231,6 +238,20 @@ public class IotasApplication extends Application<IotasConfiguration> {
 
         environment.jersey().register(MultiPartFeature.class);
         watchFiles(iotasConfiguration, catalogService);
+    }
+
+    private TimeSeriesQuerier getTimeSeriesQuerier(IotasConfiguration iotasConfiguration) {
+        if (iotasConfiguration.getTimeSeriesDBConfiguration() == null) {
+            return null;
+        }
+
+        try {
+            TimeSeriesQuerier timeSeriesQuerier = ReflectionHelper.newInstance(iotasConfiguration.getTimeSeriesDBConfiguration().getClassName());
+            timeSeriesQuerier.init(iotasConfiguration.getTimeSeriesDBConfiguration().getProperties());
+            return timeSeriesQuerier;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private void watchFiles (IotasConfiguration iotasConfiguration, CatalogService catalogService) {

--- a/webservice/src/main/java/com/hortonworks/iotas/webservice/IotasConfiguration.java
+++ b/webservice/src/main/java/com/hortonworks/iotas/webservice/IotasConfiguration.java
@@ -80,6 +80,8 @@ public class IotasConfiguration extends Configuration {
 
     private String customProcessorUploadSuccessPath;
 
+    private TimeSeriesDBConfiguration timeSeriesDBConfiguration;
+
     @JsonProperty
     public void setBrokerList(String brokerList){
         this.brokerList = brokerList;
@@ -189,5 +191,13 @@ public class IotasConfiguration extends Configuration {
 
     public void setStormApiRootUrl(String stormApiRootUrl) {
         this.stormApiRootUrl = stormApiRootUrl;
+    }
+
+    public TimeSeriesDBConfiguration getTimeSeriesDBConfiguration() {
+        return timeSeriesDBConfiguration;
+    }
+
+    public void setTimeSeriesDBConfiguration(TimeSeriesDBConfiguration timeSeriesDBConfiguration) {
+        this.timeSeriesDBConfiguration = timeSeriesDBConfiguration;
     }
 }

--- a/webservice/src/main/java/com/hortonworks/iotas/webservice/MetricsResource.java
+++ b/webservice/src/main/java/com/hortonworks/iotas/webservice/MetricsResource.java
@@ -16,6 +16,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -26,10 +27,12 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import static com.hortonworks.iotas.catalog.CatalogResponse.ResponseMessage.BAD_REQUEST_PARAM_MISSING;
 import static com.hortonworks.iotas.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND;
 import static com.hortonworks.iotas.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND_FOR_FILTER;
 import static com.hortonworks.iotas.catalog.CatalogResponse.ResponseMessage.EXCEPTION;
 import static com.hortonworks.iotas.catalog.CatalogResponse.ResponseMessage.SUCCESS;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
@@ -63,5 +66,112 @@ public class MetricsResource {
             return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
         }
         return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, id.toString());
+    }
+
+    @GET
+    @Path("/topologies/{id}/sources/{sourceId}/complete_latency")
+    @Timed
+    public Response getCompleteLatency(@PathParam("id") Long id,
+                                       @PathParam("sourceId") String sourceId,
+                                       @QueryParam("from") Long from,
+                                       @QueryParam("to") Long to) {
+        if (from == null) {
+            return WSUtils.respond(BAD_REQUEST, BAD_REQUEST_PARAM_MISSING, "from");
+        }
+        if (to == null) {
+            return WSUtils.respond(BAD_REQUEST, BAD_REQUEST_PARAM_MISSING, "to");
+        }
+
+        try {
+            Topology topology = catalogService.getTopology(id);
+            if (topology != null) {
+                Map<Long, Double> metrics = catalogService.getCompleteLatency(topology, sourceId, from, to);
+                return WSUtils.respond(OK, SUCCESS, metrics);
+            }
+        } catch (Exception ex) {
+            LOG.error("Got exception", ex);
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
+        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, id.toString());
+    }
+
+    @GET
+    @Path("/topologies/{id}/sources/{sourceId}/component_stats")
+    @Timed
+    public Response getComponentStats(@PathParam("id") Long id,
+                                      @PathParam("sourceId") String sourceId,
+                                      @QueryParam("from") Long from,
+                                      @QueryParam("to") Long to) {
+        if (from == null) {
+            return WSUtils.respond(BAD_REQUEST, BAD_REQUEST_PARAM_MISSING, "from");
+        }
+        if (to == null) {
+            return WSUtils.respond(BAD_REQUEST, BAD_REQUEST_PARAM_MISSING, "to");
+        }
+
+        try {
+            Topology topology = catalogService.getTopology(id);
+            if (topology != null) {
+                Map<String, Map<Long, Double>> metrics = catalogService.getComponentStats(topology, sourceId, from, to);
+                return WSUtils.respond(OK, SUCCESS, metrics);
+            }
+        } catch (Exception ex) {
+            LOG.error("Got exception", ex);
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
+        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, id.toString());
+    }
+
+    @GET
+    @Path("/topologies/{id}/sources/{sourceId}/kafka_topic_offsets")
+    @Timed
+    public Response getKafkaTopicOffsets(@PathParam("id") Long id,
+                                         @PathParam("sourceId") String sourceId,
+                                         @QueryParam("from") Long from,
+                                         @QueryParam("to") Long to) {
+        if (from == null) {
+            return WSUtils.respond(BAD_REQUEST, BAD_REQUEST_PARAM_MISSING, "from");
+        }
+        if (to == null) {
+            return WSUtils.respond(BAD_REQUEST, BAD_REQUEST_PARAM_MISSING, "to");
+        }
+
+        try {
+            Topology topology = catalogService.getTopology(id);
+            if (topology != null) {
+                Map<String, Map<Long, Double>> metrics = catalogService.getKafkaTopicOffsets(topology, sourceId, from, to);
+                return WSUtils.respond(OK, SUCCESS, metrics);
+            }
+        } catch (Exception ex) {
+            LOG.error("Got exception", ex);
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
+        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, id.toString());
+    }
+
+    @GET
+    @Path("/raw")
+    @Timed
+    public Response getMetrics(@QueryParam("metricName") String metricName,
+                               @QueryParam("parameters") String parameters,
+                               @QueryParam("from") Long from,
+                               @QueryParam("to") Long to) {
+        if (metricName == null) {
+            return WSUtils.respond(BAD_REQUEST, BAD_REQUEST_PARAM_MISSING, "metricName");
+        }
+        if (from == null) {
+            return WSUtils.respond(BAD_REQUEST, BAD_REQUEST_PARAM_MISSING, "from");
+        }
+        if (to == null) {
+            return WSUtils.respond(BAD_REQUEST, BAD_REQUEST_PARAM_MISSING, "to");
+        }
+
+        try {
+            Map<String, Map<Long, Double>> metrics = catalogService.getMetrics(metricName, parameters, from, to);
+            return WSUtils.respond(OK, SUCCESS, metrics);
+        } catch (Exception ex) {
+            LOG.error("Got exception", ex);
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
     }
 }

--- a/webservice/src/main/java/com/hortonworks/iotas/webservice/TimeSeriesDBConfiguration.java
+++ b/webservice/src/main/java/com/hortonworks/iotas/webservice/TimeSeriesDBConfiguration.java
@@ -1,0 +1,33 @@
+package com.hortonworks.iotas.webservice;
+
+import org.hibernate.validator.constraints.NotEmpty;
+
+import java.util.Map;
+
+/**
+ * The configuration for time series DB.
+ *
+ */
+public class TimeSeriesDBConfiguration {
+
+    @NotEmpty
+    private String className;
+
+    private Map<String, String> properties;
+
+    public String getClassName() {
+        return className;
+    }
+
+    public void setClassName(String className) {
+        this.className = className;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, String> config) {
+        this.properties = config;
+    }
+}


### PR DESCRIPTION
- Add metrics API which queries to Time-series DB
- Add new module 'metrics' which will contain implementations of TimeSeriesQuerier
- Add TimeSeriesDBConfiguration to configure TimeSeriesQuerier

I have some TODOs regarding this but would like to get this reviewed earlier.

TODO:
- [x] Describe how to configure `TimeSeriesDBConfiguration` from iotas.yaml
- [x] Add storm-graphite compatible implementation of TimeSeriesQuerier and do actual test
  - since one of my AMS patch is still in reviewing and it will not be available before Ambari 2.4
- [x] Javadoc
- [x] Add API / method to query to time-series DB with unchanged metric name.
- [x] Add OpenTSDB compatible implementation of TimeSeriesQuerier and do actual test (there seems no famous OpenTSDB IMetricConsumer yet so it will only support query with unchanged metric name)

NOTE: It depends on upcoming Ambari 2.4, and also depends on [AMBARI-17027](https://issues.apache.org/jira/browse/AMBARI-17027) which is in reviewing and could take a bit long since there're many reviewers registered due to UI (Grafana query editor) change.
