### PR TITLE
IOT-341 Build failing due to unit test failures in storage-atlas module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.1.4
+ * IOT-341 Build failing due to unit test failures in storage-atlas module
  * IOT-340: Move Cache to a separate module
  * IOT-315: RulesChannelHandler does not override abstract method setSource
  * IOT-317: Create streams-sdk

--- a/storage/atlas/src/test/java/com/hortonworks/iotas/storage/atlas/AtlasMetadataServiceTest.java
+++ b/storage/atlas/src/test/java/com/hortonworks/iotas/storage/atlas/AtlasMetadataServiceTest.java
@@ -46,7 +46,6 @@ import java.util.Random;
 /**
  *
  */
-@Ignore
 public class AtlasMetadataServiceTest {
 
     @BeforeClass

--- a/storage/atlas/src/test/java/com/hortonworks/iotas/storage/atlas/AtlasStorageManagerTest.java
+++ b/storage/atlas/src/test/java/com/hortonworks/iotas/storage/atlas/AtlasStorageManagerTest.java
@@ -39,7 +39,6 @@ import static com.hortonworks.iotas.storage.atlas.AtlasMetadataServiceTest.clean
  *
  */
 @Category(IntegrationTest.class)
-@Ignore
 public class AtlasStorageManagerTest extends AbstractStoreManagerTest {
     private static AtlasStorageManager atlasStorageManager;
 


### PR DESCRIPTION
- Enabled Atlas tests as the latest Atlas repos have right jars.
