### PR TITLE
IOT-267: Intermittent Unit test failure in WindowRulesBoltTest

### DIFF
--- a/storm/src/test/resources/window-rule-time.json
+++ b/storm/src/test/resources/window-rule-time.json
@@ -104,11 +104,11 @@
       "window": {
         "windowLength": {
           "class": ".Window$Duration",
-          "durationMs": 500
+          "durationMs": 1000
         },
         "slidingInterval": {
           "class": ".Window$Duration",
-          "durationMs": 500
+          "durationMs": 1000
         },
         "tsField": null,
         "lagMs": 0


### PR DESCRIPTION
Remove sleep and use a countdown latch to synchronize the execution.
