### PR TITLE
IOT-343: UI Sets Parallelism Property to Type String Which Causes Topology Deployment Failure

### DIFF
--- a/streams/catalog/pom.xml
+++ b/streams/catalog/pom.xml
@@ -45,17 +45,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.hortonworks.iotas</groupId>
-            <artifactId>streams-layout</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>com.hortonworks.iotas</groupId>
-            <artifactId>streams-layout-storm</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.1</version>

--- a/webservice/src/main/resources/assets/scripts/views/topology/NormalizationProcessorConfig.js
+++ b/webservice/src/main/resources/assets/scripts/views/topology/NormalizationProcessorConfig.js
@@ -708,7 +708,7 @@ define(['utils/LangSupport',
                 }
             }
             var config = {
-                parallelism: this.$('#np-parallelism').val(),
+                parallelism: parseInt(this.$('#np-parallelism').val()),
                 normalizationProcessorConfig: {
                     type: "fineGrained",
                     outputStreams: [{

--- a/webservice/src/main/resources/assets/scripts/views/topology/RuleProcessorView.js
+++ b/webservice/src/main/resources/assets/scripts/views/topology/RuleProcessorView.js
@@ -162,7 +162,7 @@ define(['require',
       }
 
         var config = {
-          parallelism: this.$('#rp-parallelism').val(),
+          parallelism: parseInt(this.$('#rp-parallelism').val()),
           rulesProcessorConfig: {
             rules: ruleArr,
             name: this.model.get('uiname'),


### PR DESCRIPTION
- parse type to int
- clenup duplicated pom dependencies
