### PR TITLE
IOT-346: Remove metrics dependency from webservice

### DIFF
--- a/webservice/pom.xml
+++ b/webservice/pom.xml
@@ -83,25 +83,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.hortonworks.iotas</groupId>
-            <artifactId>metrics</artifactId>
-            <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.sun.jersey</groupId>
-                    <artifactId>jersey-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jersey</groupId>
-                    <artifactId>jersey-server</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jersey</groupId>
-                    <artifactId>jersey-client</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>${kafkaArtifact}</artifactId>
             <exclusions>


### PR DESCRIPTION
Had a chat with @csivaguru and as per his suggestion we dont need the metrics module for webservice.
