### PR TITLE
IOT-267: Fix Intermittent Unit test failure in WindowRulesBoltTest.testTimeBasedWindow

### DIFF
--- a/storm/src/test/java/com/hortonworks/iotas/bolt/rules/WindowRulesBoltTest.java
+++ b/storm/src/test/java/com/hortonworks/iotas/bolt/rules/WindowRulesBoltTest.java
@@ -126,6 +126,7 @@ public class WindowRulesBoltTest {
         Map<String, Object> conf = wb.getComponentConfiguration();
         conf.put("topology.message.timeout.secs", 30);
         wbe.prepare(conf, mockContext, mockCollector);
+        Thread.sleep(100);
         for (int i = 1; i <= 20; i++) {
             wbe.execute(getNextTuple(i));
         }


### PR DESCRIPTION
Introduce a slight delay before adding the events so that they are processed in the same window.
