### PR TITLE
IOT-396: Enhance UDF support in rules engine

### DIFF
--- a/bootstrap/bootstrap-udf.sh
+++ b/bootstrap/bootstrap-udf.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+dir=$(dirname $0)/..
+
+# Load UDF functions
+echo "Adding aggregate functions"
+echo "stddev"
+curl -s -X POST 'http://localhost:8080/api/v1/catalog/streams/udfs' -F udfJarFile=@${dir}/streams/functions/target/streams-functions-0.1.0-SNAPSHOT.jar -F udfConfig='{"name":"STDDEV", "description": "Standard deviation", "type":"AGGREGATE", "className":"com.hortonworks.iotas.streams.udaf.Stddev"};type=application/json'
+echo
+
+echo "stddevp"
+curl -s -X POST 'http://localhost:8080/api/v1/catalog/streams/udfs' -F udfJarFile=@${dir}/streams/functions/target/streams-functions-0.1.0-SNAPSHOT.jar -F udfConfig='{"name":"STDDEVP", "description": "Population standard deviation", "type":"AGGREGATE", "className":"com.hortonworks.iotas.streams.udaf.Stddevp"};type=application/json'
+echo
+
+echo "variance"
+curl -s -X POST 'http://localhost:8080/api/v1/catalog/streams/udfs' -F udfJarFile=@${dir}/streams/functions/target/streams-functions-0.1.0-SNAPSHOT.jar -F udfConfig='{"name":"VARIANCE", "description": "Variance", "type":"AGGREGATE", "className":"com.hortonworks.iotas.streams.udaf.Variance"};type=application/json'
+echo
+
+echo "variancep"
+curl -s -X POST 'http://localhost:8080/api/v1/catalog/streams/udfs' -F udfJarFile=@${dir}/streams/functions/target/streams-functions-0.1.0-SNAPSHOT.jar -F udfConfig='{"name":"VARIANCEP", "description": "Population variance", "type":"AGGREGATE", "className":"com.hortonworks.iotas.streams.udaf.Variancep"};type=application/json'
+echo
+
+echo "collectlist"
+curl -s -X POST 'http://localhost:8080/api/v1/catalog/streams/udfs' -F udfJarFile=@${dir}/streams/functions/target/streams-functions-0.1.0-SNAPSHOT.jar -F udfConfig='{"name":"COLLECTLIST", "description": "Collect", "type":"AGGREGATE", "className":"com.hortonworks.iotas.streams.udaf.Collectlist"};type=application/json'
+echo
+
+echo "topn"
+curl -s -X POST 'http://localhost:8080/api/v1/catalog/streams/udfs' -F udfJarFile=@${dir}/streams/functions/target/streams-functions-0.1.0-SNAPSHOT.jar -F udfConfig='{"name":"TOPN", "description": "Top N", "type":"AGGREGATE", "className":"com.hortonworks.iotas.streams.udaf.Topn"};type=application/json'
+echo
+
+# Dummy entries for built in functions so that it shows up in the UI
+echo "Adding dummy entries for builtin functions"
+curl -s -X POST 'http://localhost:8080/api/v1/catalog/streams/udfs' -F udfConfig='{"name":"MIN", "description": "Minimum", "type":"AGGREGATE", "className":"builtin"};type=application/json' -F builtin=true
+echo
+curl -s -X POST 'http://localhost:8080/api/v1/catalog/streams/udfs' -F udfConfig='{"name":"MAX", "description": "Maximum", "type":"AGGREGATE", "className":"builtin"};type=application/json' -F builtin=true
+echo
+curl -s -X POST 'http://localhost:8080/api/v1/catalog/streams/udfs' -F udfConfig='{"name":"SUM", "description": "Sum", "type":"AGGREGATE", "className":"builtin"};type=application/json' -F builtin=true
+echo
+curl -s -X POST 'http://localhost:8080/api/v1/catalog/streams/udfs' -F udfConfig='{"name":"AVG", "description": "Average", "type":"AGGREGATE", "className":"builtin"};type=application/json' -F builtin=true
+echo
+curl -s -X POST 'http://localhost:8080/api/v1/catalog/streams/udfs' -F udfConfig='{"name":"COUNT", "description": "Count", "type":"AGGREGATE", "className":"builtin"};type=application/json' -F builtin=true
+echo
+curl -s -X POST 'http://localhost:8080/api/v1/catalog/streams/udfs' -F udfConfig='{"name":"UPPER", "description": "Uppercase", "type":"FUNCTION", "className":"builtin"};type=application/json' -F builtin=true
+echo
+curl -s -X POST 'http://localhost:8080/api/v1/catalog/streams/udfs' -F udfConfig='{"name":"LOWER", "description": "Lowercase", "type":"FUNCTION", "className":"builtin"};type=application/json' -F builtin=true
+echo
+curl -s -X POST 'http://localhost:8080/api/v1/catalog/streams/udfs' -F udfConfig='{"name":"INITCAP", "description": "First letter of each word in uppercase", "type":"FUNCTION", "className":"builtin"};type=application/json' -F builtin=true
+echo
+curl -s -X POST 'http://localhost:8080/api/v1/catalog/streams/udfs' -F udfConfig='{"name":"SUBSTRING", "description": "Substring", "type":"FUNCTION", "className":"builtin"};type=application/json' -F builtin=true
+echo
+curl -s -X POST 'http://localhost:8080/api/v1/catalog/streams/udfs' -F udfConfig='{"name":"CHAR_LENGTH", "description": "String length", "type":"FUNCTION", "className":"builtin"};type=application/json' -F builtin=true
+echo
+curl -s -X POST 'http://localhost:8080/api/v1/catalog/streams/udfs' -F udfConfig='{"name":"CONCAT", "description": "Concatenate", "type":"FUNCTION", "className":"builtin"};type=application/json' -F builtin=true
+echo
+echo "Done"

--- a/bootstrap/topology-rest-api-test.sh
+++ b/bootstrap/topology-rest-api-test.sh
@@ -248,7 +248,7 @@ echo -e "\n------"
 out=$(curl -s -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
     "name": "rule1",
     "description": "windowed rule test",
-    "sql": "select max(temperature) from parsedTuplesStream where humidity > 90",
+    "sql": "select max(temperature), stddev(temperature) from parsedTuplesStream where humidity > 90",
     "window": {
         "windowLength": {
           "class": ".Window$Duration",

--- a/registries/parser-registry/src/main/java/com/hortonworks/iotas/registries/parser/service/ParsersCatalogService.java
+++ b/registries/parser-registry/src/main/java/com/hortonworks/iotas/registries/parser/service/ParsersCatalogService.java
@@ -120,19 +120,7 @@ public class ParsersCatalogService {
 
     public Collection<String> verifyParserUpload (InputStream inputStream) throws IOException {
         final File tmpFile = FileUtil.writeInputStreamToTempFile(inputStream, ".jar");
-        List<String> parserClasses = JarReader.findSubtypeOfClasses(tmpFile, Parser.class);
-        return Collections2.filter(parserClasses, new Predicate<String>() {
-            @Override
-            public boolean apply(@Nullable String s) {
-                try {
-                    parserProxyUtil.loadClassFromJar(tmpFile.getAbsolutePath(), s);
-                    return true;
-                } catch (Throwable ex) {
-                    LOG.warn("class {} is subtype of Parser, but it can't be initialized.", s);
-                    return false;
-                }
-            }
-        });
+        return ProxyUtil.loadAllClassesFromJar(tmpFile, Parser.class);
     }
 
     /**

--- a/storage/core/src/main/resources/mysql/create_tables.sql
+++ b/storage/core/src/main/resources/mysql/create_tables.sql
@@ -204,5 +204,6 @@ CREATE TABLE IF NOT EXISTS udfs (
     type  VARCHAR(256) NOT NULL,
     className  VARCHAR(256) NOT NULL,
     jarStoragePath  VARCHAR(256) NOT NULL,
+    digest VARCHAR(256) NOT NULL,
     PRIMARY KEY (id)
 );

--- a/storage/core/src/main/resources/phoenix/create_tables.sql
+++ b/storage/core/src/main/resources/phoenix/create_tables.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS topology_processors ("id" BIGINT NOT NULL, "topologyI
 CREATE TABLE IF NOT EXISTS topology_processor_stream_mapping ("processorId" BIGINT NOT NULL, "streamId" BIGINT NOT NULL, CONSTRAINT pk PRIMARY KEY ("processorId", "streamId"))
 CREATE TABLE IF NOT EXISTS topology_edges ("id" BIGINT NOT NULL, "topologyId" BIGINT, "fromId" BIGINT, "toId" BIGINT, "streamGroupingsData" VARCHAR, CONSTRAINT pk PRIMARY KEY ("id"))
 CREATE TABLE IF NOT EXISTS ruleinfos ("id" BIGINT NOT NULL, "topologyId" BIGINT, "name" VARCHAR, "description" VARCHAR, "streams" VARCHAR, "condition" VARCHAR, "sql" VARCHAR, "parsedRuleStr" VARCHAR, "window" VARCHAR, "actions" VARCHAR, "projections" VARCHAR, "groupbykeys" VARCHAR, CONSTRAINT pk PRIMARY KEY ("id"))
-CREATE TABLE IF NOT EXISTS udfs ("id" BIGINT NOT NULL, "name" VARCHAR, "description" VARCHAR, "type" VARCHAR, "className" VARCHAR, "jarStoragePath" VARCHAR, CONSTRAINT pk PRIMARY KEY ("id"))
+CREATE TABLE IF NOT EXISTS udfs ("id" BIGINT NOT NULL, "name" VARCHAR, "description" VARCHAR, "type" VARCHAR, "className" VARCHAR, "jarStoragePath" VARCHAR, "digest" VARCHAR, CONSTRAINT pk PRIMARY KEY ("id"))
 CREATE TABLE IF NOT EXISTS sequence_table ("id" VARCHAR, "datasources" BIGINT, "datafeeds" BIGINT, "parser_info" BIGINT, "files" BIGINT, "topologies" BIGINT, "topology_component_definitions" BIGINT, "topology_components" BIGINT, "tag" BIGINT,  "streaminfo" BIGINT, "notifierinfos" BIGINT, "topology_sources" BIGINT, "topology_sinks" BIGINT, "topology_processors" BIGINT, "topology_edges" BIGINT, "ruleinfos" BIGINT, "udfs" BIGINT, CONSTRAINT pk PRIMARY KEY ("id"))
 CREATE SEQUENCE IF NOT EXISTS datasources_sequence
 CREATE SEQUENCE IF NOT EXISTS datafeeds_sequence

--- a/streams/catalog/src/main/java/com/hortonworks/iotas/streams/catalog/service/StormTopologyUdfJarHandler.java
+++ b/streams/catalog/src/main/java/com/hortonworks/iotas/streams/catalog/service/StormTopologyUdfJarHandler.java
@@ -1,0 +1,43 @@
+package com.hortonworks.iotas.streams.catalog.service;
+
+import com.hortonworks.iotas.streams.layout.component.Edge;
+import com.hortonworks.iotas.streams.layout.component.IotasProcessor;
+import com.hortonworks.iotas.streams.layout.component.IotasSink;
+import com.hortonworks.iotas.streams.layout.component.IotasSource;
+import com.hortonworks.iotas.streams.layout.component.TopologyDagVisitor;
+import com.hortonworks.iotas.streams.layout.component.impl.RulesProcessor;
+import com.hortonworks.iotas.streams.layout.component.rule.Rule;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class StormTopologyUdfJarHandler extends TopologyDagVisitor {
+    private Set<String> udfs = new HashSet<>();
+
+    @Override
+    public void visit(RulesProcessor rulesProcessor) {
+        for (Rule rule : rulesProcessor.getRules()) {
+            udfs.addAll(rule.getReferredUdfs());
+        }
+    }
+
+    @Override
+    public void visit(Edge edge) {
+    }
+
+    @Override
+    public void visit(IotasSource iotasSource) {
+    }
+
+    @Override
+    public void visit(IotasSink iotasSink) {
+    }
+
+    @Override
+    public void visit(IotasProcessor iotasProcessor) {
+    }
+
+    public Set<String> getUdfs() {
+        return udfs;
+    }
+}

--- a/streams/functions/pom.xml
+++ b/streams/functions/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>streams</artifactId>
+        <groupId>com.hortonworks.iotas</groupId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>streams-functions</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.hortonworks.iotas</groupId>
+            <artifactId>common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.hortonworks.iotas</groupId>
+            <artifactId>streams-sdk</artifactId>
+            <version>0.1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/streams/functions/src/main/java/com/hortonworks/iotas/streams/udaf/CollectList.java
+++ b/streams/functions/src/main/java/com/hortonworks/iotas/streams/udaf/CollectList.java
@@ -1,0 +1,27 @@
+package com.hortonworks.iotas.streams.udaf;
+
+import com.hortonworks.iotas.streams.rule.UDAF;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Collects elements within a group and returns the list of aggregated objects
+ */
+public class CollectList implements UDAF<List<Object>, Object, List<Object>> {
+    @Override
+    public List<Object> init() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public List<Object> add(List<Object> aggregate, Object val) {
+        aggregate.add(val);
+        return aggregate;
+    }
+
+    @Override
+    public List<Object> result(List<Object> aggregate) {
+        return aggregate;
+    }
+}

--- a/streams/functions/src/main/java/com/hortonworks/iotas/streams/udaf/Stddev.java
+++ b/streams/functions/src/main/java/com/hortonworks/iotas/streams/udaf/Stddev.java
@@ -1,0 +1,20 @@
+package com.hortonworks.iotas.streams.udaf;
+
+import com.hortonworks.iotas.streams.rule.UDAF;
+
+public class Stddev implements UDAF<StddevOnline, Double, Double> {
+    @Override
+    public StddevOnline init() {
+        return new StddevOnline();
+    }
+
+    @Override
+    public StddevOnline add(StddevOnline aggregate, Double val) {
+        return aggregate.add(val);
+    }
+
+    @Override
+    public Double result(StddevOnline aggregate) {
+        return aggregate.stddev();
+    }
+}

--- a/streams/functions/src/main/java/com/hortonworks/iotas/streams/udaf/StddevOnline.java
+++ b/streams/functions/src/main/java/com/hortonworks/iotas/streams/udaf/StddevOnline.java
@@ -1,0 +1,35 @@
+package com.hortonworks.iotas.streams.udaf;
+
+/**
+ * Computes online variance and stddev of values using
+ * B.P. Welford's algorithm described in Knuth's TAOCP Vol2. p232, 3rd edition.
+ */
+public class StddevOnline {
+    private int n;
+    private double mean;
+    private double aggregate;
+
+    StddevOnline add(double val) {
+        ++n;
+        double delta = val - mean;
+        mean += delta / n;
+        aggregate += (delta * (val - mean));
+        return this;
+    }
+
+    double stddevp() {
+        return Math.sqrt(variancep());
+    }
+
+    double variancep() {
+        return aggregate / n;
+    }
+
+    double stddev() {
+        return Math.sqrt(variance());
+    }
+
+    double variance() {
+        return aggregate / (n - 1);
+    }
+}

--- a/streams/functions/src/main/java/com/hortonworks/iotas/streams/udaf/Stddevp.java
+++ b/streams/functions/src/main/java/com/hortonworks/iotas/streams/udaf/Stddevp.java
@@ -1,0 +1,23 @@
+package com.hortonworks.iotas.streams.udaf;
+
+import com.hortonworks.iotas.streams.rule.UDAF;
+
+/**
+ * Population stddev
+ */
+public class Stddevp implements UDAF<StddevOnline, Double, Double> {
+    @Override
+    public StddevOnline init() {
+        return new StddevOnline();
+    }
+
+    @Override
+    public StddevOnline add(StddevOnline aggregate, Double val) {
+        return aggregate.add(val);
+    }
+
+    @Override
+    public Double result(StddevOnline aggregate) {
+        return aggregate.stddevp();
+    }
+}

--- a/streams/functions/src/main/java/com/hortonworks/iotas/streams/udaf/Topn.java
+++ b/streams/functions/src/main/java/com/hortonworks/iotas/streams/udaf/Topn.java
@@ -1,0 +1,42 @@
+package com.hortonworks.iotas.streams.udaf;
+
+import com.hortonworks.iotas.streams.rule.UDAF2;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.PriorityQueue;
+
+/**
+ * Computes streaming top n values of a group of values
+ */
+public class Topn<T extends Comparable<T>> implements UDAF2<PriorityQueue<T>, Integer, T, List<T>> {
+    @Override
+    public PriorityQueue<T> init() {
+        return new PriorityQueue<>();
+    }
+
+    @Override
+    public PriorityQueue<T> add(PriorityQueue<T> aggregate, Integer n, T val) {
+        if (n <= 0) {
+            return aggregate;
+        }
+        if (aggregate.size() >= n) {
+            if (val.compareTo(aggregate.peek()) > 0) {
+                aggregate.remove();
+                aggregate.add(val);
+            }
+        } else {
+            aggregate.add(val);
+        }
+        return aggregate;
+
+    }
+
+    @Override
+    public List<T> result(PriorityQueue<T> aggregate) {
+        List<T> res = new ArrayList<>(aggregate);
+        Collections.reverse(res);
+        return res;
+    }
+}

--- a/streams/functions/src/main/java/com/hortonworks/iotas/streams/udaf/Variance.java
+++ b/streams/functions/src/main/java/com/hortonworks/iotas/streams/udaf/Variance.java
@@ -1,0 +1,20 @@
+package com.hortonworks.iotas.streams.udaf;
+
+import com.hortonworks.iotas.streams.rule.UDAF;
+
+public class Variance implements UDAF<StddevOnline, Double, Double> {
+    @Override
+    public StddevOnline init() {
+        return new StddevOnline();
+    }
+
+    @Override
+    public StddevOnline add(StddevOnline aggregate, Double val) {
+        return aggregate.add(val);
+    }
+
+    @Override
+    public Double result(StddevOnline aggregate) {
+        return aggregate.variance();
+    }
+}

--- a/streams/functions/src/main/java/com/hortonworks/iotas/streams/udaf/Variancep.java
+++ b/streams/functions/src/main/java/com/hortonworks/iotas/streams/udaf/Variancep.java
@@ -1,0 +1,20 @@
+package com.hortonworks.iotas.streams.udaf;
+
+import com.hortonworks.iotas.streams.rule.UDAF;
+
+public class Variancep implements UDAF<StddevOnline, Double, Double> {
+    @Override
+    public StddevOnline init() {
+        return new StddevOnline();
+    }
+
+    @Override
+    public StddevOnline add(StddevOnline aggregate, Double val) {
+        return aggregate.add(val);
+    }
+
+    @Override
+    public Double result(StddevOnline aggregate) {
+        return aggregate.variancep();
+    }
+}

--- a/streams/functions/src/test/java/com/hortonworks/iotas/streams/udaf/StddevpTest.java
+++ b/streams/functions/src/test/java/com/hortonworks/iotas/streams/udaf/StddevpTest.java
@@ -1,0 +1,37 @@
+package com.hortonworks.iotas.streams.udaf;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StddevpTest {
+    @Test
+    public void testResult() throws Exception {
+        Stddevp stddevp = new Stddevp();
+        Stddev stddev = new Stddev();
+        Variancep variancep = new Variancep();
+        Variance variance = new Variance();
+        StddevOnline stddevpAgg = stddevp.init();
+        StddevOnline stddevAgg = stddevp.init();
+        StddevOnline variancepAgg = stddevp.init();
+        StddevOnline varianceAgg = stddevp.init();
+        double arr[] = {1, 2, 2, 3, 3, 4, 5};
+        double sum = 0;
+        for (double i : arr) {
+            stddevpAgg = stddevp.add(stddevpAgg, i);
+            stddevAgg = stddev.add(stddevAgg, i);
+            variancepAgg = stddev.add(variancepAgg, i);
+            varianceAgg = stddev.add(varianceAgg, i);
+            sum += i;
+        }
+        double mean = sum / arr.length;
+        double sqsum = 0.0;
+        for (double i : arr) {
+            sqsum += (mean - i) * (mean - i);
+        }
+        Assert.assertEquals(Math.sqrt(sqsum / arr.length), stddevp.result(stddevpAgg), .0001);
+        Assert.assertEquals(Math.sqrt(sqsum / (arr.length - 1)), stddev.result(stddevAgg), .0001);
+        Assert.assertEquals(sqsum / arr.length, variancep.result(variancepAgg), .0001);
+        Assert.assertEquals(sqsum / (arr.length - 1), variance.result(varianceAgg), .0001);
+    }
+
+}

--- a/streams/layout/src/main/java/com/hortonworks/iotas/streams/layout/component/TopologyActions.java
+++ b/streams/layout/src/main/java/com/hortonworks/iotas/streams/layout/component/TopologyActions.java
@@ -38,6 +38,11 @@ public interface TopologyActions {
      */
     Path getArtifactsLocation(TopologyLayout topology);
 
+    /**
+     * the Path where extra jars to be deployed are kept
+     */
+    Path getExtraJarsLocation(TopologyLayout topology);
+
     interface Status {
         String getStatus();
         Map<String, String> getExtra();

--- a/streams/layout/src/main/java/com/hortonworks/iotas/streams/layout/component/rule/Rule.java
+++ b/streams/layout/src/main/java/com/hortonworks/iotas/streams/layout/component/rule/Rule.java
@@ -18,6 +18,7 @@
 
 package com.hortonworks.iotas.streams.layout.component.rule;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableList;
 import com.hortonworks.iotas.streams.IotasEvent;
 import com.hortonworks.iotas.streams.layout.component.rule.action.Action;
@@ -29,6 +30,7 @@ import com.hortonworks.iotas.streams.layout.component.rule.expression.Window;
 
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -49,6 +51,8 @@ public class Rule implements Serializable {
     private Having having;
     private Window window;
     private List<Action> actions;
+    // quick access to user defined functions used in this rule
+    private Set<String> referredUdfs = Collections.emptySet();
 
     public Rule() {     //TODO Check
         // For JSON serializer
@@ -152,6 +156,14 @@ public class Rule implements Serializable {
         this.groupBy = groupBy;
     }
 
+    public void setReferredUdfs(Set<String> referredUdfs) {
+        this.referredUdfs = new HashSet<>(referredUdfs);
+    }
+
+    public Set<String> getReferredUdfs() {
+        return referredUdfs;
+    }
+
     @Override
     public String toString() {
         return "Rule{" +
@@ -162,10 +174,11 @@ public class Rule implements Serializable {
                 ", streams=" + streams +
                 ", projection=" + projection +
                 ", condition=" + condition +
-                ", having=" + having +
                 ", groupBy=" + groupBy +
+                ", having=" + having +
                 ", window=" + window +
                 ", actions=" + actions +
+                ", referredUdfs=" + referredUdfs +
                 '}';
     }
 }

--- a/streams/pom.xml
+++ b/streams/pom.xml
@@ -23,6 +23,7 @@
         <module>service</module>
         <module>runners</module>
         <module>schemaevolver</module>
+        <module>functions</module>
     </modules>
 
 

--- a/streams/runners/storm/layout/src/main/java/com/hortonworks/iotas/streams/layout/storm/RuleBoltFluxComponent.java
+++ b/streams/runners/storm/layout/src/main/java/com/hortonworks/iotas/streams/layout/storm/RuleBoltFluxComponent.java
@@ -56,7 +56,7 @@ public class RuleBoltFluxComponent extends AbstractFluxComponent {
         String rulesProcessorBuilderComponentId = "rulesProcessorBuilder" +
                 UUID_FOR_COMPONENTS;
         String rulesProcessorBuilderClassName = "com.hortonworks.iotas.streams" +
-                "layout.component.RulesProcessorJsonBuilder";
+                ".layout.component.RulesProcessorJsonBuilder";
         ObjectMapper mapper = new ObjectMapper();
         String rulesProcessorJson = null;
         try {

--- a/streams/sdk/src/main/java/com/hortonworks/iotas/streams/rule/UDAF.java
+++ b/streams/sdk/src/main/java/com/hortonworks/iotas/streams/rule/UDAF.java
@@ -1,0 +1,47 @@
+package com.hortonworks.iotas.streams.rule;
+
+/**
+ * <p>
+ * Interface for user defined aggregate functions (UDAF) of single argument.
+ * E.g. min(x), max(y)
+ * <p>
+ * Performing the aggregation operation over a group of values
+ * should produce a result equivalent to:
+ * <pre>
+ *   A aggregate = udafObj.init();
+ *   // for each entity in the group
+ *   for (...) {
+ *     aggregate = udafObj.add(aggregate, value);
+ *   }
+ *   R result = udafObj.result(aggregate);
+ * </pre>
+ *
+ * @param <A> the aggregate type
+ * @param <V> the value type
+ * @param <R> the result type
+ */
+public interface UDAF<A, V, R> {
+    /**
+     * Initial value for the aggregator.
+     *
+     * @return the initial value
+     */
+    A init();
+
+    /**
+     * Return a new aggregate by applying the current value with the accumulated value.
+     *
+     * @param aggregate the current aggregate
+     * @param val       the current value
+     * @return the new aggregate
+     */
+    A add(A aggregate, V val);
+
+    /**
+     * Returns the result of the aggregate.
+     *
+     * @param aggregate the current aggregate
+     * @return the result
+     */
+    R result(A aggregate);
+}

--- a/streams/sdk/src/main/java/com/hortonworks/iotas/streams/rule/UDAF2.java
+++ b/streams/sdk/src/main/java/com/hortonworks/iotas/streams/rule/UDAF2.java
@@ -1,0 +1,48 @@
+package com.hortonworks.iotas.streams.rule;
+
+/**
+ * <p>
+ * Interface for user defined aggregate functions (UDAF) of two arguments.
+ * E.g. topn(5, x)
+ * </p>
+ * Performing the aggregation operation over a group of values
+ * should produce a result equivalent to:
+ * <pre>
+ *   A aggregate = udafObj.init();
+ *   // for each entity in the group
+ *   for (...) {
+ *     aggregate = udafObj.add(aggregate, value1, value2);
+ *   }
+ *   R result = udafObj.result(aggregate);
+ * </pre>
+ * @param <A> the aggregate type
+ * @param <V1> the value type of first argument
+ * @param <V2> the value type of second argument
+ * @param <R> the result type
+ */
+public interface UDAF2<A, V1, V2, R> {
+    /**
+     * Initial value for the aggregator.
+     *
+     * @return the initial value
+     */
+    A init();
+
+    /**
+     * Return a new aggregate by applying the current value with the accumulated value.
+     *
+     * @param aggregate the current aggregate
+     * @param val1       the current value of the first argument
+     * @param val2       the current value of the second argument
+     * @return the new aggregate
+     */
+    A add(A aggregate, V1 val1, V2 val2);
+
+    /**
+     * Returns the result of the aggregate.
+     *
+     * @param aggregate the current aggregate
+     * @return the result
+     */
+    R result(A aggregate);
+}

--- a/streams/service/src/main/java/com/hortonworks/iotas/streams/service/UDFCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/iotas/streams/service/UDFCatalogResource.java
@@ -1,12 +1,16 @@
 package com.hortonworks.iotas.streams.service;
 
 import com.codahale.metrics.annotation.Timed;
+import com.google.common.base.Optional;
 import com.hortonworks.iotas.common.catalog.CatalogResponse;
 import com.hortonworks.iotas.common.QueryParam;
 import com.hortonworks.iotas.common.util.FileStorage;
+import com.hortonworks.iotas.common.util.FileUtil;
 import com.hortonworks.iotas.streams.catalog.UDFInfo;
 import com.hortonworks.iotas.streams.catalog.service.StreamCatalogService;
 import com.hortonworks.iotas.common.util.WSUtils;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
@@ -28,11 +32,18 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 import javax.ws.rs.core.UriInfo;
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import static com.hortonworks.iotas.common.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND;
@@ -46,7 +57,7 @@ import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
 
-@Path("/api/v1/catalog")
+@Path("/api/v1/catalog/streams")
 @Produces(MediaType.APPLICATION_JSON)
 public class UDFCatalogResource {
     private static final Logger LOG = LoggerFactory.getLogger(UDFCatalogResource.class);
@@ -60,6 +71,30 @@ public class UDFCatalogResource {
 
     /**
      * List ALL UDFs or the ones matching specific query params.
+     * <p>
+     * GET api/v1/catalog/udfs
+     * </p>
+     * <pre>
+     * {
+     *   "responseCode": 1000,
+     *   "responseMessage": "Success",
+     *   "entities": [
+     *     {
+     *       "id": 34,
+     *       "name": "STDDEV",
+     *       "description": "Standard deviation",
+     *       "type": "AGGREGATE",
+     *       "className": "com.hortonworks.iotas.streams.rule.udaf.Stddev"
+     *     },
+     *     { "id": 46,
+     *        "name": "LOWER",
+     *        "description": "Lowercase",
+     *        "type": "FUNCTION",
+     *        "className": "builtin"
+     *     }
+     *    ]
+     * }
+     * </pre>
      */
     @GET
     @Path("/udfs")
@@ -85,6 +120,26 @@ public class UDFCatalogResource {
         return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND_FOR_FILTER, queryParams.toString());
     }
 
+    /**
+     * Get a specific UDF by id.
+     *
+     * <p>
+     * GET api/v1/catalog/udfs/:ID
+     * </p>
+     * <pre>
+     * {
+     *   "responseCode": 1000,
+     *   "responseMessage": "Success",
+     *   "entity": {
+     *     "id": 48,
+     *     "name": "SUBSTRING",
+     *     "description": "Substring",
+     *     "type": "FUNCTION",
+     *     "className": "builtin"
+     *   }
+     * }
+     * </pre>
+     */
     @GET
     @Path("/udfs/{id}")
     @Timed
@@ -101,22 +156,28 @@ public class UDFCatalogResource {
         return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, id.toString());
     }
 
-    // curl -X POST 'http://localhost:8080/api/v1/catalog/udfs' -F udfJarFile=/tmp/foo-function.jar
-    // -F udfConfig='{"name":"foo", "description": "testing", "type":"FUNCTION", "className":"com.test.Foo"};type=application/json'
+    /**
+     * Add a new UDF.
+     * <p>
+     * curl -X POST 'http://localhost:8080/api/v1/catalog/udfs' -F udfJarFile=/tmp/foo-function.jar
+     * -F udfConfig='{"name":"Foo", "description": "testing", "type":"FUNCTION", "className":"com.test.Foo"};type=application/json'
+     * </p>
+     */
     @Timed
     @POST
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Path("/udfs")
     public Response addUDF(@FormDataParam("udfJarFile") final InputStream inputStream,
-                               @FormDataParam("udfJarFile") final FormDataContentDisposition contentDispositionHeader,
-                               @FormDataParam("udfConfig") final FormDataBodyPart udfConfig) {
+                           @FormDataParam("udfJarFile") final FormDataContentDisposition contentDispositionHeader,
+                           @FormDataParam("udfConfig") final FormDataBodyPart udfConfig,
+                           @FormDataParam("builtin") final boolean builtin) {
         try {
             LOG.debug("Media type {}", udfConfig.getMediaType());
             if (!udfConfig.getMediaType().equals(MediaType.APPLICATION_JSON_TYPE)) {
                 return WSUtils.respond(UNSUPPORTED_MEDIA_TYPE, CatalogResponse.ResponseMessage.UNSUPPORTED_MEDIA_TYPE);
             }
             UDFInfo udfInfo = udfConfig.getValueAs(UDFInfo.class);
-            saveUDF(inputStream, udfInfo);
+            processUdf(inputStream, udfInfo, true, builtin);
             UDFInfo createdUdfInfo = catalogService.addUDF(udfInfo);
             return WSUtils.respond(CREATED, SUCCESS, createdUdfInfo);
         } catch (ProcessingException ex) {
@@ -126,6 +187,26 @@ public class UDFCatalogResource {
         }
     }
 
+    /**
+     * Remove a UDF by ID.
+     *
+     * <p>
+     * DELETE api/v1/catalog/udfs/:ID
+     * </p>
+     * <pre>
+     * {
+     *   "responseCode": 1000,
+     *   "responseMessage": "Success",
+     *   "entity": {
+     *     "id": 48,
+     *     "name": "SUBSTRING",
+     *     "description": "Substring",
+     *     "type": "FUNCTION",
+     *     "className": "builtin"
+     *   }
+     * }
+     * </pre>
+     */
     @DELETE
     @Path("/udfs/{id}")
     @Timed
@@ -142,21 +223,44 @@ public class UDFCatalogResource {
         }
     }
 
+    /**
+     * Update a udf.
+     * <p>
+     *     curl -X PUT 'http://localhost:8080/api/v1/catalog/udfs/34'
+     *     -F udfJarFile=@/tmp/streams-functions-0.1.0-SNAPSHOT.jar
+     *     -F udfConfig='{"name":"stddev", "description": "stddev",
+     *                   "type":"AGGREGATE", "className":"com.hortonworks.iotas.streams.rule.udaf.Stddev"};type=application/json'
+     * </p>
+     * <pre>
+     * {
+     *   "responseCode": 1000,
+     *   "responseMessage": "Success",
+     *   "entity": {
+     *     "id": 48,
+     *     "name": "SUBSTRING",
+     *     "description": "Substring",
+     *     "type": "FUNCTION",
+     *     "className": "builtin"
+     *   }
+     * }
+     * </pre>
+     */
     @PUT
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Path("/udfs/{id}")
     @Timed
     public Response addOrUpdateUDF(@PathParam("id") Long udfId,
-                                       @FormDataParam("udfJarFile") final InputStream inputStream,
-                                       @FormDataParam("udfJarFile") final FormDataContentDisposition contentDispositionHeader,
-                                       @FormDataParam("udfConfig") final FormDataBodyPart udfConfig) {
+                                   @FormDataParam("udfJarFile") final InputStream inputStream,
+                                   @FormDataParam("udfJarFile") final FormDataContentDisposition contentDispositionHeader,
+                                   @FormDataParam("udfConfig") final FormDataBodyPart udfConfig,
+                                   @FormDataParam("builtin") final boolean builtin) {
         try {
             LOG.debug("Media type {}", udfConfig.getMediaType());
             if (!udfConfig.getMediaType().equals(MediaType.APPLICATION_JSON_TYPE)) {
                 return WSUtils.respond(UNSUPPORTED_MEDIA_TYPE, CatalogResponse.ResponseMessage.UNSUPPORTED_MEDIA_TYPE);
             }
             UDFInfo udfInfo = udfConfig.getValueAs(UDFInfo.class);
-            saveUDF(inputStream, udfInfo);
+            processUdf(inputStream, udfInfo, false, builtin);
             UDFInfo newUdfInfo = catalogService.addOrUpdateUDF(udfId, udfInfo);
             return WSUtils.respond(OK, SUCCESS, newUdfInfo);
         } catch (ProcessingException ex) {
@@ -166,11 +270,17 @@ public class UDFCatalogResource {
         }
     }
 
+    /**
+     * Download the jar corresponding to a specific UDF.
+     * <p>
+     * E.g. curl http://localhost:8080/api/v1/catalog/udfs/download/34 -o /tmp/file.jar
+     * </p>
+     */
     @Timed
     @GET
     @Produces({"application/java-archive", "application/json"})
     @Path("/udfs/download/{udfId}")
-    public Response downloadParserJar(@PathParam("udfId") Long udfId) {
+    public Response downloadUdf(@PathParam("udfId") Long udfId) {
         try {
             UDFInfo udfInfo = catalogService.getUDF(udfId);
             if (udfInfo != null) {
@@ -184,16 +294,71 @@ public class UDFCatalogResource {
         return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, udfId.toString());
     }
 
-    private void saveUDF(InputStream is, UDFInfo udfInfo) throws IOException {
+    private void processUdf(InputStream inputStream,
+                            UDFInfo udfInfo,
+                            boolean checkDuplicate,
+                            boolean builtin) throws Exception {
+        if (builtin) {
+            udfInfo.setDigest("builtin");
+            udfInfo.setJarStoragePath("builtin");
+            checkDuplicate(udfInfo);
+        } else {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            File tmpFile;
+            try (DigestInputStream dis = new DigestInputStream(inputStream, md)) {
+                tmpFile = FileUtil.writeInputStreamToTempFile(inputStream, ".jar");
+            }
+            Set<String> udafs = catalogService.loadUdafsFromJar(tmpFile);
+            validateUDF(udafs, udfInfo, checkDuplicate);
+            String digest = Hex.encodeHexString(md.digest());
+            LOG.debug("Digest: {}", digest);
+            udfInfo.setDigest(digest);
+            String jarPath = getExistingJarPath(digest).or(uploadJar(new FileInputStream(tmpFile), udfInfo.getName()));
+            udfInfo.setJarStoragePath(jarPath);
+        }
+    }
+
+    private String uploadJar(InputStream is, String udfName) throws IOException {
+        String uploadedPath;
         if (is != null) {
-            String jarFileName = udfInfo.getName() + "-" + UUID.randomUUID().toString();
-            String uploadedPath = this.fileStorage.uploadFile(is, jarFileName);
-            udfInfo.setJarStoragePath(uploadedPath);
+            String jarFileName = UUID.randomUUID().toString() + ".jar";
+            uploadedPath = this.fileStorage.uploadFile(is, jarFileName);
             LOG.debug("Jar uploaded to {}", uploadedPath);
         } else {
-            String message = String.format("Udf %s jar content is missing.", udfInfo.getName());
+            String message = String.format("Udf %s jar content is missing.", udfName);
             LOG.error(message);
             throw new IllegalArgumentException(message);
         }
+        return uploadedPath;
+    }
+
+    private void validateUDF(Set<String> udfs, UDFInfo udfInfo, boolean checkDuplicate) {
+        if (!udfs.contains(udfInfo.getClassName())) {
+            throw new RuntimeException("Cannot load class from uploaded Jar: " + udfInfo.getClassName());
+        }
+        LOG.debug("Validating UDF, Class {} is in the available classes {}", udfInfo.getClassName(), udfs);
+        if (checkDuplicate) {
+            checkDuplicate(udfInfo);
+        }
+    }
+
+    private void checkDuplicate(UDFInfo udfInfo) {
+        Collection<UDFInfo> existing = catalogService.listUDFs(
+                Collections.singletonList(new QueryParam(UDFInfo.NAME, udfInfo.getName())));
+        if (!existing.isEmpty()) {
+            throw new RuntimeException("UDF with the same name already exists, use update (PUT) api instead");
+        }
+    }
+
+    /**
+     * See if there is already a jar with the same digest
+     */
+    private Optional<String> getExistingJarPath(String digest) {
+        Collection<UDFInfo> existing = catalogService.listUDFs(
+                Collections.singletonList(new QueryParam(UDFInfo.DIGEST, digest)));
+        if (existing.size() >= 1) {
+            return Optional.of(existing.iterator().next().getJarStoragePath());
+        }
+        return Optional.absent();
     }
 }


### PR DESCRIPTION
1. Added a new module for built-in functions that we provide and a bootstrap script to load them
2. Topology deployment code now bundles the appropriate udf jars while submitting the topology (using --jars option)
3. Added a few basic aggregate functions

Note: this depends on https://github.com/apache/storm/pull/1706
