### PR TITLE
IOT-392 ClusterConfiguration should be able to take in ambari url and grab component configurations

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -47,6 +47,14 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-properties</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.fge</groupId>
             <artifactId>json-schema-validator</artifactId>
             <exclusions>

--- a/common/src/main/java/com/hortonworks/iotas/common/catalog/CatalogResponse.java
+++ b/common/src/main/java/com/hortonworks/iotas/common/catalog/CatalogResponse.java
@@ -30,7 +30,9 @@ public class CatalogResponse {
         DATASOURCE_SCHEMA_NOT_UNIQUE(1107, "Datasource has [%s] datafeeds and cannot be mapped to a unique schema.", 1),
         CUSTOM_PROCESSOR_ONLY(1108, "Custom endpoint supported only for processors.", 0),
         UNSUPPORTED_MEDIA_TYPE(1109, "Unsupported Media Type", 0),
-        BAD_REQUEST(1110, "Bad Request", 0);
+        BAD_REQUEST(1110, "Bad Request", 0),
+        IMPORT_ALREADY_IN_PROGRESS(1111, "Cluster [%s] is already in progress of import.", 1),
+        ENTITY_BY_NAME_NOT_FOUND(1102, "Entity with name [%s] not found.", 1);
 
         private final int code;
         private final String msg;

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,16 @@
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-xml</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-properties</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>

--- a/registries/tag-registry/src/main/java/com/hortonworks/iotas/registries/tag/service/TagCatalogResource.java
+++ b/registries/tag-registry/src/main/java/com/hortonworks/iotas/registries/tag/service/TagCatalogResource.java
@@ -150,7 +150,6 @@ public class TagCatalogResource {
     @GET
     @Path("/tags/{id}")
     @Timed
-    @Produces(MediaType.APPLICATION_JSON)
     public Response getTagById(@PathParam("id") Long tagId) {
         try {
             Tag result = tagService.getTag(tagId);
@@ -420,7 +419,6 @@ public class TagCatalogResource {
     @GET
     @Path("/tags/{id}/entities")
     @Timed
-    @Produces(MediaType.APPLICATION_JSON)
     public Response getTaggedEntities(@PathParam("id") Long tagId) {
         try {
             List<TaggedEntity> result = tagService.getEntities(tagId, true);
@@ -458,7 +456,6 @@ public class TagCatalogResource {
     @GET
     @Path("/taggedentities/{namespace}/{id}/tags")
     @Timed
-    @Produces(MediaType.APPLICATION_JSON)
     public Response getTagsForEntity(@PathParam("namespace") String namespace, @PathParam("id") Long entityId) {
         try {
             List<Tag> tags = tagService.getTags(new TaggedEntity(namespace, entityId));

--- a/storage/core/src/main/resources/mysql/create_tables.sql
+++ b/storage/core/src/main/resources/mysql/create_tables.sql
@@ -221,3 +221,42 @@ CREATE TABLE IF NOT EXISTS udfs (
     digest VARCHAR(256) NOT NULL,
     PRIMARY KEY (id)
 );
+
+CREATE TABLE IF NOT EXISTS clusters (
+  id BIGINT AUTO_INCREMENT NOT NULL,
+  name VARCHAR(256) NOT NULL,
+  description VARCHAR(256),
+  timestamp BIGINT,
+  PRIMARY KEY (id)
+)
+
+CREATE TABLE IF NOT EXISTS services (
+  id BIGINT AUTO_INCREMENT NOT NULL,
+  clusterId BIGINT NOT NULL,
+  name VARCHAR(256) NOT NULL,
+  description VARCHAR(256),
+  timestamp BIGINT,
+  PRIMARY KEY (id)
+)
+
+CREATE TABLE IF NOT EXISTS service_configurations (
+  id BIGINT AUTO_INCREMENT NOT NULL,
+  serviceId BIGINT NOT NULL,
+  name VARCHAR(256) NOT NULL,
+  configuration TEXT NOT NULL,
+  description VARCHAR(256),
+  filename VARCHAR(256),
+  timestamp BIGINT,
+  PRIMARY KEY (id)
+)
+
+CREATE TABLE IF NOT EXISTS components (
+  id BIGINT AUTO_INCREMENT NOT NULL,
+  serviceId BIGINT NOT NULL,
+  name VARCHAR(256) NOT NULL,
+  hosts TEXT NOT NULL,
+  protocol VARCHAR(256),
+  port BIGINT,
+  timestamp BIGINT,
+  PRIMARY KEY (id)
+)

--- a/storage/core/src/main/resources/mysql/drop_tables.sql
+++ b/storage/core/src/main/resources/mysql/drop_tables.sql
@@ -17,3 +17,7 @@ DROP TABLE IF EXISTS topology_edges;
 DROP TABLE IF EXISTS ruleinfos;
 DROP TABLE IF EXISTS windowinfos;
 DROP TABLE IF EXISTS udfs;
+DROP TABLE IF EXISTS clusters;
+DROP TABLE IF EXISTS services;
+DROP TABLE IF EXISTS service_configurations;
+DROP TABLE IF EXISTS components;

--- a/storage/core/src/main/resources/phoenix/create_tables.sql
+++ b/storage/core/src/main/resources/phoenix/create_tables.sql
@@ -20,7 +20,12 @@ CREATE TABLE IF NOT EXISTS topology_edges ("id" BIGINT NOT NULL, "topologyId" BI
 CREATE TABLE IF NOT EXISTS ruleinfos ("id" BIGINT NOT NULL, "topologyId" BIGINT, "name" VARCHAR, "description" VARCHAR, "streams" VARCHAR, "condition" VARCHAR, "sql" VARCHAR, "parsedRuleStr" VARCHAR, "window" VARCHAR, "actions" VARCHAR, CONSTRAINT pk PRIMARY KEY ("id"))
 CREATE TABLE IF NOT EXISTS windowinfos ("id" BIGINT NOT NULL, "topologyId" BIGINT, "name" VARCHAR, "description" VARCHAR, "streams" VARCHAR, "condition" VARCHAR, "parsedRuleStr" VARCHAR, "window" VARCHAR, "actions" VARCHAR, "projections" VARCHAR, "groupbykeys" VARCHAR, CONSTRAINT pk PRIMARY KEY ("id"))
 CREATE TABLE IF NOT EXISTS udfs ("id" BIGINT NOT NULL, "name" VARCHAR, "description" VARCHAR, "type" VARCHAR, "className" VARCHAR, "jarStoragePath" VARCHAR, "digest" VARCHAR, CONSTRAINT pk PRIMARY KEY ("id"))
-CREATE TABLE IF NOT EXISTS sequence_table ("id" VARCHAR, "datasources" BIGINT, "datafeeds" BIGINT, "parser_info" BIGINT, "files" BIGINT, "topologies" BIGINT, "topology_component_definitions" BIGINT, "topology_components" BIGINT, "tag" BIGINT,  "streaminfo" BIGINT, "notifierinfos" BIGINT, "topology_sources" BIGINT, "topology_sinks" BIGINT, "topology_processors" BIGINT, "topology_edges" BIGINT, "ruleinfos" BIGINT, "windowinfos" BIGINT, "udfs" BIGINT, CONSTRAINT pk PRIMARY KEY ("id"))
+CREATE TABLE IF NOT EXISTS clusters ("id" BIGINT NOT NULL, "name" VARCHAR NOT NULL, "description" VARCHAR, "timestamp" BIGINT, CONSTRAINT pk PRIMARY KEY ("id"))
+CREATE TABLE IF NOT EXISTS services ("id" BIGINT NOT NULL, "clusterId" BIGINT NOT NULL, "name" VARCHAR NOT NULL, "description" VARCHAR, "timestamp" BIGINT, CONSTRAINT pk PRIMARY KEY ("id"))
+CREATE TABLE IF NOT EXISTS service_configurations ("id" BIGINT NOT NULL, "serviceId" BIGINT NOT NULL, "name" VARCHAR NOT NULL, "configuration" VARCHAR NOT NULL, "description" VARCHAR, "filename" VARCHAR, "timestamp" BIGINT, CONSTRAINT pk PRIMARY KEY ("id"))
+CREATE TABLE IF NOT EXISTS components ("id" BIGINT NOT NULL, "serviceId" BIGINT NOT NULL, "name" VARCHAR NOT NULL, "hosts" VARCHAR NOT NULL, "protocol" VARCHAR, "port" BIGINT, "timestamp" BIGINT, CONSTRAINT pk PRIMARY KEY ("id"))
+CREATE TABLE IF NOT EXISTS sequence_table ("id" VARCHAR, "datasources" BIGINT, "datafeeds" BIGINT, "parser_info" BIGINT, "files" BIGINT, "topologies" BIGINT, "topology_component_definitions" BIGINT, "topology_components" BIGINT, "tag" BIGINT,  "streaminfo" BIGINT, "notifierinfos" BIGINT, "topology_sources" BIGINT, "topology_sinks" BIGINT, "topology_processors" BIGINT, "topology_edges" BIGINT, "ruleinfos" BIGINT, "windowinfos" BIGINT, "udfs" BIGINT, "clusters" BIGINT, "services" BIGINT, "service_configurations" BIGINT, "components" BIGINT CONSTRAINT pk PRIMARY KEY ("id"))
+
 CREATE SEQUENCE IF NOT EXISTS datasources_sequence
 CREATE SEQUENCE IF NOT EXISTS datafeeds_sequence
 CREATE SEQUENCE IF NOT EXISTS parser_info_sequence
@@ -38,3 +43,7 @@ CREATE SEQUENCE IF NOT EXISTS topology_edges_sequence
 CREATE SEQUENCE IF NOT EXISTS ruleinfos_sequence
 CREATE SEQUENCE IF NOT EXISTS windowinfos_sequence
 CREATE SEQUENCE IF NOT EXISTS udfs_sequence
+CREATE SEQUENCE IF NOT EXISTS clusters_sequence
+CREATE SEQUENCE IF NOT EXISTS services_sequence
+CREATE SEQUENCE IF NOT EXISTS service_configurations_sequence
+CREATE SEQUENCE IF NOT EXISTS components_sequence

--- a/storage/core/src/main/resources/phoenix/drop_tables.sql
+++ b/storage/core/src/main/resources/phoenix/drop_tables.sql
@@ -20,6 +20,10 @@ DROP TABLE IF EXISTS notifierinfos
 DROP TABLE IF EXISTS ruleinfos
 DROP TABLE IF EXISTS windowinfos
 DROP TABLE IF EXISTS udfs
+DROP TABLE IF EXISTS clusters
+DROP TABLE IF EXISTS services
+DROP TABLE IF EXISTS service_configurations
+DROP TABLE IF EXISTS components
 DROP SEQUENCE IF EXISTS datasources_sequence
 DROP SEQUENCE IF EXISTS datafeeds_sequence
 DROP SEQUENCE IF EXISTS parser_info_sequence
@@ -37,3 +41,7 @@ DROP SEQUENCE IF EXISTS topology_edges_sequence
 DROP SEQUENCE IF EXISTS ruleinfos_sequence
 DROP SEQUENCE IF EXISTS windowinfos_sequence
 DROP SEQUENCE IF EXISTS udfs_sequence
+DROP SEQUENCE IF EXISTS clusters_sequence
+DROP SEQUENCE IF EXISTS services_sequence
+DROP SEQUENCE IF EXISTS service_configurations_sequence
+DROP SEQUENCE IF EXISTS components_sequence

--- a/streams/catalog/pom.xml
+++ b/streams/catalog/pom.xml
@@ -46,6 +46,11 @@
         </dependency>
         <dependency>
             <groupId>com.hortonworks.iotas</groupId>
+            <artifactId>streams-cluster</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.hortonworks.iotas</groupId>
             <artifactId>tag-registry</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
@@ -61,10 +66,12 @@
             <artifactId>commons-io</artifactId>
             <version>2.1</version>
         </dependency>
+
+        <!-- needed for pretty print xml configuration file -->
         <dependency>
-            <groupId>com.hortonworks.registries</groupId>
-            <artifactId>schema-registry-avro</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>woodstox-core-asl</artifactId>
+            <version>4.4.1</version>
         </dependency>
 
         <!--test-->

--- a/streams/catalog/src/main/java/com/hortonworks/iotas/streams/catalog/Cluster.java
+++ b/streams/catalog/src/main/java/com/hortonworks/iotas/streams/catalog/Cluster.java
@@ -8,23 +8,17 @@ import com.hortonworks.iotas.storage.catalog.AbstractStorable;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Logical cluster which contains services.
+ * @see Service
+ */
 public class Cluster extends AbstractStorable {
-    private static final String NAMESPACE = "cluster";
-    /**
-     * The cluster type
-     */
-    public enum Type {
-        STORM, KAFKA, HDFS, HBASE
-    }
+    private static final String NAMESPACE = "clusters";
 
     private Long id;
     private String name;
-    private Type type;
     private String description = "";
-    private String tags = "";
     private Long timestamp;
-    private String clusterConfigFileName;
-    private String clusterConfigStorageName;
 
     /**
      * The name of the cluster
@@ -38,18 +32,6 @@ public class Cluster extends AbstractStorable {
     }
 
     /**
-     * The type of the cluster. Should be one of {@link Cluster.Type}
-     */
-    public Type getType() {
-        return type;
-    }
-
-    public void setType(Type type) {
-        this.type = type;
-    }
-
-
-    /**
      * The cluster description (optional)
      */
     public String getDescription() {
@@ -58,18 +40,6 @@ public class Cluster extends AbstractStorable {
 
     public void setDescription(String description) {
         this.description = description;
-    }
-
-
-    /**
-     * A comma separated tags associated with the cluster (optional)
-     */
-    public String getTags() {
-        return tags;
-    }
-
-    public void setTags(String tags) {
-        this.tags = tags;
     }
 
     /**
@@ -96,28 +66,6 @@ public class Cluster extends AbstractStorable {
         this.timestamp = timestamp;
     }
 
-    /**
-     * Name of cluster specific config file. E.g. hdfs-site.xml, hbase-site.xml etc
-     */
-    public String getClusterConfigFileName() {
-        return clusterConfigFileName;
-    }
-
-    public void setClusterConfigFileName(String clusterConfigFileName) {
-        this.clusterConfigFileName = clusterConfigFileName;
-    }
-
-    /**
-     * The actual name with which the file is stored in the storage. E.g. hdfs-site.xml-UUID
-     */
-    public String getClusterConfigStorageName() {
-        return clusterConfigStorageName;
-    }
-
-    public void setClusterConfigStorageName(String clusterConfigStorageName) {
-        this.clusterConfigStorageName = clusterConfigStorageName;
-    }
-
     @JsonIgnore
     public PrimaryKey getPrimaryKey() {
         Map<Schema.Field, Object> fieldToObjectMap = new HashMap<>();
@@ -128,32 +76,29 @@ public class Cluster extends AbstractStorable {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof Cluster)) return false;
 
         Cluster cluster = (Cluster) o;
 
-        if (id != null ? !id.equals(cluster.id) : cluster.id != null) return false;
-        if (name != null ? !name.equals(cluster.name) : cluster.name != null) return false;
-        if (type != cluster.type) return false;
-        if (description != null ? !description.equals(cluster.description) : cluster.description != null) return false;
-        if (tags != null ? !tags.equals(cluster.tags) : cluster.tags != null) return false;
-        if (timestamp != null ? !timestamp.equals(cluster.timestamp) : cluster.timestamp != null) return false;
-        if (clusterConfigFileName != null ? !clusterConfigFileName.equals(cluster.clusterConfigFileName) : cluster.clusterConfigFileName != null)
+        if (getId() != null ? !getId().equals(cluster.getId()) : cluster.getId() != null)
             return false;
-        return clusterConfigStorageName != null ? clusterConfigStorageName.equals(cluster.clusterConfigStorageName) : cluster.clusterConfigStorageName == null;
+        if (getName() != null ? !getName().equals(cluster.getName()) : cluster.getName() != null)
+            return false;
+        if (getDescription() != null ?
+            !getDescription().equals(cluster.getDescription()) :
+            cluster.getDescription() != null) return false;
+        return getTimestamp() != null ?
+            getTimestamp().equals(cluster.getTimestamp()) :
+            cluster.getTimestamp() == null;
 
     }
 
     @Override
     public int hashCode() {
-        int result = id != null ? id.hashCode() : 0;
-        result = 31 * result + (name != null ? name.hashCode() : 0);
-        result = 31 * result + (type != null ? type.hashCode() : 0);
-        result = 31 * result + (description != null ? description.hashCode() : 0);
-        result = 31 * result + (tags != null ? tags.hashCode() : 0);
-        result = 31 * result + (timestamp != null ? timestamp.hashCode() : 0);
-        result = 31 * result + (clusterConfigFileName != null ? clusterConfigFileName.hashCode() : 0);
-        result = 31 * result + (clusterConfigStorageName != null ? clusterConfigStorageName.hashCode() : 0);
+        int result = getId() != null ? getId().hashCode() : 0;
+        result = 31 * result + (getName() != null ? getName().hashCode() : 0);
+        result = 31 * result + (getDescription() != null ? getDescription().hashCode() : 0);
+        result = 31 * result + (getTimestamp() != null ? getTimestamp().hashCode() : 0);
         return result;
     }
 
@@ -162,12 +107,8 @@ public class Cluster extends AbstractStorable {
         return "Cluster{" +
                 "id=" + id +
                 ", name='" + name + '\'' +
-                ", type=" + type +
                 ", description='" + description + '\'' +
-                ", tags='" + tags + '\'' +
                 ", timestamp=" + timestamp +
-                ", clusterConfigFileName='" + clusterConfigFileName + '\'' +
-                ", clusterConfigStorageName='" + clusterConfigStorageName + '\'' +
                 "}";
     }
 }

--- a/streams/catalog/src/main/java/com/hortonworks/iotas/streams/catalog/Component.java
+++ b/streams/catalog/src/main/java/com/hortonworks/iotas/streams/catalog/Component.java
@@ -6,27 +6,25 @@ import com.hortonworks.iotas.storage.PrimaryKey;
 import com.hortonworks.iotas.storage.catalog.AbstractStorable;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+/**
+ * Component represents an indivial component of Service. For example, NIMBUS, BROKER, etc.
+ */
 public class Component extends AbstractStorable {
-    private static final String NAMESPACE = "component";
-
-    /**
-     * The component types
-     * to ensure that we are dealing with known types
-     */
-    public enum ComponentType {
-        NIMBUS, SUPERVISOR, UI, ZOOKEEPER, BROKER, NAMENODE, DATANODE
-    }
+    private static final String NAMESPACE = "components";
 
     private Long id;
-    private Long clusterId;
+    private Long serviceId;
     private String name;
-    private ComponentType type;
-    private String description = "";
-    private String config = "";
-    private String hosts;
-    private int port;
+    private List<String> hosts;
+
+    // The protocol for communicating with this port.
+    // Its representation is up to component.
+    // For example. protocols for KAFKA are PLAINTEXT, SSL, etc.
+    private String protocol;
+    private Integer port;
     private Long timestamp;
 
     /**
@@ -41,14 +39,14 @@ public class Component extends AbstractStorable {
     }
 
     /**
-     * The foreign key reference to the cluster id.
+     * The foreign key reference to the service id.
      */
-    public Long getClusterId() {
-        return clusterId;
+    public Long getServiceId() {
+        return serviceId;
     }
 
-    public void setClusterId(Long clusterId) {
-        this.clusterId = clusterId;
+    public void setServiceId(Long serviceId) {
+        this.serviceId = serviceId;
     }
 
     /**
@@ -63,57 +61,35 @@ public class Component extends AbstractStorable {
     }
 
     /**
-     * The type of the component (Nimbus, Broker etc).
-     */
-    public ComponentType getType() {
-        return type;
-    }
-
-    public void setType(ComponentType type) {
-        this.type = type;
-    }
-
-    /**
-     * Component description.
-     */
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    /**
-     * Component specific config.
-     */
-    public String getConfig() {
-        return config;
-    }
-
-    public void setConfig(String config) {
-        this.config = config;
-    }
-
-    /**
      * The set of hosts where the component runs.
      */
-    public String getHosts() {
+    public List<String> getHosts() {
         return hosts;
     }
 
-    public void setHosts(String hosts) {
+    public void setHosts(List<String> hosts) {
         this.hosts = hosts;
     }
 
     /**
-     * The port where the component listens.
+     * The protocol where the component communicates. (optional)
      */
-    public int getPort() {
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    /**
+     * The port where the component listens. (optional)
+     */
+    public Integer getPort() {
         return port;
     }
 
-    public void setPort(int port) {
+    public void setPort(Integer port) {
         this.port = port;
     }
 
@@ -144,43 +120,46 @@ public class Component extends AbstractStorable {
 
         Component component = (Component) o;
 
-        if (port != component.port) return false;
-        if (id != null ? !id.equals(component.id) : component.id != null) return false;
-        if (clusterId != null ? !clusterId.equals(component.clusterId) : component.clusterId != null) return false;
-        if (name != null ? !name.equals(component.name) : component.name != null) return false;
-        if (type != component.type) return false;
-        if (description != null ? !description.equals(component.description) : component.description != null)
+        if (getId() != null ? !getId().equals(component.getId()) : component.getId() != null)
             return false;
-        if (config != null ? !config.equals(component.config) : component.config != null) return false;
-        return !(hosts != null ? !hosts.equals(component.hosts) : component.hosts != null);
+        if (getServiceId() != null ?
+            !getServiceId().equals(component.getServiceId()) :
+            component.getServiceId() != null) return false;
+        if (getName() != null ?
+            !getName().equals(component.getName()) :
+            component.getName() != null) return false;
+        if (getHosts() != null ?
+            !getHosts().equals(component.getHosts()) :
+            component.getHosts() != null) return false;
+        if (getPort() != null ?
+            !getPort().equals(component.getPort()) :
+            component.getPort() != null) return false;
+        return getTimestamp() != null ?
+            getTimestamp().equals(component.getTimestamp()) :
+            component.getTimestamp() == null;
 
     }
 
     @Override
     public int hashCode() {
-        int result = id != null ? id.hashCode() : 0;
-        result = 31 * result + (clusterId != null ? clusterId.hashCode() : 0);
-        result = 31 * result + (name != null ? name.hashCode() : 0);
-        result = 31 * result + (type != null ? type.hashCode() : 0);
-        result = 31 * result + (description != null ? description.hashCode() : 0);
-        result = 31 * result + (config != null ? config.hashCode() : 0);
-        result = 31 * result + (hosts != null ? hosts.hashCode() : 0);
-        result = 31 * result + port;
+        int result = getId() != null ? getId().hashCode() : 0;
+        result = 31 * result + (getServiceId() != null ? getServiceId().hashCode() : 0);
+        result = 31 * result + (getName() != null ? getName().hashCode() : 0);
+        result = 31 * result + (getHosts() != null ? getHosts().hashCode() : 0);
+        result = 31 * result + (getPort() != null ? getPort().hashCode() : 0);
+        result = 31 * result + (getTimestamp() != null ? getTimestamp().hashCode() : 0);
         return result;
     }
 
     @Override
     public String toString() {
         return "Component{" +
-                "id=" + id +
-                ", clusterId=" + clusterId +
-                ", name='" + name + '\'' +
-                ", type=" + type +
-                ", description='" + description + '\'' +
-                ", config='" + config + '\'' +
-                ", hosts='" + hosts + '\'' +
-                ", port=" + port +
-                ", timestamp=" + timestamp +
-                '}';
+            "id=" + id +
+            ", serviceId=" + serviceId +
+            ", name='" + name + '\'' +
+            ", hosts=" + hosts +
+            ", port=" + port +
+            ", timestamp=" + timestamp +
+            '}';
     }
 }

--- a/streams/catalog/src/main/java/com/hortonworks/iotas/streams/catalog/Service.java
+++ b/streams/catalog/src/main/java/com/hortonworks/iotas/streams/catalog/Service.java
@@ -1,0 +1,132 @@
+package com.hortonworks.iotas.streams.catalog;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.hortonworks.iotas.common.Schema;
+import com.hortonworks.iotas.storage.PrimaryKey;
+import com.hortonworks.iotas.storage.catalog.AbstractStorable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Service represents a component of system. For example, STORM, KAFKA, etc.
+ */
+public class Service extends AbstractStorable {
+  private static final String NAMESPACE = "services";
+
+  private Long id;
+  private Long clusterId;
+  private String name;
+  private String description = "";
+  private Long timestamp;
+
+  /**
+   * The primary key
+   */
+  @Override
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  /**
+   * The foreign key reference to the cluster id.
+   */
+  public Long getClusterId() {
+    return clusterId;
+  }
+
+  public void setClusterId(Long clusterId) {
+    this.clusterId = clusterId;
+  }
+
+  /**
+   * The name of the cluster
+   */
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /**
+   * The cluster description (optional)
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public Long getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(Long timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  @JsonIgnore
+  @Override
+  public String getNameSpace() {
+    return NAMESPACE;
+  }
+
+  @JsonIgnore
+  @Override
+  public PrimaryKey getPrimaryKey() {
+    Map<Schema.Field, Object> fieldToObjectMap = new HashMap<Schema.Field, Object>();
+    fieldToObjectMap.put(new Schema.Field("id", Schema.Type.LONG), this.id);
+    return new PrimaryKey(fieldToObjectMap);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof Service)) return false;
+
+    Service service = (Service) o;
+
+    if (getId() != null ? !getId().equals(service.getId()) : service.getId() != null) return false;
+    if (getClusterId() != null ?
+        !getClusterId().equals(service.getClusterId()) :
+        service.getClusterId() != null) return false;
+    if (getName() != null ? !getName().equals(service.getName()) : service.getName() != null)
+      return false;
+    if (getDescription() != null ?
+        !getDescription().equals(service.getDescription()) :
+        service.getDescription() != null) return false;
+    return getTimestamp() != null ?
+        getTimestamp().equals(service.getTimestamp()) :
+        service.getTimestamp() == null;
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = getId() != null ? getId().hashCode() : 0;
+    result = 31 * result + (getClusterId() != null ? getClusterId().hashCode() : 0);
+    result = 31 * result + (getName() != null ? getName().hashCode() : 0);
+    result = 31 * result + (getDescription() != null ? getDescription().hashCode() : 0);
+    result = 31 * result + (getTimestamp() != null ? getTimestamp().hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "Service{" +
+        "id=" + id +
+        ", clusterId='" + clusterId + '\'' +
+        ", name='" + name + '\'' +
+        ", description='" + description + '\'' +
+        ", timestamp=" + timestamp +
+        "}";
+  }
+}

--- a/streams/catalog/src/main/java/com/hortonworks/iotas/streams/catalog/ServiceConfiguration.java
+++ b/streams/catalog/src/main/java/com/hortonworks/iotas/streams/catalog/ServiceConfiguration.java
@@ -1,0 +1,166 @@
+package com.hortonworks.iotas.streams.catalog;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.hortonworks.iotas.common.Schema;
+import com.hortonworks.iotas.storage.PrimaryKey;
+import com.hortonworks.iotas.storage.catalog.AbstractStorable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Catalog that matches one configuration file of service.
+ */
+public class ServiceConfiguration extends AbstractStorable {
+  private static final String NAMESPACE = "service_configurations";
+
+  private Long id;
+  private Long serviceId;
+  private String name;
+  private String configuration;
+  private String description = "";
+  private String filename = "";
+  private Long timestamp;
+
+  /**
+   * The primary key
+   */
+  @Override
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  /**
+   * The foreign key reference to the service id.
+   */
+  public Long getServiceId() {
+    return serviceId;
+  }
+
+  public void setServiceId(Long serviceId) {
+    this.serviceId = serviceId;
+  }
+
+  /**
+   * The name of the configuration. (e.g storm-site)
+   */
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /**
+   * The configuration represented to JSON.
+   */
+  public String getConfiguration() {
+    return configuration;
+  }
+
+  public void setConfiguration(String configuration) {
+    this.configuration = configuration;
+  }
+
+  /**
+   * The configuration description (optional)
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  /**
+   * Actual file name of configuration. (optional)
+   */
+  public String getFilename() {
+    return filename;
+  }
+
+  public void setFilename(String filename) {
+    this.filename = filename;
+  }
+
+  public Long getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(Long timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  @JsonIgnore
+  @Override
+  public String getNameSpace() {
+    return NAMESPACE;
+  }
+
+  @JsonIgnore
+  @Override
+  public PrimaryKey getPrimaryKey() {
+    Map<Schema.Field, Object> fieldToObjectMap = new HashMap<Schema.Field, Object>();
+    fieldToObjectMap.put(new Schema.Field("id", Schema.Type.LONG), this.id);
+    return new PrimaryKey(fieldToObjectMap);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof ServiceConfiguration)) return false;
+
+    ServiceConfiguration that = (ServiceConfiguration) o;
+
+    if (getId() != null ? !getId().equals(that.getId()) : that.getId() != null) return false;
+    if (getServiceId() != null ?
+        !getServiceId().equals(that.getServiceId()) :
+        that.getServiceId() != null) return false;
+    if (getName() != null ? !getName().equals(that.getName()) : that.getName() != null)
+      return false;
+    if (getConfiguration() != null ?
+        !getConfiguration().equals(that.getConfiguration()) :
+        that.getConfiguration() != null) return false;
+    if (getDescription() != null ?
+        !getDescription().equals(that.getDescription()) :
+        that.getDescription() != null) return false;
+    if (getFilename() != null ?
+        !getFilename().equals(that.getFilename()) :
+        that.getFilename() != null) return false;
+    return getTimestamp() != null ?
+        getTimestamp().equals(that.getTimestamp()) :
+        that.getTimestamp() == null;
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = getId() != null ? getId().hashCode() : 0;
+    result = 31 * result + (getServiceId() != null ? getServiceId().hashCode() : 0);
+    result = 31 * result + (getName() != null ? getName().hashCode() : 0);
+    result = 31 * result + (getConfiguration() != null ? getConfiguration().hashCode() : 0);
+    result = 31 * result + (getDescription() != null ? getDescription().hashCode() : 0);
+    result = 31 * result + (getFilename() != null ? getFilename().hashCode() : 0);
+    result = 31 * result + (getTimestamp() != null ? getTimestamp().hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "ServiceConfiguration{" +
+        "id=" + id +
+        ", serviceId=" + serviceId +
+        ", name='" + name + '\'' +
+        ", configuration='" + configuration + '\'' +
+        ", description='" + description + '\'' +
+        ", filename='" + filename + '\'' +
+        ", timestamp=" + timestamp +
+        '}';
+  }
+}

--- a/streams/catalog/src/main/java/com/hortonworks/iotas/streams/catalog/configuration/ConfigFileType.java
+++ b/streams/catalog/src/main/java/com/hortonworks/iotas/streams/catalog/configuration/ConfigFileType.java
@@ -1,0 +1,31 @@
+package com.hortonworks.iotas.streams.catalog.configuration;
+
+import com.google.common.io.Files;
+
+/**
+ * Defines configuration file's type. It is needed for writing configuration map to file.
+ * @see ConfigFileWriter
+ */
+public enum ConfigFileType {
+  HADOOP_XML, PROPERTIES, YAML;
+
+  public static ConfigFileType getFileTypeFromFileName(String fileName) {
+    String fileExt = Files.getFileExtension(fileName);
+    if (fileExt.isEmpty()) {
+      return null;
+    }
+
+    switch (fileExt) {
+    case "properties":
+      return PROPERTIES;
+    case "xml":
+      // NOTE: If there're other types of xml rather than Hadoop-configuration-like,
+      // we shouldn't guess it only based on extension.
+      return HADOOP_XML;
+    case "yaml":
+      return YAML;
+    }
+
+    return null;
+  }
+}

--- a/streams/catalog/src/main/java/com/hortonworks/iotas/streams/catalog/configuration/ConfigFileWriter.java
+++ b/streams/catalog/src/main/java/com/hortonworks/iotas/streams/catalog/configuration/ConfigFileWriter.java
@@ -1,0 +1,116 @@
+package com.hortonworks.iotas.streams.catalog.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.javaprop.JavaPropsMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Writer that write configuration to file based on the file type.
+ */
+public class ConfigFileWriter {
+  public void writeConfigToFile(ConfigFileType confFileType, Map<String, Object> configuration,
+      File destPath) throws IOException {
+    if (confFileType == null) {
+      throw new IllegalArgumentException("You should provide valid config file type to write configuration to file. file type: " + confFileType);
+    }
+
+    switch (confFileType) {
+    case HADOOP_XML:
+      writeConfigToHadoopXmlTypeFile(configuration, destPath);
+      break;
+
+    case PROPERTIES:
+      writeConfigToPropertiesTypeFile(configuration, destPath);
+      break;
+
+    case YAML:
+      writeConfigToYamlTypeFile(configuration, destPath);
+      break;
+
+    default:
+      throw new IllegalArgumentException("Writer doesn't know how to write such kind of file type. file type: " + confFileType);
+    }
+  }
+
+  private void writeConfigToHadoopXmlTypeFile(Map<String, Object> configuration, File destPath)
+      throws IOException {
+    ObjectMapper objectMapper = new XmlMapper();
+    objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+    HadoopXml hadoopXml = new HadoopXml();
+    for (Map.Entry<String, Object> property : configuration.entrySet()) {
+      hadoopXml.addProperty(new HadoopXmlProperty(property.getKey(), property.getValue()));
+    }
+
+    objectMapper.writeValue(destPath, hadoopXml);
+  }
+
+  private void writeConfigToPropertiesTypeFile(Map<String, Object> configuration, File destPath)
+      throws IOException {
+    ObjectMapper objectMapper = new JavaPropsMapper();
+    objectMapper.writeValue(destPath, configuration);
+  }
+
+  private void writeConfigToYamlTypeFile(Map<String, Object> configuration, File destPath)
+      throws IOException {
+    ObjectMapper objectMapper = new YAMLMapper();
+    objectMapper.writeValue(destPath, configuration);
+  }
+
+  @JacksonXmlRootElement(localName = "configuration")
+  static class HadoopXml {
+    @JacksonXmlElementWrapper(useWrapping = false)
+    @JacksonXmlProperty(localName = "property")
+    private List<HadoopXmlProperty> properties = new ArrayList<>();
+
+    public List<HadoopXmlProperty> getProperties() {
+      return properties;
+    }
+
+    public void setProperties(List<HadoopXmlProperty> properties) {
+      this.properties = properties;
+    }
+
+    public void addProperty(HadoopXmlProperty property) {
+      properties.add(property);
+    }
+  }
+
+  static class HadoopXmlProperty {
+    private String name;
+    private Object value;
+
+    public HadoopXmlProperty(String name, Object value) {
+      this.name = name;
+      this.value = value;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public Object getValue() {
+      return value;
+    }
+
+    public void setValue(Object value) {
+      this.value = value;
+    }
+  }
+
+}

--- a/streams/catalog/src/test/java/com/hortonworks/iotas/streams/catalog/configuration/ConfigFileTypeTest.java
+++ b/streams/catalog/src/test/java/com/hortonworks/iotas/streams/catalog/configuration/ConfigFileTypeTest.java
@@ -1,0 +1,17 @@
+package com.hortonworks.iotas.streams.catalog.configuration;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ConfigFileTypeTest {
+  @Test
+  public void getFileTypeFromFileName() throws Exception {
+    assertEquals(ConfigFileType.HADOOP_XML, ConfigFileType.getFileTypeFromFileName("core-site.xml"));
+    assertEquals(ConfigFileType.YAML, ConfigFileType.getFileTypeFromFileName("storm.yaml"));
+    assertEquals(ConfigFileType.PROPERTIES, ConfigFileType.getFileTypeFromFileName("config.properties"));
+    assertNull(ConfigFileType.getFileTypeFromFileName("config"));
+    assertNull(ConfigFileType.getFileTypeFromFileName("config.hadoop"));
+  }
+
+}

--- a/streams/catalog/src/test/java/com/hortonworks/iotas/streams/catalog/configuration/ConfigFileWriterTest.java
+++ b/streams/catalog/src/test/java/com/hortonworks/iotas/streams/catalog/configuration/ConfigFileWriterTest.java
@@ -1,0 +1,112 @@
+package com.hortonworks.iotas.streams.catalog.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ConfigFileWriterTest {
+
+  private ConfigFileWriter writer = new ConfigFileWriter();
+
+  @Test
+  public void writeHadoopXmlConfigToFile() throws Exception {
+    Map<String, Object> configuration = createDummyConfiguration();
+
+    File destPath = Files.createTempFile("config", "xml").toFile();
+    destPath.deleteOnExit();
+
+    writer.writeConfigToFile(ConfigFileType.HADOOP_XML, configuration, destPath);
+    assertTrue(destPath.exists());
+    try (InputStream is = new FileInputStream(destPath)) {
+      String content = IOUtils.toString(is);
+
+      System.out.println("Test print: XML content - " + content);
+
+      assertTrue(content.trim().startsWith("<configuration>"));
+      assertTrue(content.trim().endsWith("</configuration>"));
+      assertTrue(content.contains("<property>"));
+      assertTrue(content.contains("</property>"));
+
+      for (Map.Entry<String, Object> property : configuration.entrySet()) {
+        assertTrue(content.contains("<name>" + property.getKey() + "</name>"));
+        assertTrue(content.contains("<value>" + property.getValue() + "</value>"));
+      }
+    }
+  }
+
+  @Test
+  public void writeJavaPropertiesConfigToFile() throws Exception {
+    Map<String, Object> configuration = createDummyConfiguration();
+
+    File destPath = Files.createTempFile("config", "properties").toFile();
+    destPath.deleteOnExit();
+
+    writer.writeConfigToFile(ConfigFileType.PROPERTIES, configuration, destPath);
+    assertTrue(destPath.exists());
+    try (InputStream is = new FileInputStream(destPath)) {
+      String content = IOUtils.toString(is);
+      System.out.println("Test print: properties content - " + content);
+    }
+
+    try (InputStream is = new FileInputStream(destPath)) {
+      Properties prop = new Properties();
+      prop.load(is);
+
+      for (Map.Entry<String, Object> property : configuration.entrySet()) {
+        assertEquals(property.getValue().toString(), prop.getProperty(property.getKey()));
+      }
+    }
+  }
+
+  @Test
+  public void writeYamlConfigToFile() throws Exception {
+    Map<String, Object> configuration = createDummyConfiguration();
+
+    File destPath = Files.createTempFile("config", "yaml").toFile();
+    destPath.deleteOnExit();
+
+    writer.writeConfigToFile(ConfigFileType.YAML, configuration, destPath);
+    assertTrue(destPath.exists());
+    try (InputStream is = new FileInputStream(destPath)) {
+      String content = IOUtils.toString(is);
+      System.out.println("Test print: yaml content - " + content);
+
+      ObjectMapper mapper = new YAMLMapper();
+      Map<String, Object> readConfig = mapper.readValue(content, Map.class);
+
+      assertEquals(configuration, readConfig);
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void writeUnknownTypeConfigToFile() throws Exception {
+    Map<String, Object> configuration = createDummyConfiguration();
+
+    File destPath = Files.createTempFile("config", "unknown").toFile();
+    destPath.deleteOnExit();
+
+    writer.writeConfigToFile(null, configuration, destPath);
+    fail("It shouldn't reach here.");
+  }
+
+  private Map<String, Object> createDummyConfiguration() {
+    Map<String, Object> dummyConfiguration = new HashMap<>();
+    dummyConfiguration.put("javax.jdo.option.ConnectionDriverName", "com.mysql.jdbc.Driver");
+    dummyConfiguration.put("ipc.client.connect.max.retries", 50);
+    return dummyConfiguration;
+  }
+}

--- a/streams/cluster/pom.xml
+++ b/streams/cluster/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>streams</artifactId>
+        <groupId>com.hortonworks.iotas</groupId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>streams-cluster</artifactId>
+    <properties>
+        <commons-lang.version>2.5</commons-lang.version>
+    </properties>
+
+    <dependencies>
+        <!-- module dependency -->
+        <dependency>
+            <groupId>com.hortonworks.iotas</groupId>
+            <artifactId>common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.hortonworks.iotas</groupId>
+            <artifactId>streams-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.1</version>
+        </dependency>
+
+        <!--test-->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <version>${jmockit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/streams/cluster/src/main/java/com/hortonworks/iotas/streams/cluster/discovery/ServiceNodeDiscoverer.java
+++ b/streams/cluster/src/main/java/com/hortonworks/iotas/streams/cluster/discovery/ServiceNodeDiscoverer.java
@@ -1,0 +1,60 @@
+package com.hortonworks.iotas.streams.cluster.discovery;
+
+import com.hortonworks.iotas.streams.exception.ConfigException;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Interface for service and node discovery.
+ */
+public interface ServiceNodeDiscoverer {
+  /**
+   * Initialize method. Any one time initialization is done here.
+   *
+   * @param conf Configuration for implementation of ServiceNodeDiscoverer.
+   * @throws ConfigException throw when instance can't be initialized with this configuration (misconfigured).
+   */
+  void init(Map<String, String> conf) throws ConfigException;
+
+  /**
+   * Get all service names from cluster.
+   *
+   * @return all service names from cluster. some examples are 'STORM', 'KAFKA', and so on.
+   */
+  List<String> getServices();
+
+  /**
+   * Get all component names from cluster for given service.
+   *
+   * @param serviceName service name. some examples are 'STORM', 'KAFKA', and so on.
+   * @return all component names for given service. some examples are 'NIMBUS', 'UI SERVER', and so on.
+   */
+  List<String> getComponents(String serviceName);
+
+  /**
+   * Retrieves all hosts from cluster for given service.
+   *
+   * @param serviceName service name. some examples are 'STORM', 'KAFKA', and so on.
+   * @param componentName component name. some examples are 'NIMBUS', 'UI SERVER', and so on.
+   * @return all hosts for given component in service.
+   */
+  List<String> getComponentNodes(String serviceName, String componentName);
+
+  /**
+   * Retrieves all configurations from cluster for given service.
+   * Note that this should return the map which is associating config type -> config key -> config value.
+   *
+   * @param serviceName service name. some examples are 'STORM', 'KAFKA', and so on.
+   * @return all configurations for given service.
+   */
+  Map<String, Map<String, Object>> getConfigurations(String serviceName);
+
+  /**
+   * Get actual file name for given config type. This is for including configuration files to topology jar.
+   *
+   * @param configType config type which is as same as discoverer provides
+   * @return actual configuration file name
+   */
+  String getActualFileName(String configType);
+}

--- a/streams/cluster/src/main/java/com/hortonworks/iotas/streams/cluster/discovery/ambari/AmbariRestAPIConstants.java
+++ b/streams/cluster/src/main/java/com/hortonworks/iotas/streams/cluster/discovery/ambari/AmbariRestAPIConstants.java
@@ -1,0 +1,26 @@
+package com.hortonworks.iotas.streams.cluster.discovery.ambari;
+
+/**
+ * Constants which is used for parsing Ambari REST API response.
+ */
+public final class AmbariRestAPIConstants {
+  private AmbariRestAPIConstants() {}
+
+  public static final String AMBARI_JSON_SCHEMA_COMMON_ITEMS = "items";
+  public static final String AMBARI_JSON_SCHEMA_COMMON_TYPE = "type";
+  public static final String AMBARI_JSON_SCHEMA_COMMON_VERSION = "version";
+  public static final String AMBARI_JSON_SCHEMA_COMMON_TAG = "tag";
+  public static final String AMBARI_JSON_SCHEMA_COMMON_HREF = "href";
+  public static final String AMBARI_JSON_SCHEMA_COMMON_PROPERTIES = "properties";
+
+
+  public static final String AMBARI_JSON_SCHEMA_SERVICE_INFO = "ServiceInfo";
+  public static final String AMBARI_JSON_SCHEMA_SERVICE_NAME = "service_name";
+  public static final String ABARI_JSON_SCHEMA_SERVICE_COMPONENT_INFO = "ServiceComponentInfo";
+  public static final String AMBARI_JSON_SCHEMA_COMPONENTS = "components";
+  public static final String AMBARI_JSON_SCHEMA_COMPONENT_NAME = "component_name";
+  public static final String AMBARI_JSON_SCHEMA_HOST_COMPONENTS = "host_components";
+  public static final String AMBARI_JSON_SCHEMA_HOST_ROLES = "HostRoles";
+  public static final String AMBARI_JSON_SCHEMA_HOST_NAME = "host_name";
+
+}

--- a/streams/cluster/src/main/java/com/hortonworks/iotas/streams/cluster/discovery/ambari/AmbariServiceNodeDiscoverer.java
+++ b/streams/cluster/src/main/java/com/hortonworks/iotas/streams/cluster/discovery/ambari/AmbariServiceNodeDiscoverer.java
@@ -1,0 +1,225 @@
+package com.hortonworks.iotas.streams.cluster.discovery.ambari;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import com.hortonworks.iotas.streams.cluster.discovery.ServiceNodeDiscoverer;
+import com.hortonworks.iotas.streams.exception.ConfigException;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Services and nodes discover using Ambari.
+ */
+public class AmbariServiceNodeDiscoverer implements ServiceNodeDiscoverer {
+  private static final Logger LOG = LoggerFactory.getLogger(AmbariServiceNodeDiscoverer.class);
+
+  public static final String CONFIGURATIONS_URL = "/configurations";
+  public static final String SERVICES_URL = "/services";
+  public static final String SERVICE_URL = "/services/%s";
+  public static final String COMPONENT_URL = "/services/%s/components/%s";
+
+  private Client client;
+  private final String apiRootUrl;
+
+  private final String username;
+  private final String password;
+
+  public AmbariServiceNodeDiscoverer(String apiRootUrl, String username, String password) {
+    this.apiRootUrl = apiRootUrl;
+    this.username = username;
+    this.password = password;
+  }
+
+  @Override
+  public void init(Map<String, String> conf) throws ConfigException {
+    setupClient();
+  }
+
+  @Override public List<String> getServices() {
+    List<String> serviceNames = new ArrayList<>();
+
+    String targetUrl = apiRootUrl + SERVICES_URL;
+
+    LOG.debug("services URI: {}", targetUrl);
+
+    Map<String, ?> responseMap = client.target(targetUrl).request(MediaType.TEXT_PLAIN_TYPE).get(Map.class);
+    List<Map<String, ?>> services = (List<Map<String, ?>>) responseMap.get(AmbariRestAPIConstants.AMBARI_JSON_SCHEMA_COMMON_ITEMS);
+
+    if (services.size() > 0) {
+      for (Map<String, ?> service : services) {
+        Map<String, ?> componentInfo = (Map<String, ?>) service.get(AmbariRestAPIConstants.AMBARI_JSON_SCHEMA_SERVICE_INFO);
+        String serviceName = (String) componentInfo.get(AmbariRestAPIConstants.AMBARI_JSON_SCHEMA_SERVICE_NAME);
+        serviceNames.add(serviceName);
+      }
+    }
+
+    return serviceNames;
+  }
+
+  @Override public List<String> getComponents(String serviceName) {
+    List<String> componentNames = new ArrayList<>();
+
+    String targetUrl = String.format(apiRootUrl + SERVICE_URL, serviceName);
+
+    LOG.debug("components URI: {}", targetUrl);
+
+    Map<String, ?> responseMap = client.target(targetUrl).request(MediaType.TEXT_PLAIN_TYPE).get(Map.class);
+    List<Map<String, ?>> components = (List<Map<String, ?>>) responseMap.get(AmbariRestAPIConstants.AMBARI_JSON_SCHEMA_COMPONENTS);
+
+    if (components.size() > 0) {
+      for (Map<String, ?> component : components) {
+        Map<String, ?> componentInfo = (Map<String, ?>) component.get(AmbariRestAPIConstants.ABARI_JSON_SCHEMA_SERVICE_COMPONENT_INFO);
+        String componentName = (String) componentInfo.get(AmbariRestAPIConstants.AMBARI_JSON_SCHEMA_COMPONENT_NAME);
+        componentNames.add(componentName);
+      }
+    }
+
+    return componentNames;
+  }
+
+  @Override public List<String> getComponentNodes(String serviceName, String componentName) {
+    List<String> componentNodes = new ArrayList<>();
+
+    String targetUrl = String.format(apiRootUrl + COMPONENT_URL, serviceName, componentName);
+
+    LOG.debug("host components URI: {}", targetUrl);
+
+    Map<String, ?> responseMap = client.target(targetUrl).request(MediaType.TEXT_PLAIN_TYPE).get(Map.class);
+    List<Map<String, ?>> hostComponents = (List<Map<String, ?>>) responseMap.get(
+        AmbariRestAPIConstants.AMBARI_JSON_SCHEMA_HOST_COMPONENTS);
+
+    if (hostComponents.size() > 0) {
+      for (Map<String, ?> hostComponent : hostComponents) {
+        Map<String, ?> hostRoles = (Map<String, ?>) hostComponent.get(AmbariRestAPIConstants.AMBARI_JSON_SCHEMA_HOST_ROLES);
+        String hostName = (String) hostRoles.get(AmbariRestAPIConstants.AMBARI_JSON_SCHEMA_HOST_NAME);
+        componentNodes.add(hostName);
+      }
+    }
+
+    return componentNodes;
+  }
+
+  @Override public Map<String, Map<String, Object>> getConfigurations(String serviceName) {
+    // this will throw IllegalArgumentException if service is not supported yet.
+    ServiceConfigurations serviceConfigurations;
+    try {
+      serviceConfigurations = ServiceConfigurations.valueOf(serviceName.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("service " + serviceName + " is not supported.");
+    }
+
+    String[] confNames = serviceConfigurations.getConfNames();
+    List<String> confNameList = Lists.newArrayList(confNames);
+
+    Map<String, Map<String, Object>> configurations = new HashMap<>();
+
+    String targetUrl = apiRootUrl + CONFIGURATIONS_URL;
+
+    LOG.debug("configurations URI: {}", targetUrl);
+
+    Map<String, ?> responseMap = client.target(targetUrl).request(MediaType.TEXT_PLAIN_TYPE).get(Map.class);
+    List<Map<String, ?>> items = (List<Map<String, ?>>) responseMap.get(AmbariRestAPIConstants.AMBARI_JSON_SCHEMA_COMMON_ITEMS);
+
+    if (items.size() > 0) {
+      Map<String, ServiceConfigurationItem> confToItem = extractLatestConfigurationItems(
+          confNameList, items);
+
+      for (ServiceConfigurationItem confItem : confToItem.values()) {
+        configurations.put(confItem.getType(), getProperties(confItem));
+      }
+    }
+
+    return configurations;
+  }
+
+  @Override
+  public String getActualFileName(String configType) {
+    return ConfigFilePattern.getActualFileName(configType);
+  }
+
+  private Map<String, ServiceConfigurationItem> extractLatestConfigurationItems(List<String> confNameList,
+      List<Map<String, ?>> items) {
+    Map<String, ServiceConfigurationItem> confToItem = new HashMap<>();
+    for (Map<String, ?> item : items) {
+      String type = (String) item.get(AmbariRestAPIConstants.AMBARI_JSON_SCHEMA_COMMON_TYPE);
+      if (!confNameList.contains(type)) {
+        continue;
+      }
+
+      Integer version = ((Number) item.get(AmbariRestAPIConstants.AMBARI_JSON_SCHEMA_COMMON_VERSION)).intValue();
+      String tag = (String) item.get(AmbariRestAPIConstants.AMBARI_JSON_SCHEMA_COMMON_TAG);
+      String href = (String) item.get(AmbariRestAPIConstants.AMBARI_JSON_SCHEMA_COMMON_HREF);
+
+      ServiceConfigurationItem latestItem = confToItem.get(type);
+      if (latestItem == null || latestItem.getVersion() < version) {
+        confToItem.put(type, new ServiceConfigurationItem(type, version, tag, href));
+      }
+    }
+    return confToItem;
+  }
+
+  private Map<String, Object> getProperties(ServiceConfigurationItem confItem) {
+    String targetUrl = confItem.getHref();
+
+    LOG.debug("configuration item URI: {}", targetUrl);
+
+    Map<String, ?> responseMap = client.target(targetUrl).request(MediaType.TEXT_PLAIN_TYPE).get(Map.class);
+    List<Map<String, ?>> items = (List<Map<String, ?>>) responseMap.get(AmbariRestAPIConstants.AMBARI_JSON_SCHEMA_COMMON_ITEMS);
+
+    if (items.size() > 0) {
+      return (Map<String, Object>) items.get(0).get(AmbariRestAPIConstants.AMBARI_JSON_SCHEMA_COMMON_PROPERTIES);
+    }
+
+    return Collections.emptyMap();
+  }
+
+  private void setupClient() {
+    HttpAuthenticationFeature feature = HttpAuthenticationFeature.basicBuilder()
+        .credentials(username, password).build();
+    ClientConfig clientConfig = new ClientConfig();
+    clientConfig.register(feature);
+    clientConfig.register(JsonToMapProvider.class);
+
+    client = ClientBuilder.newClient(clientConfig);
+  }
+
+  @Provider
+  public static class JsonToMapProvider implements MessageBodyReader<Map> {
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations,
+        MediaType mediaType) {
+      return (MediaType.APPLICATION_JSON_TYPE.equals(mediaType) ||
+          MediaType.TEXT_PLAIN_TYPE.equals(mediaType));
+    }
+
+    @Override
+    public Map<String, Object> readFrom(Class<Map> aClass, Type type,
+        Annotation[] annotations, MediaType mediaType,
+        MultivaluedMap<String, String> multivaluedMap, InputStream inputStream)
+        throws IOException, WebApplicationException {
+      return objectMapper.readValue(inputStream, aClass);
+    }
+
+  }
+}

--- a/streams/cluster/src/main/java/com/hortonworks/iotas/streams/cluster/discovery/ambari/ComponentPropertyPattern.java
+++ b/streams/cluster/src/main/java/com/hortonworks/iotas/streams/cluster/discovery/ambari/ComponentPropertyPattern.java
@@ -1,0 +1,57 @@
+package com.hortonworks.iotas.streams.cluster.discovery.ambari;
+
+import java.util.regex.Pattern;
+
+/**
+ * Defines the pattern to extract Component's properties from configuration.
+ * Currently it only extracts protocol and port from one configuration key.
+ */
+public enum ComponentPropertyPattern {
+  // HDFS
+  // There're multiple ports assigned for each components in HDFS and HBASE
+  // So what port to pick is subject to change for the future use cases
+  NAMENODE("dfs.http.address"),
+  SECONDARY_NAMENODE("dfs.secondary.http.address"),
+  DATANODE("dfs.datanode.http.address", Pattern.compile("()[0-9\\\\.]+:([0-9]+)")),
+
+  // HBASE
+  HBASE_MASTER("hbase.master.port"),
+  HBASE_REGIONSERVER("hbase.regionserver.port"),
+
+  // STORM
+  NIMBUS("nimbus.thrift.port"),
+  STORM_UI_SERVER("ui.port"),
+  DRPC_SERVER("drpc.port"),
+
+  // ZOOKEEPER
+  ZOOKEEPER_SERVER("clientPort"),
+
+  // HIVE
+  HIVE_SERVER("hive.server2.thrift.port"),
+  HIVE_METASTORE("hive.metastore.uris", Pattern.compile("([a-zA-Z]+)://[a-zA-Z0-9_-]*:([0-9]+)")),
+
+  // KAFKA
+  // protocol (plaintext, ssl, kerberos, etc?), host (can be empty), port
+  // https://cwiki.apache.org/confluence/display/KAFKA/Multiple+Listeners+for+Kafka+Brokers
+  KAFKA_BROKER("listeners", Pattern.compile("([a-zA-Z]+)://[a-zA-Z0-9_-]*:([0-9]+)"));
+
+  private final String connectionConfName;
+  private final Pattern parsePattern;
+
+  ComponentPropertyPattern(String connectionConfName) {
+    this(connectionConfName, Pattern.compile("()(.+)"));
+  }
+
+  ComponentPropertyPattern(String connectionConfName, Pattern parsePattern) {
+    this.connectionConfName = connectionConfName;
+    this.parsePattern = parsePattern;
+  }
+
+  public String getConnectionConfName() {
+    return connectionConfName;
+  }
+
+  public Pattern getParsePattern() {
+    return parsePattern;
+  }
+}

--- a/streams/cluster/src/main/java/com/hortonworks/iotas/streams/cluster/discovery/ambari/ConfigFilePattern.java
+++ b/streams/cluster/src/main/java/com/hortonworks/iotas/streams/cluster/discovery/ambari/ConfigFilePattern.java
@@ -1,0 +1,40 @@
+package com.hortonworks.iotas.streams.cluster.discovery.ambari;
+
+/**
+ * Defines mapping between config type and actual file name.
+ * If Services are imported from import via Ambari API, this pattern applies to ServiceConfiguration.
+ */
+public enum ConfigFilePattern {
+  CORE_SITE("core-site", "core-site.xml"),
+  HDFS_SITE("hdfs-site", "hdfs-site.xml"),
+  HIVE_SITE("hive-site", "hive-site.xml"),
+  HBASE_SITE("hbase-site", "hbase-site.xml");
+
+  private final String confType;
+  private final String actualFileName;
+
+  ConfigFilePattern(String confType, String actualFileName) {
+    this.confType = confType;
+    this.actualFileName = actualFileName;
+  }
+
+  public static String getActualFileName(String confType) {
+    ConfigFilePattern pattern = lookup(confType);
+    if (pattern != null) {
+      return pattern.actualFileName;
+    }
+
+    return null;
+  }
+
+  public static ConfigFilePattern lookup(String confType) {
+    for (ConfigFilePattern value : values()) {
+      if (value.confType.equals(confType)) {
+        return value;
+      }
+    }
+
+    return null;
+  }
+
+}

--- a/streams/cluster/src/main/java/com/hortonworks/iotas/streams/cluster/discovery/ambari/ServiceConfigurationItem.java
+++ b/streams/cluster/src/main/java/com/hortonworks/iotas/streams/cluster/discovery/ambari/ServiceConfigurationItem.java
@@ -1,0 +1,34 @@
+package com.hortonworks.iotas.streams.cluster.discovery.ambari;
+
+/**
+ * Data structure of "Service Configuration" in Ambari REST API response.
+ */
+public class ServiceConfigurationItem {
+    private String type;
+    private Integer version;
+    private String tag;
+    private String href;
+
+    public ServiceConfigurationItem(String type, Integer version, String tag, String href) {
+      this.type = type;
+      this.version = version;
+      this.tag = tag;
+      this.href = href;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public Integer getVersion() {
+      return version;
+    }
+
+    public String getTag() {
+      return tag;
+    }
+
+    public String getHref() {
+      return href;
+    }
+  }

--- a/streams/cluster/src/main/java/com/hortonworks/iotas/streams/cluster/discovery/ambari/ServiceConfigurations.java
+++ b/streams/cluster/src/main/java/com/hortonworks/iotas/streams/cluster/discovery/ambari/ServiceConfigurations.java
@@ -1,0 +1,26 @@
+package com.hortonworks.iotas.streams.cluster.discovery.ambari;
+
+/**
+ * Defines mapping between Service and its configuration types.
+ */
+public enum ServiceConfigurations {
+  ZOOKEEPER("zoo.cfg", "zookeeper-env"),
+  STORM("storm-site", "storm-env"),
+  KAFKA("kafka-broker", "kafka-env"),
+  // excluded ssl configurations for security reason
+  HDFS("core-site", "hadoop-env", "hadoop-policy", "hdfs-site"),
+  HBASE("hbase-env", "hbase-policy", "hbase-site"),
+  HIVE("hive-env", "hive-interactive-env", "hive-interactive-site",
+      "hive-metastore-site", "hiveserver2-interactive-site",
+      "hiveserver2-site");
+
+  private final String[] confNames;
+
+  ServiceConfigurations(String... confNames) {
+    this.confNames = confNames;
+  }
+
+  public String[] getConfNames() {
+    return confNames;
+  }
+}

--- a/streams/layout/src/main/java/com/hortonworks/iotas/streams/layout/TopologyLayoutConstants.java
+++ b/streams/layout/src/main/java/com/hortonworks/iotas/streams/layout/TopologyLayoutConstants.java
@@ -1,7 +1,9 @@
 package com.hortonworks.iotas.streams.layout;
 
 public final class TopologyLayoutConstants {
-    private TopologyLayoutConstants () {}
+
+
+  private TopologyLayoutConstants () {}
     // streaming engines
     public static final String STORM_STREAMING_ENGINE = "STORM";
 
@@ -126,6 +128,7 @@ public final class TopologyLayoutConstants {
     public final static String JSON_KEY_CUSTOM_PROCESSOR_PREFIX_REGEX = "config\\.";
 
     public static final String JSON_KEY_CLUSTERS = "clusters";
+    public static final String JSON_KEY_SERVICES = "services";
 
     public static final String JAVA_JAR_COMMAND = "javaJarCommand";
 

--- a/streams/pom.xml
+++ b/streams/pom.xml
@@ -24,6 +24,7 @@
         <module>runners</module>
         <module>schemaevolver</module>
         <module>functions</module>
+        <module>cluster</module>
     </modules>
 
 

--- a/streams/service/pom.xml
+++ b/streams/service/pom.xml
@@ -49,6 +49,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.hortonworks.iotas</groupId>
+            <artifactId>streams-cluster</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
             <exclusions>

--- a/streams/service/src/main/java/com/hortonworks/iotas/streams/service/DataSourceWithDataFeedCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/iotas/streams/service/DataSourceWithDataFeedCatalogResource.java
@@ -122,7 +122,6 @@ public class DataSourceWithDataFeedCatalogResource {
     @GET
     @Path("/datasources/{id}")
     @Timed
-    @Produces(MediaType.APPLICATION_JSON)
     public Response getDataSourceWithDataFeedById(@PathParam("id") Long dataSourceId) {
         try {
             DataSourceDto dataSource = dataSourceFacade.getDataSource(dataSourceId);

--- a/streams/service/src/main/java/com/hortonworks/iotas/streams/service/FeedCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/iotas/streams/service/FeedCatalogResource.java
@@ -73,7 +73,6 @@ public class FeedCatalogResource {
     @GET
     @Path("/feeds/{id}")
     @Timed
-    @Produces(MediaType.APPLICATION_JSON)
     public Response getDataFeedById(@PathParam("id") Long dataFeedId) {
         try {
             DataFeed result = catalogService.getDataFeed(dataFeedId);
@@ -89,7 +88,6 @@ public class FeedCatalogResource {
     @GET
     @Path("/feeds/{id}/schema")
     @Timed
-    @Produces(MediaType.APPLICATION_JSON)
     public Response getParserSchemaForDatafeed(@PathParam("id") Long dataFeedId) {
         try {
             DataFeed dataFeed = catalogService.getDataFeed(dataFeedId);

--- a/streams/service/src/main/java/com/hortonworks/iotas/streams/service/NotifierInfoCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/iotas/streams/service/NotifierInfoCatalogResource.java
@@ -78,7 +78,6 @@ public class NotifierInfoCatalogResource {
     @GET
     @Path("/notifiers/{id}")
     @Timed
-    @Produces(MediaType.APPLICATION_JSON)
     public Response getNotifierById(@PathParam("id") Long id) {
         try {
             NotifierInfo result = catalogService.getNotifierInfo(id);

--- a/streams/service/src/main/java/com/hortonworks/iotas/streams/service/RuleCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/iotas/streams/service/RuleCatalogResource.java
@@ -113,7 +113,6 @@ public class RuleCatalogResource {
     @GET
     @Path("/{id}")
     @Timed
-    @Produces(MediaType.APPLICATION_JSON)
     public Response getTopologyRuleById(@PathParam("topologyId") Long topologyId, @PathParam("id") Long ruleId) {
         try {
             RuleInfo ruleInfo = catalogService.getRule(ruleId);

--- a/streams/service/src/main/java/com/hortonworks/iotas/streams/service/ServiceCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/iotas/streams/service/ServiceCatalogResource.java
@@ -1,0 +1,229 @@
+package com.hortonworks.iotas.streams.service;
+
+import com.codahale.metrics.annotation.Timed;
+import com.hortonworks.iotas.common.QueryParam;
+import com.hortonworks.iotas.common.util.WSUtils;
+import com.hortonworks.iotas.storage.exception.AlreadyExistsException;
+import com.hortonworks.iotas.streams.catalog.Cluster;
+import com.hortonworks.iotas.streams.catalog.Service;
+import com.hortonworks.iotas.streams.catalog.service.StreamCatalogService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static com.hortonworks.iotas.common.catalog.CatalogResponse.ResponseMessage;
+import static com.hortonworks.iotas.common.catalog.CatalogResponse.ResponseMessage.ENTITY_BY_NAME_NOT_FOUND;
+import static com.hortonworks.iotas.common.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND;
+import static com.hortonworks.iotas.common.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND_FOR_FILTER;
+import static com.hortonworks.iotas.common.catalog.CatalogResponse.ResponseMessage.EXCEPTION;
+import static com.hortonworks.iotas.common.catalog.CatalogResponse.ResponseMessage.SUCCESS;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
+
+@Path("/api/v1/catalog")
+@Produces(MediaType.APPLICATION_JSON)
+public class ServiceCatalogResource {
+    private static final Logger LOG = LoggerFactory.getLogger(ServiceCatalogResource.class);
+    private final StreamCatalogService catalogService;
+
+    public ServiceCatalogResource(StreamCatalogService catalogService) {
+        this.catalogService = catalogService;
+    }
+
+    /**
+     * List ALL services or the ones matching specific query params.
+     */
+    @GET
+    @Path("/clusters/{clusterId}/services")
+    @Timed
+    public Response listServices(@PathParam("clusterId") Long clusterId, @Context UriInfo uriInfo) {
+        List<QueryParam> queryParams = buildClusterIdAwareQueryParams(clusterId, uriInfo);
+        try {
+            Collection<Service> services;
+            services = catalogService.listServices(queryParams);
+            if (services != null) {
+                return WSUtils.respond(services, OK, SUCCESS);
+            }
+        } catch (Exception ex) {
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
+
+        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND_FOR_FILTER, queryParams.toString());
+    }
+
+    /**
+     * List ALL services or the ones matching specific query params.
+     */
+    @GET
+    @Path("/clusters/name/{clusterName}/services")
+    @Timed
+    public Response listServicesByName(@PathParam("clusterName") String clusterName, @Context UriInfo uriInfo) {
+        Cluster cluster = catalogService.getClusterByName(clusterName);
+        if (cluster == null) {
+            return WSUtils.respond(NOT_FOUND, ENTITY_BY_NAME_NOT_FOUND, "cluster name " + clusterName);
+        }
+
+        List<QueryParam> queryParams = buildClusterIdAwareQueryParams(cluster.getId(), uriInfo);
+        try {
+            Collection<Service> services;
+            services = catalogService.listServices(queryParams);
+            if (services != null) {
+                return WSUtils.respond(services, OK, SUCCESS);
+            }
+        } catch (Exception ex) {
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
+
+        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND_FOR_FILTER, queryParams.toString());
+    }
+
+    @GET
+    @Path("/clusters/{clusterId}/services/{id}")
+    @Timed
+    public Response getServiceById(@PathParam("clusterId") Long clusterId, @PathParam("id") Long serviceId) {
+        try {
+            Service result = catalogService.getService(serviceId);
+            if (result != null) {
+                if (result.getClusterId() == null || !result.getClusterId().equals(clusterId)) {
+                    return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, "cluster: " + clusterId.toString());
+                }
+                return WSUtils.respond(result, OK, SUCCESS);
+            }
+        } catch (Exception ex) {
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
+        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, buildMessageForCompositeId(clusterId, serviceId));
+    }
+
+    @GET
+    @Path("/clusters/name/{clusterName}/services/name/{serviceName}")
+    @Timed
+    public Response getServiceByName(@PathParam("clusterName") String clusterName,
+        @PathParam("serviceName") String serviceName) {
+        Cluster cluster = catalogService.getClusterByName(clusterName);
+        if (cluster == null) {
+            return WSUtils.respond(NOT_FOUND, ENTITY_BY_NAME_NOT_FOUND, "cluster name " + clusterName);
+        }
+
+        try {
+            Service result = catalogService.getServiceByName(cluster.getId(), serviceName);
+            if (result != null) {
+                return WSUtils.respond(result, OK, SUCCESS);
+            }
+        } catch (Exception ex) {
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
+        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, buildMessageForCompositeName(clusterName, serviceName));
+    }
+
+    @Timed
+    @POST
+    @Path("/clusters/{clusterId}/services")
+    public Response addService(@PathParam("clusterId") Long clusterId, Service service) {
+        // overwrite cluster id to given path param
+        service.setClusterId(clusterId);
+
+        try {
+            Cluster cluster = catalogService.getCluster(clusterId);
+            if (cluster == null) {
+                return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, "cluster: " + clusterId.toString());
+            }
+
+            String serviceName = service.getName();
+            Service result = catalogService.getServiceByName(clusterId, serviceName);
+            if (result != null) {
+                throw new AlreadyExistsException("Service entity already exists with cluster id " +
+                    clusterId + " and service name " + serviceName);
+            }
+
+            Service createdService = catalogService.addService(service);
+            return WSUtils.respond(createdService, CREATED, SUCCESS);
+        } catch (ProcessingException ex) {
+            return WSUtils.respond(BAD_REQUEST, ResponseMessage.BAD_REQUEST);
+        } catch (Exception ex) {
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
+    }
+
+    @DELETE
+    @Path("/clusters/{clusterId}/services/{id}")
+    @Timed
+    public Response removeService(@PathParam("id") Long serviceId) {
+        try {
+            Service removedService = catalogService.removeService(serviceId);
+            if (removedService != null) {
+                return WSUtils.respond(removedService, OK, SUCCESS);
+            } else {
+                return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, serviceId.toString());
+            }
+        } catch (Exception ex) {
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
+    }
+
+    @PUT
+    @Path("/clusters/{clusterId}/services/{id}")
+    @Timed
+    public Response addOrUpdateService(@PathParam("clusterId") Long clusterId,
+        @PathParam("id") Long serviceId, Service service) {
+        // overwrite cluster id to given path param
+        service.setClusterId(clusterId);
+
+        try {
+            Cluster cluster = catalogService.getCluster(clusterId);
+            if (cluster == null) {
+                return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, "cluster: " + clusterId.toString());
+            }
+
+            Service newService = catalogService.addOrUpdateService(serviceId, service);
+            return WSUtils.respond(newService, OK, SUCCESS);
+        } catch (ProcessingException ex) {
+            return WSUtils.respond(BAD_REQUEST, ResponseMessage.BAD_REQUEST, ex.getMessage());
+        } catch (Exception ex) {
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
+    }
+
+    private List<QueryParam> buildClusterIdAwareQueryParams(Long clusterId, UriInfo uriInfo) {
+        List<QueryParam> queryParams = new ArrayList<>();
+        queryParams.add(new QueryParam("clusterId", clusterId.toString()));
+        if (uriInfo != null) {
+            MultivaluedMap<String, String> params = uriInfo.getQueryParameters();
+            if (!params.isEmpty()) {
+                queryParams.addAll(WSUtils.buildQueryParameters(params));
+            }
+        }
+
+        return queryParams;
+    }
+
+    private String buildMessageForCompositeId(Long clusterId, Long serviceId) {
+        return String.format("cluster id <%d>, service id <%d>",
+            clusterId, serviceId);
+    }
+
+    private String buildMessageForCompositeName(String clusterName, String serviceName) {
+        return String.format("cluster name <%s>, service name <%s>",
+            clusterName, serviceName);
+    }
+
+}

--- a/streams/service/src/main/java/com/hortonworks/iotas/streams/service/ServiceConfigurationCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/iotas/streams/service/ServiceConfigurationCatalogResource.java
@@ -1,0 +1,250 @@
+package com.hortonworks.iotas.streams.service;
+
+import com.codahale.metrics.annotation.Timed;
+import com.hortonworks.iotas.common.QueryParam;
+import com.hortonworks.iotas.common.util.WSUtils;
+import com.hortonworks.iotas.storage.exception.AlreadyExistsException;
+import com.hortonworks.iotas.streams.catalog.Cluster;
+import com.hortonworks.iotas.streams.catalog.Service;
+import com.hortonworks.iotas.streams.catalog.ServiceConfiguration;
+import com.hortonworks.iotas.streams.catalog.service.StreamCatalogService;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static com.hortonworks.iotas.common.catalog.CatalogResponse.ResponseMessage.ENTITY_BY_NAME_NOT_FOUND;
+import static com.hortonworks.iotas.common.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND;
+import static com.hortonworks.iotas.common.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND_FOR_FILTER;
+import static com.hortonworks.iotas.common.catalog.CatalogResponse.ResponseMessage.EXCEPTION;
+import static com.hortonworks.iotas.common.catalog.CatalogResponse.ResponseMessage.SUCCESS;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
+
+@Path("/api/v1/catalog")
+@Produces(MediaType.APPLICATION_JSON)
+public class ServiceConfigurationCatalogResource {
+    private StreamCatalogService catalogService;
+
+    public ServiceConfigurationCatalogResource(StreamCatalogService catalogService) {
+        this.catalogService = catalogService;
+    }
+
+    /**
+     * List ALL configurations or the ones matching specific query params.
+     */
+    @GET
+    @Path("/services/{serviceId}/configurations")
+    @Timed
+    public Response listServiceConfigurations(@PathParam("serviceId") Long serviceId, @Context UriInfo uriInfo) {
+        List<QueryParam> queryParams = buildServiceIdAwareQueryParams(serviceId, uriInfo);
+
+        try {
+            Collection<ServiceConfiguration> configurations = catalogService.listServiceConfigurations(queryParams);
+            if (configurations != null) {
+                return WSUtils.respond(configurations, OK, SUCCESS);
+            }
+        } catch (Exception ex) {
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
+
+        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND_FOR_FILTER, queryParams.toString());
+    }
+
+    /**
+     * List ALL configurations or the ones matching specific query params.
+     */
+    @GET
+    @Path("/clusters/name/{clusterName}/services/name/{serviceName}/configurations")
+    @Timed
+    public Response listServiceConfigurationsByName(@PathParam("clusterName") String clusterName,
+        @PathParam("serviceName") String serviceName, @Context UriInfo uriInfo) {
+        Cluster cluster = catalogService.getClusterByName(clusterName);
+        if (cluster == null) {
+            return WSUtils.respond(NOT_FOUND, ENTITY_BY_NAME_NOT_FOUND, "cluster name " + clusterName);
+        }
+
+        Service service = catalogService.getServiceByName(cluster.getId(), serviceName);
+        if (service == null) {
+            return WSUtils.respond(NOT_FOUND, ENTITY_BY_NAME_NOT_FOUND, "service name " + serviceName);
+        }
+
+        List<QueryParam> queryParams = buildServiceIdAwareQueryParams(service.getId(), uriInfo);
+
+        try {
+            Collection<ServiceConfiguration> configurations = catalogService.listServiceConfigurations(queryParams);
+            if (configurations != null) {
+                return WSUtils.respond(configurations, OK, SUCCESS);
+            }
+        } catch (Exception ex) {
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
+
+        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND_FOR_FILTER, queryParams.toString());
+    }
+
+    @GET
+    @Path("/services/{serviceId}/configurations/{id}")
+    @Timed
+    public Response getConfigurationById(@PathParam("serviceId") Long serviceId, @PathParam("id") Long configurationId) {
+        try {
+            ServiceConfiguration configuration = catalogService.getServiceConfiguration(configurationId);
+            if (configuration != null) {
+                if (configuration.getServiceId() == null || !configuration.getServiceId().equals(serviceId)) {
+                    return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, "service: " + serviceId.toString());
+                }
+                return WSUtils.respond(configuration, OK, SUCCESS);
+            }
+        } catch (Exception ex) {
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
+        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, buildMessageForCompositeId(serviceId, configurationId));
+    }
+
+    @GET
+    @Path("/clusters/name/{clusterName}/services/name/{serviceName}/configurations/name/{configurationName}")
+    @Timed
+    public Response getConfigurationByName(@PathParam("clusterName") String clusterName,
+        @PathParam("serviceName") String serviceName, @PathParam("configurationName") String configurationName) {
+        Cluster cluster = catalogService.getClusterByName(clusterName);
+        if (cluster == null) {
+            return WSUtils.respond(NOT_FOUND, ENTITY_BY_NAME_NOT_FOUND, "cluster name " + clusterName);
+        }
+
+        Service service = catalogService.getServiceByName(cluster.getId(), serviceName);
+        if (service == null) {
+            return WSUtils.respond(NOT_FOUND, ENTITY_BY_NAME_NOT_FOUND, "service name " + serviceName);
+        }
+
+        try {
+            ServiceConfiguration configuration = catalogService.getServiceConfigurationByName(service.getId(), configurationName);
+            if (configuration != null) {
+                return WSUtils.respond(configuration, OK, SUCCESS);
+            }
+        } catch (Exception ex) {
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
+        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, buildMessageForCompositeName(clusterName, serviceName, configurationName));
+    }
+
+    @POST
+    @Path("/services/{serviceId}/configurations")
+    @Timed
+    public Response addServiceConfiguration(@PathParam("serviceId") Long serviceId, ServiceConfiguration serviceConfiguration) {
+        // just overwrite the service id to given path param
+        serviceConfiguration.setServiceId(serviceId);
+
+        try {
+            Service service = catalogService.getService(serviceId);
+            if (service == null) {
+                return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, "service: " + serviceId.toString());
+            }
+
+            String configurationName = serviceConfiguration.getName();
+            ServiceConfiguration result = catalogService.getServiceConfigurationByName(serviceId, configurationName);
+            if (result != null) {
+                throw new AlreadyExistsException("ServiceConfiguration entity already exists with service id " +
+                    serviceId + " and configuration name " + configurationName);
+            }
+
+            ServiceConfiguration createdConfiguration = catalogService.addServiceConfiguration(serviceConfiguration);
+            return WSUtils.respond(createdConfiguration, CREATED, SUCCESS);
+        } catch (Exception ex) {
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
+    }
+
+    @PUT
+    @Path("/services/{serviceId}/configurations")
+    @Timed
+    public Response addOrUpdateServiceConfiguration(@PathParam("serviceId") Long serviceId,
+        ServiceConfiguration serviceConfiguration) {
+        // overwrite service id to given path param
+        serviceConfiguration.setServiceId(serviceId);
+
+        Service service = catalogService.getService(serviceId);
+        if (service == null) {
+            return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, "service: " + serviceId.toString());
+        }
+
+        try {
+            ServiceConfiguration createdConfiguration = catalogService.addOrUpdateServiceConfiguration(serviceId,
+                serviceConfiguration);
+            return WSUtils.respond(createdConfiguration, CREATED, SUCCESS);
+        } catch (Exception ex) {
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
+    }
+
+    @DELETE
+    @Path("/services/{serviceId}/configurations/{id}")
+    @Timed
+    public Response removeServiceConfiguration(@PathParam("id") Long serviceConfigurationId) {
+        try {
+            ServiceConfiguration removedConfiguration = catalogService.removeServiceConfiguration(serviceConfigurationId);
+            if (removedConfiguration != null) {
+                return WSUtils.respond(removedConfiguration, OK, SUCCESS);
+            } else {
+                return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, serviceConfigurationId.toString());
+            }
+        } catch (Exception ex) {
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
+    }
+
+    @PUT
+    @Path("/services/{serviceId}/configurations/{id}")
+    @Timed
+    public Response addOrUpdateServiceConfiguration(@PathParam("serviceId") Long serviceId,
+        @PathParam("id") Long serviceConfigurationId, ServiceConfiguration serviceConfiguration) {
+        // overwrite service id to given path param
+        serviceConfiguration.setServiceId(serviceId);
+
+        try {
+            ServiceConfiguration newConfiguration = catalogService.addOrUpdateServiceConfiguration(serviceId,
+                serviceConfigurationId, serviceConfiguration);
+            return WSUtils.respond(newConfiguration, OK, SUCCESS);
+        } catch (Exception ex) {
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
+    }
+
+    private List<QueryParam> buildServiceIdAwareQueryParams(Long serviceId, UriInfo uriInfo) {
+        List<QueryParam> queryParams = new ArrayList<QueryParam>();
+        queryParams.add(new QueryParam("serviceId", serviceId.toString()));
+        if (uriInfo != null) {
+            MultivaluedMap<String, String> params = uriInfo.getQueryParameters();
+            if (!params.isEmpty()) {
+                queryParams.addAll(WSUtils.buildQueryParameters(params));
+            }
+        }
+
+        return queryParams;
+    }
+
+    private String buildMessageForCompositeId(Long serviceId, Long serviceConfigurationId) {
+        return String.format("service id <%d>, configuration id <%d>",
+                serviceId, serviceConfigurationId);
+    }
+
+    private String buildMessageForCompositeName(String clusterName, String serviceName,
+        String serviceConfigurationName) {
+        return String.format("cluster name <%s>, service name <%s>, configuration name <%s>",
+            clusterName, serviceName, serviceConfigurationName);
+    }
+
+}

--- a/streams/service/src/main/java/com/hortonworks/iotas/streams/service/StreamsModule.java
+++ b/streams/service/src/main/java/com/hortonworks/iotas/streams/service/StreamsModule.java
@@ -112,8 +112,12 @@ public class StreamsModule implements ModuleRegistration, StorageManagerAware {
 
     private List<Object> getClusterRelatedResources (StreamCatalogService streamcatalogService) {
         List<Object> result = new ArrayList<>();
-        final ClusterCatalogResource clusterCatalogResource = new ClusterCatalogResource(streamcatalogService, fileStorage);
+        final ClusterCatalogResource clusterCatalogResource = new ClusterCatalogResource(streamcatalogService);
         result.add(clusterCatalogResource);
+        final ServiceCatalogResource serviceCatalogResource = new ServiceCatalogResource(streamcatalogService);
+        result.add(serviceCatalogResource);
+        final ServiceConfigurationCatalogResource serviceConfigurationCatalogResource = new ServiceConfigurationCatalogResource(streamcatalogService);
+        result.add(serviceConfigurationCatalogResource);
         final ComponentCatalogResource componentCatalogResource = new ComponentCatalogResource(streamcatalogService);
         result.add(componentCatalogResource);
         return result;

--- a/streams/service/src/main/java/com/hortonworks/iotas/streams/service/TopologyCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/iotas/streams/service/TopologyCatalogResource.java
@@ -101,7 +101,6 @@ public class TopologyCatalogResource {
     @GET
     @Path("/topologies/{topologyId}")
     @Timed
-    @Produces(MediaType.APPLICATION_JSON)
     public Response getTopologyById (@PathParam("topologyId") Long topologyId) {
         try {
             Topology result = catalogService.getTopology(topologyId);
@@ -317,7 +316,6 @@ public class TopologyCatalogResource {
     @GET
     @Path("/system/componentdefinitions/{component}/{id}")
     @Timed
-    @Produces(MediaType.APPLICATION_JSON)
     public Response getTopologyById (@PathParam("component") TopologyComponentDefinition.TopologyComponentType componentType, @PathParam ("id") Long id) {
         try {
             TopologyComponentDefinition result = catalogService

--- a/streams/service/src/main/java/com/hortonworks/iotas/streams/service/TopologyEdgeCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/iotas/streams/service/TopologyEdgeCatalogResource.java
@@ -128,7 +128,6 @@ public class TopologyEdgeCatalogResource {
     @GET
     @Path("/{id}")
     @Timed
-    @Produces(MediaType.APPLICATION_JSON)
     public Response getTopologyEdgeById(@PathParam("topologyId") Long topologyId, @PathParam("id") Long edgeId) {
         try {
             TopologyEdge edge = catalogService.getTopologyEdge(edgeId);

--- a/streams/service/src/main/java/com/hortonworks/iotas/streams/service/TopologyEditorMetadataResource.java
+++ b/streams/service/src/main/java/com/hortonworks/iotas/streams/service/TopologyEditorMetadataResource.java
@@ -36,7 +36,6 @@ public class TopologyEditorMetadataResource {
     @GET
     @Path("/system/topologyeditormetadata")
     @Timed
-    @Produces(MediaType.APPLICATION_JSON)
     public Response listTopologyEditorMetadata () {
         try {
             Collection<TopologyEditorMetadata> result = catalogService.listTopologyEditorMetadata();
@@ -52,7 +51,6 @@ public class TopologyEditorMetadataResource {
     @GET
     @Path("/system/topologyeditormetadata/{id}")
     @Timed
-    @Produces(MediaType.APPLICATION_JSON)
     public Response getTopologyEditorMetadataByTopologyId (@PathParam("id") Long topologyId) {
         try {
             TopologyEditorMetadata result = catalogService.getTopologyEditorMetadata(topologyId);

--- a/streams/service/src/main/java/com/hortonworks/iotas/streams/service/TopologyProcessorCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/iotas/streams/service/TopologyProcessorCatalogResource.java
@@ -129,7 +129,6 @@ public class TopologyProcessorCatalogResource {
     @GET
     @Path("/{id}")
     @Timed
-    @Produces(MediaType.APPLICATION_JSON)
     public Response getTopologyProcessorById(@PathParam("topologyId") Long topologyId, @PathParam("id") Long processorId) {
         try {
             TopologyProcessor source = catalogService.getTopologyProcessor(processorId);

--- a/streams/service/src/main/java/com/hortonworks/iotas/streams/service/TopologySinkCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/iotas/streams/service/TopologySinkCatalogResource.java
@@ -127,7 +127,6 @@ public class TopologySinkCatalogResource {
     @GET
     @Path("/{id}")
     @Timed
-    @Produces(MediaType.APPLICATION_JSON)
     public Response getTopologySinkById(@PathParam("topologyId") Long topologyId, @PathParam("id") Long sinkId) {
         try {
             TopologySink sink = catalogService.getTopologySink(sinkId);

--- a/streams/service/src/main/java/com/hortonworks/iotas/streams/service/TopologySourceCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/iotas/streams/service/TopologySourceCatalogResource.java
@@ -133,7 +133,6 @@ public class TopologySourceCatalogResource {
     @GET
     @Path("/{id}")
     @Timed
-    @Produces(MediaType.APPLICATION_JSON)
     public Response getTopologySourceById(@PathParam("topologyId") Long topologyId, @PathParam("id") Long sourceId) {
         try {
             TopologySource source = catalogService.getTopologySource(sourceId);

--- a/streams/service/src/main/java/com/hortonworks/iotas/streams/service/TopologyStreamCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/iotas/streams/service/TopologyStreamCatalogResource.java
@@ -133,7 +133,6 @@ public class TopologyStreamCatalogResource {
     @GET
     @Path("/{id}")
     @Timed
-    @Produces(MediaType.APPLICATION_JSON)
     public Response getStreamInfoById(@PathParam("topologyId") Long topologyId, @PathParam("id") Long id) {
         try {
             StreamInfo streamInfo = catalogService.getStreamInfo(id);

--- a/streams/service/src/main/java/com/hortonworks/iotas/streams/service/UDFCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/iotas/streams/service/UDFCatalogResource.java
@@ -141,7 +141,6 @@ public class UDFCatalogResource {
     @GET
     @Path("/udfs/{id}")
     @Timed
-    @Produces(MediaType.APPLICATION_JSON)
     public Response getUDFById(@PathParam("id") Long id) {
         try {
             UDFInfo result = catalogService.getUDF(id);

--- a/webservice/Cluster.md
+++ b/webservice/Cluster.md
@@ -2,41 +2,65 @@
 
 ## Concepts
 
-
 **Cluster**
 
-A *Cluster* is a top level entity that can be used to define an external components like storm, kafka or spark clusters
-that IOT framework interacts with. A cluster is an aggregation of components that runs on some *Host:port*. 
+A *Cluster* is a top level entity that can be used to create logical container which contains 
+external services.
 
-Field| Type | Comment
----|---|----
-Id   | Integer | The primary key
-name | String| 
-type | Enum  | Storm, Kafka, Spark etc
-description | String| 
-tags | String | E.g For tagging this as test/prod etc
-  
-**Components**
+Field | Type | Comment
+id | Long | The primary key
+name | String | The name of cluster. It should be unique.
+description | String | The description of cluster if any.
 
-A component refers to an entity within a cluster providing a specific functionality. E.g Storm Nimbus, 
-Kafka Broker etc. To keep it simple, rather than creating a separate entity for host, the hostnames (and port) is 
+**Service**
+
+A *Service* defines an external components like storm, kafka, and so on that project interacts with.
+A service entity is belong to a cluster entity.
+
+Field | Type | Comment
+id | Long | The primary key
+clusterId | Long | The cluster's primary key which a service is belong to.
+name | String | The name of service. Combination of cluster id and service name should be unique.
+description | String | The description of service if any.
+
+**ServiceConfiguration**
+
+A *ServiceConfiguration* defines a part of configurations of service. It is designed to match one 
+configuration file of service, like `core-site.xml`, and `storm.yaml`, and so on.
+A service configuration is belong to a service entity.
+
+Field | Type | Comment
+id | Long | The primary key
+serviceId | Long | The service's primary key which a service configuration is belong to.
+name | String | The name of service configuration. Combination of service id and service configuration name should be unique.
+configuration | String | The JSON representation of actual configuration (key, value) pairs. Deserialized Java type is `Map<String, Object>`.
+description | String | The description of service if any.
+filename | String | The filename of configuration. If it's presented, it can be used to be stored and provide actual `config file` to topology.
+
+**Component**
+
+A *component* refers to an an entity within a cluster providing a specific functionality. 
+E.g Storm Nimbus, Kafka Broker etc. To keep it simple, rather than creating a separate entity for host, the hostnames (and port) is  
 directly specified as fields within a component.
 
+A component refers to an entity within a cluster providing a specific functionality. E.g Storm Nimbus, 
+Kafka Broker etc. To keep it simple, rather than creating a separate entity for host, the hostnames (and port, and protocol) is 
+directly specified as fields within a component.
 
 Field| Type | Comment
 ---|---|----
-Id | Integer | The primary key
-clusterId | Integer | Foreign key reference to Cluster.
-name | String |
-type | Enum | The component type. Values are based on Cluster type {NIMBUS, SUPERVISOR, UI, ZK} in Storm, {BROKER, ZK} in Kafka
-description | String | Detailed description of the component.
-config | String | Optional component configuration (json key value pair). Can be used to override deployed properties.
-hosts | String | A list of host names or IP (range expression) where this component runs.
+Id | Long | The primary key
+serviceId | Long | The service's primary key which a component is belong to.
+name | String | The name of component. Combination of service id and component name should be unique.
+hosts | List<String> | A list of host names or IP where this component runs.
+protocol | String | The protocol for communicating with this port.
 port  | Integer | The port number where this component listens.
 
 ## Rest API
 
-Only the create api is specifed now. Others will be added once we finalize.
+We'll describe full CRUD of Cluster, but not for others since Response format for same CRUD is really similar.
+For Service, Service Configuration, and Component, we'll just enumerate which APIs are provided, 
+and show only sample for creating a service, service configuration, component. 
 
 ### Create a cluster
 
@@ -46,10 +70,8 @@ Only the create api is specifed now. Others will be added once we finalize.
 
 ```json
 {
- "name": "Storm cluster",
- "type": "STORM",
- "description": "The storm cluster that handles IOT events",
- "tags": "production"
+ "name": "production",
+ "description": "The production cluster that handles streaming events"
 }
 ```
    
@@ -60,19 +82,18 @@ Only the create api is specifed now. Others will be added once we finalize.
     
 ```json
 {
- "responseCode": 1000,
- "responseMessage": "Success",
- "entity": {
- "id" : 1,
- "clusterName": "Storm cluster",
- "type": "STORM",
- "description": "The storm cluster that handles IOT events",
- "tags": "production"
- }
+  "responseCode": 1000,
+  "responseMessage": "Success",
+  "entity": {
+    "id": 1,
+    "name": "production",
+    "description": "The production cluster that handles streaming events",
+    "timestamp": 1475657006739
+  }
 }
 ```
 
-### Get
+### Get Cluster
 
 `GET /api/v1/catalog/clusters/:clusterid`
 
@@ -88,11 +109,9 @@ Only the create api is specifed now. Others will be added once we finalize.
   "responseMessage": "Success",
   "entity": {
     "id": 1,
-    "name": "Storm cluster",
-    "type": "STORM",
-    "description": "The storm cluster that handles IOT events",
-    "tags": "production",
-    "timestamp": 1440672386842
+    "name": "production",
+    "description": "The production cluster that handles streaming events",
+    "timestamp": 1475657006739
   }
 }
 ```
@@ -105,11 +124,44 @@ Only the create api is specifed now. Others will be added once we finalize.
 ```json
 {
   "responseCode": 1101,
-  "responseMessage": "Entity with id [10] not found."
+  "responseMessage": "Entity with id [10] not found. Please check webservice/ErrorCodes.md for more details."
 }
 ```
 
-### Get All
+`GET /api/v1/catalog/clusters/name/:clustername`
+
+**Success Response**
+
+    GET /api/v1/catalog/clusters/name/production
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+```json
+{
+  "responseCode": 1000,
+  "responseMessage": "Success",
+  "entity": {
+    "id": 1,
+    "name": "production",
+    "description": "The production cluster that handles streaming events",
+    "timestamp": 1475657006739
+  }
+}
+```
+**Error Response**
+
+    GET /api/v1/catalog/clusters/name/production10
+    HTTP/1.1 404 Not Found
+    Content-Type: application/json
+    
+```json
+{
+  "responseCode": 1102,
+  "responseMessage": "Entity with name [production10] not found. Please check webservice/ErrorCodes.md for more details."
+}
+```
+
+### List Clusters
 
 `GET /api/v1/catalog/clusters`
 
@@ -123,27 +175,22 @@ Only the create api is specifed now. Others will be added once we finalize.
   "responseMessage": "Success",
   "entities": [
     {
-      "id": 1,
-      "name": "Storm cluster",
-      "type": "STORM",
-      "description": "The storm cluster that handles IOT events",
-      "tags": "production",
-      "timestamp": 1440672386842
+      "id": 3,
+      "name": "production2",
+      "description": "The production2 cluster that handles streaming events",
+      "timestamp": 1475657136244
     },
     {
-      "id": 2,
-      "name": "Kafka cluster",
-      "type": "KAFKA",
-      "description": "The kafka cluster",
-      "tags": "production",
-      "timestamp": 1440672386842
-    }    
-    ..
-    ..
+      "id": 1,
+      "name": "production",
+      "description": "The production cluster that handles streaming events",
+      "timestamp": 1475657006739
+    }
   ]
 }
 ```
-### Update
+
+### Update Cluster
 
 `PUT /api/v1/catalog/clusters/:clusterid`
 
@@ -151,10 +198,8 @@ Only the create api is specifed now. Others will be added once we finalize.
 
 ```json
 {
- "name": "New Storm cluster",
- "type": "STORM",
- "description": "The storm cluster that handles IOT events",
- "tags": "production"
+	"name": "production-new",
+	"description": "The new-production cluster that handles streaming events"
 }
 ```
 
@@ -169,16 +214,14 @@ Only the create api is specifed now. Others will be added once we finalize.
   "responseMessage": "Success",
   "entity": {
     "id": 1,
-    "name": "New Storm cluster",
-    "type": "STORM",
-    "description": "The storm cluster that handles IOT events",
-    "tags": "production",
-    "timestamp": 1440672956507
+    "name": "production-new",
+    "description": "The new-production cluster that handles streaming events",
+    "timestamp": 1475657294903
   }
 }
 ```
 
-### Delete
+### Delete Cluster
 
 `DELETE /api/v1/catalog/clusters/:clusterid`
 
@@ -193,30 +236,25 @@ Only the create api is specifed now. Others will be added once we finalize.
   "responseMessage": "Success",
   "entity": {
     "id": 1,
-    "name": "Storm cluster",
-    "type": "STORM",
-    "description": "The storm cluster that handles IOT events",
-    "tags": "production",
-    "timestamp": 1440672386842
+    "name": "production-new",
+    "description": "The new-production cluster that handles streaming events",
+    "timestamp": 1475657294903
   }
 }
 ```
 
 
-### Create components
+### Create Services
 
-`POST /api/v1/clusters/:clusterid/components`
+`POST /api/v1/clusters/:clusterId/services`
 
 **Sample Input**
 
 ```json
 {
- "name": "Nimbus",
- "type": "NIMBUS",
- "description": "Storm nimbus servers",
- "config": "",
- "hosts": "storm[1-2].hortonworks.com",
- "port": 6627
+  "clusterId": 3,
+  "name": "HIVE",
+  "description": ""
 }
 ```
    
@@ -230,148 +268,114 @@ Only the create api is specifed now. Others will be added once we finalize.
   "responseCode": 1000,
   "responseMessage": "Success",
   "entity": {
-    "id": 1,
-    "clusterId": 1,
-    "name": "Nimbus",
-    "type": "NIMBUS",
-    "description": "Storm nimbus servers",
-    "config": "",
-    "hosts": "storm[1-2].hortonworks.com",
-    "port": 6627,
-    "timestamp": 1440673170488
+    "id": 13,
+    "clusterId": 3,
+    "name": "HIVE",
+    "description": "",
+    "timestamp": 1475660875465
   }
 }
 ```
 
-### Get
+### List Services
 
-`GET /api/v1/catalog/clusters/:clusterid/components/:componentid`
+`GET /api/v1/catalog/clusters/:clusterId/services`
 
+`GET /api/v1/catalog/clusters/name/:clusterName/services`
+
+### Get Service
+
+`GET /api/v1/catalog/clusters/{clusterId}/services/{id}`
+
+`GET /api/v1/catalog/clusters/name/{clusterName}/services/name/{serviceName}`
+
+### Update Service
+
+`PUT /api/v1/catalog/clusters/{clusterId}/services/{id}`
+
+### Delete Service
+
+`DELETE /api/v1/catalog/clusters/{clusterId}/services/{id}`
+
+### Create Service Configurations
+
+`POST /api/v1/catalog/services/{serviceId}/configurations`
+
+
+**Sample Input**
+
+```json
+{
+  "serviceId": 13,
+  "name": "hive-interactive-site",
+  "configuration": "{\"hive.driver.parallel.compilation\":\"true\",\"hive.exec.orc.split.strategy\":\"HYBRID\",\"hive.execution.engine\":\"tez\",\"hive.execution.mode\":\"llap\",\"hive.llap.auto.allow.uber\":\"false\",\"hive.llap.client.consistent.splits\":\"true\",\"hive.llap.daemon.allow.permanent.fns\":\"false\",\"hive.llap.daemon.memory.per.instance.mb\":\"250\",\"hive.llap.daemon.num.executors\":\"1\",\"hive.llap.daemon.queue.name\":\"default\",\"hive.llap.daemon.rpc.port\":\"15001\",\"hive.llap.daemon.service.hosts\":\"@llap0\",\"hive.llap.daemon.task.scheduler.enable.preemption\":\"true\",\"hive.llap.daemon.vcpus.per.instance\":\"${hive.llap.daemon.num.executors}\",\"hive.llap.daemon.work.dirs\":\"${yarn.nodemanager.local-dirs}\",\"hive.llap.daemon.yarn.container.mb\":\"341\",\"hive.llap.daemon.yarn.shuffle.port\":\"15551\",\"hive.llap.execution.mode\":\"all\",\"hive.llap.io.enabled\":\"true\",\"hive.llap.io.memory.mode\":\"cache\",\"hive.llap.io.memory.size\":\"0\",\"hive.llap.io.threadpool.size\":\"2\",\"hive.llap.io.use.lrfu\":\"true\",\"hive.llap.management.rpc.port\":\"15004\",\"hive.llap.object.cache.enabled\":\"true\",\"hive.llap.task.scheduler.locality.delay\":\"-1\",\"hive.llap.zk.sm.connectionString\":\"sandbox.hortonworks.com:2181\",\"hive.mapjoin.hybridgrace.hashtable\":\"false\",\"hive.metastore.event.listeners\":\"\",\"hive.metastore.uris\":\"\",\"hive.optimize.dynamic.partition.hashjoin\":\"true\",\"hive.prewarm.enabled\":\"false\",\"hive.server2.enable.doAs\":\"false\",\"hive.server2.tez.default.queues\":\"default\",\"hive.server2.tez.initialize.default.sessions\":\"true\",\"hive.server2.tez.sessions.per.default.queue\":\"1\",\"hive.server2.thrift.http.port\":\"10501\",\"hive.server2.thrift.port\":\"10500\",\"hive.server2.webui.port\":\"10502\",\"hive.server2.webui.use.ssl\":\"false\",\"hive.server2.zookeeper.namespace\":\"hiveserver2-hive2\",\"hive.tez.bucket.pruning\":\"true\",\"hive.tez.exec.print.summary\":\"true\",\"hive.tez.input.generate.consistent.splits\":\"true\",\"hive.vectorized.execution.mapjoin.minmax.enabled\":\"true\",\"hive.vectorized.execution.mapjoin.native.enabled\":\"true\",\"hive.vectorized.execution.mapjoin.native.fast.hashtable.enabled\":\"true\",\"hive.vectorized.execution.reduce.enabled\":\"true\",\"llap.shuffle.connection-keep-alive.enable\":\"true\",\"llap.shuffle.connection-keep-alive.timeout\":\"60\"}",
+  "description": "",
+  "filename": "hive-interactive-site.xml"
+}
+```
+   
 **Success Response**
 
-    GET /api/v1/catalog/clusters/1/components/1
-    HTTP/1.1 200 OK
+    HTTP/1.1 201 Created
     Content-Type: application/json
-
+    
 ```json
 {
   "responseCode": 1000,
   "responseMessage": "Success",
   "entity": {
-    "id": 1,
-    "clusterId": 1,
-    "name": "Nimbus",
-    "type": "NIMBUS",
-    "description": "Storm nimbus servers",
-    "config": "",
-    "hosts": "storm[1-2].hortonworks.com",
-    "port": 6627,
-    "timestamp": 1440673170488
+    "id": 37,
+    "serviceId": 13,
+    "name": "hive-interactive-site",
+    "configuration": "{\"hive.driver.parallel.compilation\":\"true\",\"hive.exec.orc.split.strategy\":\"HYBRID\",\"hive.execution.engine\":\"tez\",\"hive.execution.mode\":\"llap\",\"hive.llap.auto.allow.uber\":\"false\",\"hive.llap.client.consistent.splits\":\"true\",\"hive.llap.daemon.allow.permanent.fns\":\"false\",\"hive.llap.daemon.memory.per.instance.mb\":\"250\",\"hive.llap.daemon.num.executors\":\"1\",\"hive.llap.daemon.queue.name\":\"default\",\"hive.llap.daemon.rpc.port\":\"15001\",\"hive.llap.daemon.service.hosts\":\"@llap0\",\"hive.llap.daemon.task.scheduler.enable.preemption\":\"true\",\"hive.llap.daemon.vcpus.per.instance\":\"${hive.llap.daemon.num.executors}\",\"hive.llap.daemon.work.dirs\":\"${yarn.nodemanager.local-dirs}\",\"hive.llap.daemon.yarn.container.mb\":\"341\",\"hive.llap.daemon.yarn.shuffle.port\":\"15551\",\"hive.llap.execution.mode\":\"all\",\"hive.llap.io.enabled\":\"true\",\"hive.llap.io.memory.mode\":\"cache\",\"hive.llap.io.memory.size\":\"0\",\"hive.llap.io.threadpool.size\":\"2\",\"hive.llap.io.use.lrfu\":\"true\",\"hive.llap.management.rpc.port\":\"15004\",\"hive.llap.object.cache.enabled\":\"true\",\"hive.llap.task.scheduler.locality.delay\":\"-1\",\"hive.llap.zk.sm.connectionString\":\"sandbox.hortonworks.com:2181\",\"hive.mapjoin.hybridgrace.hashtable\":\"false\",\"hive.metastore.event.listeners\":\"\",\"hive.metastore.uris\":\"\",\"hive.optimize.dynamic.partition.hashjoin\":\"true\",\"hive.prewarm.enabled\":\"false\",\"hive.server2.enable.doAs\":\"false\",\"hive.server2.tez.default.queues\":\"default\",\"hive.server2.tez.initialize.default.sessions\":\"true\",\"hive.server2.tez.sessions.per.default.queue\":\"1\",\"hive.server2.thrift.http.port\":\"10501\",\"hive.server2.thrift.port\":\"10500\",\"hive.server2.webui.port\":\"10502\",\"hive.server2.webui.use.ssl\":\"false\",\"hive.server2.zookeeper.namespace\":\"hiveserver2-hive2\",\"hive.tez.bucket.pruning\":\"true\",\"hive.tez.exec.print.summary\":\"true\",\"hive.tez.input.generate.consistent.splits\":\"true\",\"hive.vectorized.execution.mapjoin.minmax.enabled\":\"true\",\"hive.vectorized.execution.mapjoin.native.enabled\":\"true\",\"hive.vectorized.execution.mapjoin.native.fast.hashtable.enabled\":\"true\",\"hive.vectorized.execution.reduce.enabled\":\"true\",\"llap.shuffle.connection-keep-alive.enable\":\"true\",\"llap.shuffle.connection-keep-alive.timeout\":\"60\"}",
+    "description": "",
+    "filename": "hive-interactive-site.xml",
+    "timestamp": 1475677909645
   }
 }
 ```
 
-**Error Response**
+### List Service Configurations
 
-    GET /api/v1/catalog/clusters/1/components/10
-    HTTP/1.1 404 Not Found
-    Content-Type: application/json
-    
-```json
-{
-  "responseCode": 1101,
-  "responseMessage": "Entity with id [10] not found."
-}
-```
-    
-### Get All
+`GET /api/v1/catalog/services/:serviceId/configurations`
 
-`GET /api/v1/catalog/clusters/:clusterid/components`
+`GET /api/v1/catalog/services/name/:serviceName/configurations`
 
-    GET /api/v1/catalog/clusters/1/components
-    HTTP/1.1 200 OK
-    Content-Type: application/json
+### Get Service Configuration
 
-```json
-{
-  "responseCode": 1000,
-  "responseMessage": "Success",
-  "entities": [
-    {
-      "id": 2,
-      "clusterId": 1,
-      "name": "Supervisor",
-      "type": "SUPERVISOR",
-      "description": "Storm supervisor servers",
-      "config": "",
-      "hosts": "storm[1-2].hortonworks.com",
-      "port": 6627,
-      "timestamp": 1440669873019
-    },
-    {
-      "id": 1,
-      "clusterId": 1,
-      "name": "Nimbus",
-      "type": "NIMBUS",
-      "description": "Storm nimbus servers",
-      "config": "",
-      "hosts": "storm[1-2].hortonworks.com",
-      "port": 6627,
-      "timestamp": 1440669538339
-    }
-    ..
-    ..
-  ]
-}
-```
+`GET /api/v1/catalog/services/:serviceId/configurations/:configurationId`
 
-### Update
+`GET /api/v1/catalog/clusters/name/:clusterName/services/name/:serviceName/configurations/:configurationName`
 
-`PUT /api/v1/catalog/clusters/:clusterid/components/:componentid`
+### Update Service Configuration
 
-*Sample Input*
+`PUT /api/v1/catalog/services/:serviceId/configurations/:configurationId`
+
+### Delete Service Configuration
+
+`DELETE /api/v1/catalog/services/:serviceId/configurations/:configurationId`
+
+### Create components
+
+`POST /api/v1/services/:serviceId/components`
+
+**Sample Input**
 
 ```json
 {
-    "name": "New Supervisor",
-    "type": "SUPERVISOR",
-    "description": "Storm supervisor servers",
-    "config": "",
-    "hosts": "storm[1-2].hortonworks.com",
-    "port": 6627
+  "serviceId": 13,
+  "name": "HIVE_SERVER",
+  "hosts": [
+    "sandbox.hortonworks.com"
+  ],
+  "protocol": "thrift",
+  "port": 10500
 }
 ```
-
-*Success Response*
-
-    HTTP/1.1 200 OK
-    Content-Type: application/json
    
-```json
-{
-  "responseCode": 1000,
-  "responseMessage": "Success",
-  "entity": {
-    "id": 1,
-    "clusterId": 1,
-    "name": "New Supervisor",
-    "type": "SUPERVISOR",
-    "description": "Storm supervisor servers",
-    "config": "",
-    "hosts": "storm[1-2].hortonworks.com",
-    "port": 6627,
-    "timestamp": 1440673315032
-  }
-}
-```
+**Success Response**
 
-### Delete
-
-`DELETE /api/v1/catalog/clusters/:clusterid/components/:componentid`
-
-*Success Response*
-
-    HTTP/1.1 200 OK
+    HTTP/1.1 201 Created
     Content-Type: application/json
     
 ```json
@@ -379,15 +383,36 @@ Only the create api is specifed now. Others will be added once we finalize.
   "responseCode": 1000,
   "responseMessage": "Success",
   "entity": {
-    "id": 2,
-    "clusterId": 1,
-    "name": "Supervisor",
-    "type": "SUPERVISOR",
-    "description": "Storm supervisor servers",
-    "config": "",
-    "hosts": "storm[1-2].hortonworks.com",
-    "port": 6627,
-    "timestamp": 1440669873019
+    "id": 39,
+    "serviceId": 13,
+    "name": "HIVE_SERVER",
+    "hosts": [
+      "sandbox.hortonworks.com"
+    ],
+    "protocol": "thrift",
+    "port": 10500,
+    "timestamp": 1475678254672
   }
 }
 ```
+
+### List Components
+
+`GET /api/v1/catalog/clusters/:clusterId/services`
+
+`GET /api/v1/catalog/clusters/name/:clusterName/services`
+
+### Get Component
+
+`GET /api/v1/catalog/clusters/{clusterId}/services/{id}`
+
+`GET /api/v1/catalog/clusters/name/{clusterName}/services/name/{serviceName}`
+
+### Update Component
+
+`PUT /api/v1/catalog/services/{serviceId}/configurations/{id}`
+
+### Delete Component
+
+`DELETE /api/v1/catalog/services/{serviceId}/configurations/{id}`
+

--- a/webservice/conf/iotas.yaml
+++ b/webservice/conf/iotas.yaml
@@ -88,10 +88,9 @@ storageProviderConfiguration:
 
 # Time series DB querier configuration
 #timeSeriesDBConfiguration:
-#  className: ""com.hortonworks.iotas.metrics.streams.storm.ambari.AmbariMetricsServiceWithStormQuerier"
+#  className: "com.hortonworks.iotas.metrics.streams.storm.ambari.AmbariMetricsServiceWithStormQuerier"
 #  properties:
 #    - collectorApiUrl: "http://localhost:6188/ws/v1/timeline/metrics"
-
 
 # use the simple server factory if you only want to run on a single port
 #server:

--- a/webservice/src/main/java/com/hortonworks/iotas/webservice/IotasApplication.java
+++ b/webservice/src/main/java/com/hortonworks/iotas/webservice/IotasApplication.java
@@ -112,8 +112,6 @@ public class IotasApplication extends Application<IotasConfiguration> {
         return CacheBuilder.newBuilder().maximumSize(maxSize);
     }
 
-
-
     private FileStorage getJarStorage (IotasConfiguration configuration) {
         FileStorage fileStorage = null;
         try {

--- a/webservice/src/main/java/com/hortonworks/iotas/webservice/IotasConfiguration.java
+++ b/webservice/src/main/java/com/hortonworks/iotas/webservice/IotasConfiguration.java
@@ -39,6 +39,8 @@ public class IotasConfiguration extends Configuration {
     @NotNull
     private StorageProviderConfiguration storageProviderConfiguration;
 
+    private TimeSeriesDBConfiguration timeSeriesDBConfiguration;
+
     @JsonProperty
     public StorageProviderConfiguration getStorageProviderConfiguration() {
         return storageProviderConfiguration;
@@ -49,8 +51,6 @@ public class IotasConfiguration extends Configuration {
         this.storageProviderConfiguration = storageProviderConfiguration;
     }
 
-
-    private TimeSeriesDBConfiguration timeSeriesDBConfiguration;
 
     public String getCatalogRootUrl () {
         return catalogRootUrl;


### PR DESCRIPTION
Change description:
- introduce ServiceNodeDisconverer
  - retrieve services and associated components
  - retrieve configuration for such service
- introduce ServiceDiscoveryResource
  - which serves like a proxy to Ambari Resource REST API
  - and also provides a feature: importing Ambari services/components/configurations to Cluster
- restructure Cluster and Component
  - Cluster: logical type (not meant to STORM, KAFKA, etc.)
  - Service: STORM, KAFKA, etc.
  - Component: NIMBUS, SUPERVISOR, etc.
- WARN: commented the feature of importing configuration file, and adding them to topology jar

Usage of import:
- register cluster first via calling /v1/api/catalog/clusters with POST
  - content-type: application/json
  - content: refer `Cluster` class
- call import API with cluster id via calling /v1/api/discovery/import/clusters
  - content-type: application/json
  - content: refer `Cluster` class, but only need to input `id`
  - response will show how services / components are imported to given cluster

The way to query Cluster, Service, Component is similar with other catalogs.

Might be needed to sort out modules/packages since I'm not clear on refactored modules.

TODO (might skip some if we think it can be)
- Didn't add tests for querying Ambari side yet.
- API paths are not cleared. 
  - Please refer the comments from https://hwxiot.atlassian.net/browse/IOT-393
  - Need to make it clear with @hmcl and @harshach. 
  - Would like to here other reviewers' opinions.
- I only added some of component port finding rules. Need to add more to try best finding for components.

Below is what I got the response from import API. 
These services / components are also stored to the backend so able to get them via relevant catalog REST API.

```
{
    "responseCode": 1000,
    "responseMessage": "Success",
    "entity": {
        "cluster": {
            "id": 1,
            "name": "c1",
            "description": "test cluster",
            "timestamp": 1475225386981
        },
        "services": [
            {
                "service": {
                    "id": 5,
                    "clusterId": 1,
                    "name": "HDFS",
                    "description": "",
                    "timestamp": 1475225400200,
                    "configuration": "{\"ipc.server.tcpnodelay\":\"true\",\"mapreduce.jobtracker.webinterface.trusted\":\"false\",\"dfs.replication\":\"1\",\"hadoop.security.auth_to_local\":\"DEFAULT\",\"dfs.namenode.audit.log.async\":\"true\",\"dfs.namenode.checkpoint.dir\":\"/hadoop/hdfs/namesecondary\",\"hdfs_log_dir_prefix\":\"/var/log/hadoop\",\"dfs.namenode.avoid.read.stale.datanode\":\"true\",\"nfs.file.dump.dir\":\"/tmp/.hdfs-nfs\",\"ipc.client.connection.maxidletime\":\"30000\",\"keyserver_port\":\"\",\"dfs.namenode.https-address\":\"sandbox.hortonworks.com:50470\",\"dfs.encrypt.data.transfer.cipher.suites\":\"AES/CTR/NoPadding\",\"dfs.hosts.exclude\":\"/etc/hadoop/conf/dfs.exclude\",\"hadoop_pid_dir_prefix\":\"/var/run/hadoop\",\"security.refresh.policy.protocol.acl\":\"hadoop\",\"security.namenode.protocol.acl\":\"*\",\"security.client.datanode.protocol.acl\":\"*\",\"dfs.namenode.fslock.fair\":\"false\",\"net.topology.script.file.name\":\"/etc/hadoop/conf/topology_script.py\",\"dfs.permissions.enabled\":\"true\",\"dfs.datanode.balance.bandwidthPerSec\":\"6250000\",\"dfs.namenode.stale.datanode.interval\":\"30000\",\"io.serializations\":\"org.apache.hadoop.io.serializer.WritableSerialization\",\"dfs.http.policy\":\"HTTP_ONLY\",\"io.compression.codec.lzo.class\":\"com.hadoop.compression.lzo.LzoCodec\",\"security.inter.tracker.protocol.acl\":\"*\",\"hadoop.proxyuser.root.groups\":\"*\",\"dfs.domain.socket.path\":\"/var/lib/hadoop-hdfs/dn_socket\",\"security.client.protocol.acl\":\"*\",\"dfs.namenode.handler.count\":\"25\",\"dfs.replication.max\":\"50\",\"dfs.webhdfs.enabled\":\"true\",\"security.inter.datanode.protocol.acl\":\"*\",\"hadoop.proxyuser.hdfs.groups\":\"*\",\"dfs.namenode.name.dir\":\"/hadoop/hdfs/namenode\",\"dfs.namenode.avoid.write.stale.datanode\":\"true\",\"hdfs_tmp_dir\":\"/tmp\",\"fs.trash.interval\":\"360\",\"dfs.datanode.https.address\":\"0.0.0.0:50475\",\"dfs.datanode.failed.volumes.tolerated\":\"0\",\"hadoop.proxyuser.hcat.groups\":\"*\",\"hdfs_user_nproc_limit\":\"65536\",\"hadoop.proxyuser.hbase.hosts\":\"*\",\"dfs.block.access.token.enable\":\"true\",\"dfs.datanode.data.dir\":\"/hadoop/hdfs/data\",\"namenode_opt_maxnewsize\":\"100m\",\"hadoop.proxyuser.hive.hosts\":\"sandbox.hortonworks.com\",\"proxyuser_group\":\"users\",\"dfs.blocksize\":\"134217728\",\"nfs.exports.allowed.hosts\":\"* rw\",\"dfs.datanode.address\":\"0.0.0.0:50010\",\"dfs.datanode.data.dir.perm\":\"750\",\"ipc.client.connect.max.retries\":\"50\",\"dfs.namenode.write.stale.datanode.ratio\":\"1.0f\",\"io.file.buffer.size\":\"131072\",\"hadoop.proxyuser.falcon.hosts\":\"*\",\"hadoop.proxyuser.oozie.hosts\":\"sandbox.hortonworks.com\",\"dfs.namenode.checkpoint.txns\":\"1000000\",\"dfs.journalnode.edits.dir\":\"/hadoop/hdfs/journalnode\",\"nfsgateway_heapsize\":\"1024\",\"hadoop.proxyuser.oozie.groups\":\"*\",\"dfs.namenode.safemode.threshold-pct\":\"1.000\",\"keyserver_host\":\" \",\"security.job.client.protocol.acl\":\"*\",\"hadoop_heapsize\":\"250\",\"security.refresh.usertogroups.mappings.protocol.acl\":\"hadoop\",\"dtnode_heapsize\":\"250m\",\"hadoop.proxyuser.falcon.groups\":\"*\",\"hadoop.security.key.provider.path\":\"\",\"ipc.client.idlethreshold\":\"8000\",\"dfs.encryption.key.provider.uri\":\"\",\"dfs.journalnode.http-address\":\"0.0.0.0:8480\",\"hadoop.http.authentication.simple.anonymous.allowed\":\"true\",\"hadoop.security.authorization\":\"false\",\"dfs.namenode.rpc-address\":\"sandbox.hortonworks.com:8020\",\"security.job.task.protocol.acl\":\"*\",\"hadoop.security.authentication\":\"simple\",\"hadoop.proxyuser.hdfs.hosts\":\"*\",\"dfs.client.read.shortcircuit.streams.cache.size\":\"4096\",\"hadoop.proxyuser.hue.hosts\":\"*\",\"hdfs_user\":\"hdfs\",\"namenode_heapsize\":\"250m\",\"dfs.namenode.accesstime.precision\":\"0\",\"namenode_opt_maxpermsize\":\"256m\",\"hadoop.proxyuser.hcat.hosts\":\"sandbox.hortonworks.com\",\"hadoop.proxyuser.hue.groups\":\"*\",\"io.compression.codecs\":\"org.apache.hadoop.io.compress.GzipCodec,org.apache.hadoop.io.compress.DefaultCodec,org.apache.hadoop.io.compress.SnappyCodec,com.hadoop.compression.lzo.LzoCodec,com.hadoop.compression.lzo.LzopCodec\",\"hadoop.proxyuser.hive.groups\":\"*\",\"fs.defaultFS\":\"hdfs://sandbox.hortonworks.com:8020\",\"dfs.content-summary.limit\":\"5000\",\"security.datanode.protocol.acl\":\"*\",\"dfs.journalnode.https-address\":\"0.0.0.0:8481\",\"dfs.datanode.du.reserved\":\"1073741824\",\"dfs.datanode.ipc.address\":\"0.0.0.0:8010\",\"dfs.cluster.administrators\":\" hdfs\",\"dfs.datanode.max.transfer.threads\":\"16384\",\"content\":\"\\n# Set Hadoop-specific environment variables here.\\n\\n# The only required environment variable is JAVA_HOME.  All others are\\n# optional.  When running a distributed configuration it is best to\\n# set JAVA_HOME in this file, so that it is correctly defined on\\n# remote nodes.\\n\\n# The java implementation to use.  Required.\\nexport JAVA_HOME={{java_home}}\\nexport HADOOP_HOME_WARN_SUPPRESS=1\\n\\n# Hadoop home directory\\nexport HADOOP_HOME=${HADOOP_HOME:-{{hadoop_home}}}\\n\\n# Hadoop Configuration Directory\\n\\n{# this is different for HDP1 #}\\n# Path to jsvc required by secure HDP 2.0 datanode\\nexport JSVC_HOME={{jsvc_path}}\\n\\n\\n# The maximum amount of heap to use, in MB. Default is 1000.\\nexport HADOOP_HEAPSIZE=\\\"{{hadoop_heapsize}}\\\"\\n\\nexport HADOOP_NAMENODE_INIT_HEAPSIZE=\\\"-Xms{{namenode_heapsize}}\\\"\\n\\n# Extra Java runtime options.  Empty by default.\\nexport HADOOP_OPTS=\\\"-Djava.net.preferIPv4Stack=true ${HADOOP_OPTS}\\\"\\n\\n# Command specific options appended to HADOOP_OPTS when specified\\nHADOOP_JOBTRACKER_OPTS=\\\"-server -XX:ParallelGCThreads=8 -XX:+UseConcMarkSweepGC -XX:ErrorFile={{hdfs_log_dir_prefix}}/$USER/hs_err_pid%p.log -XX:NewSize={{jtnode_opt_newsize}} -XX:MaxNewSize={{jtnode_opt_maxnewsize}} -Xloggc:{{hdfs_log_dir_prefix}}/$USER/gc.log-`date +'%Y%m%d%H%M'` -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xmx{{jtnode_heapsize}} -Dhadoop.security.logger=INFO,DRFAS -Dmapred.audit.logger=INFO,MRAUDIT -Dhadoop.mapreduce.jobsummary.logger=INFO,JSA ${HADOOP_JOBTRACKER_OPTS}\\\"\\n\\nHADOOP_TASKTRACKER_OPTS=\\\"-server -Xmx{{ttnode_heapsize}} -Dhadoop.security.logger=ERROR,console -Dmapred.audit.logger=ERROR,console ${HADOOP_TASKTRACKER_OPTS}\\\"\\n\\n{% if java_version < 8 %}\\nSHARED_HADOOP_NAMENODE_OPTS=\\\"-server -XX:ParallelGCThreads=8 -XX:+UseConcMarkSweepGC -XX:ErrorFile={{hdfs_log_dir_prefix}}/$USER/hs_err_pid%p.log -XX:NewSize={{namenode_opt_newsize}} -XX:MaxNewSize={{namenode_opt_maxnewsize}} -XX:PermSize={{namenode_opt_permsize}} -XX:MaxPermSize={{namenode_opt_maxpermsize}} -Xloggc:{{hdfs_log_dir_prefix}}/$USER/gc.log-`date +'%Y%m%d%H%M'` -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:CMSInitiatingOccupancyFraction=70 -XX:+UseCMSInitiatingOccupancyOnly -Xms{{namenode_heapsize}} -Xmx{{namenode_heapsize}} -Dhadoop.security.logger=INFO,DRFAS -Dhdfs.audit.logger=INFO,DRFAAUDIT\\\"\\nexport HADOOP_NAMENODE_OPTS=\\\"${SHARED_HADOOP_NAMENODE_OPTS} -XX:OnOutOfMemoryError=\\\\\\\"/usr/hdp/current/hadoop-hdfs-namenode/bin/kill-name-node\\\\\\\" -Dorg.mortbay.jetty.Request.maxFormContentSize=-1 ${HADOOP_NAMENODE_OPTS}\\\"\\nexport HADOOP_DATANODE_OPTS=\\\"-server -XX:ParallelGCThreads=4 -XX:+UseConcMarkSweepGC -XX:ErrorFile=/var/log/hadoop/$USER/hs_err_pid%p.log -XX:NewSize=200m -XX:MaxNewSize=200m -XX:PermSize=128m -XX:MaxPermSize=256m -Xloggc:/var/log/hadoop/$USER/gc.log-`date +'%Y%m%d%H%M'` -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xms{{dtnode_heapsize}} -Xmx{{dtnode_heapsize}} -Dhadoop.security.logger=INFO,DRFAS -Dhdfs.audit.logger=INFO,DRFAAUDIT ${HADOOP_DATANODE_OPTS}\\\"\\n\\nexport HADOOP_SECONDARYNAMENODE_OPTS=\\\"${SHARED_HADOOP_NAMENODE_OPTS} -XX:OnOutOfMemoryError=\\\\\\\"/usr/hdp/current/hadoop-hdfs-secondarynamenode/bin/kill-secondary-name-node\\\\\\\" ${HADOOP_SECONDARYNAMENODE_OPTS}\\\"\\n\\n# The following applies to multiple commands (fs, dfs, fsck, distcp etc)\\nexport HADOOP_CLIENT_OPTS=\\\"-Xmx${HADOOP_HEAPSIZE}m -XX:MaxPermSize=512m $HADOOP_CLIENT_OPTS\\\"\\n\\n{% else %}\\nSHARED_HADOOP_NAMENODE_OPTS=\\\"-server -XX:ParallelGCThreads=8 -XX:+UseConcMarkSweepGC -XX:ErrorFile={{hdfs_log_dir_prefix}}/$USER/hs_err_pid%p.log -XX:NewSize={{namenode_opt_newsize}} -XX:MaxNewSize={{namenode_opt_maxnewsize}} -Xloggc:{{hdfs_log_dir_prefix}}/$USER/gc.log-`date +'%Y%m%d%H%M'` -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:CMSInitiatingOccupancyFraction=70 -XX:+UseCMSInitiatingOccupancyOnly -Xms{{namenode_heapsize}} -Xmx{{namenode_heapsize}} -Dhadoop.security.logger=INFO,DRFAS -Dhdfs.audit.logger=INFO,DRFAAUDIT\\\"\\nexport HADOOP_NAMENODE_OPTS=\\\"${SHARED_HADOOP_NAMENODE_OPTS} -XX:OnOutOfMemoryError=\\\\\\\"/usr/hdp/current/hadoop-hdfs-namenode/bin/kill-name-node\\\\\\\" -Dorg.mortbay.jetty.Request.maxFormContentSize=-1 ${HADOOP_NAMENODE_OPTS}\\\"\\nexport HADOOP_DATANODE_OPTS=\\\"-server -XX:ParallelGCThreads=4 -XX:+UseConcMarkSweepGC -XX:ErrorFile=/var/log/hadoop/$USER/hs_err_pid%p.log -XX:NewSize=200m -XX:MaxNewSize=200m -Xloggc:/var/log/hadoop/$USER/gc.log-`date +'%Y%m%d%H%M'` -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xms{{dtnode_heapsize}} -Xmx{{dtnode_heapsize}} -Dhadoop.security.logger=INFO,DRFAS -Dhdfs.audit.logger=INFO,DRFAAUDIT ${HADOOP_DATANODE_OPTS}\\\"\\n\\nexport HADOOP_SECONDARYNAMENODE_OPTS=\\\"${SHARED_HADOOP_NAMENODE_OPTS} -XX:OnOutOfMemoryError=\\\\\\\"/usr/hdp/current/hadoop-hdfs-secondarynamenode/bin/kill-secondary-name-node\\\\\\\" ${HADOOP_SECONDARYNAMENODE_OPTS}\\\"\\n\\n# The following applies to multiple commands (fs, dfs, fsck, distcp etc)\\nexport HADOOP_CLIENT_OPTS=\\\"-Xmx${HADOOP_HEAPSIZE}m $HADOOP_CLIENT_OPTS\\\"\\n{% endif %}\\n\\nHADOOP_NFS3_OPTS=\\\"-Xmx{{nfsgateway_heapsize}}m -Dhadoop.security.logger=ERROR,DRFAS ${HADOOP_NFS3_OPTS}\\\"\\nHADOOP_BALANCER_OPTS=\\\"-server -Xmx{{hadoop_heapsize}}m ${HADOOP_BALANCER_OPTS}\\\"\\n\\n\\n# On secure datanodes, user to run the datanode as after dropping privileges\\nexport HADOOP_SECURE_DN_USER=${HADOOP_SECURE_DN_USER:-{{hadoop_secure_dn_user}}}\\n\\n# Extra ssh options.  Empty by default.\\nexport HADOOP_SSH_OPTS=\\\"-o ConnectTimeout=5 -o SendEnv=HADOOP_CONF_DIR\\\"\\n\\n# Where log files are stored.  $HADOOP_HOME/logs by default.\\nexport HADOOP_LOG_DIR={{hdfs_log_dir_prefix}}/$USER\\n\\n# History server logs\\nexport HADOOP_MAPRED_LOG_DIR={{mapred_log_dir_prefix}}/$USER\\n\\n# Where log files are stored in the secure data environment.\\nexport HADOOP_SECURE_DN_LOG_DIR={{hdfs_log_dir_prefix}}/$HADOOP_SECURE_DN_USER\\n\\n# File naming remote slave hosts.  $HADOOP_HOME/conf/slaves by default.\\n# export HADOOP_SLAVES=${HADOOP_HOME}/conf/slaves\\n\\n# host:path where hadoop code should be rsync'd from.  Unset by default.\\n# export HADOOP_MASTER=master:/home/$USER/src/hadoop\\n\\n# Seconds to sleep between slave commands.  Unset by default.  This\\n# can be useful in large clusters, where, e.g., slave rsyncs can\\n# otherwise arrive faster than the master can service them.\\n# export HADOOP_SLAVE_SLEEP=0.1\\n\\n# The directory where pid files are stored. /tmp by default.\\nexport HADOOP_PID_DIR={{hadoop_pid_dir_prefix}}/$USER\\nexport HADOOP_SECURE_DN_PID_DIR={{hadoop_pid_dir_prefix}}/$HADOOP_SECURE_DN_USER\\n\\n# History server pid\\nexport HADOOP_MAPRED_PID_DIR={{mapred_pid_dir_prefix}}/$USER\\n\\nYARN_RESOURCEMANAGER_OPTS=\\\"-Dyarn.server.resourcemanager.appsummary.logger=INFO,RMSUMMARY\\\"\\n\\n# A string representing this instance of hadoop. $USER by default.\\nexport HADOOP_IDENT_STRING=$USER\\n\\n# The scheduling priority for daemon processes.  See 'man nice'.\\n\\n# export HADOOP_NICENESS=10\\n\\n# Add database libraries\\nJAVA_JDBC_LIBS=\\\"\\\"\\nif [ -d \\\"/usr/share/java\\\" ]; then\\n  for jarFile in `ls /usr/share/java | grep -E \\\"(mysql|ojdbc|postgresql|sqljdbc)\\\" 2>/dev/null`\\n  do\\n    JAVA_JDBC_LIBS=${JAVA_JDBC_LIBS}:$jarFile\\n  done\\nfi\\n\\n# Add libraries to the hadoop classpath - some may not need a colon as they already include it\\nexport HADOOP_CLASSPATH=${HADOOP_CLASSPATH}${JAVA_JDBC_LIBS}\\n\\n# Setting path to hdfs command line\\nexport HADOOP_LIBEXEC_DIR={{hadoop_libexec_dir}}\\n\\n# Mostly required for hadoop 2.0\\nexport JAVA_LIBRARY_PATH=${JAVA_LIBRARY_PATH}\\n\\nexport HADOOP_OPTS=\\\"-Dhdp.version=$HDP_VERSION $HADOOP_OPTS\\\"\\n\\n{% if is_datanode_max_locked_memory_set %}\\n# Fix temporary bug, when ulimit from conf files is not picked up, without full relogin. \\n# Makes sense to fix only when runing DN as root \\nif [ \\\"$command\\\" == \\\"datanode\\\" ] && [ \\\"$EUID\\\" -eq 0 ] && [ -n \\\"$HADOOP_SECURE_DN_USER\\\" ]; then\\n  ulimit -l {{datanode_max_locked_memory}}\\nfi\\n{% endif %}\",\"dfs.https.port\":\"50470\",\"namenode_opt_newsize\":\"50m\",\"dfs.client.read.shortcircuit\":\"true\",\"dfs.namenode.http-address\":\"sandbox.hortonworks.com:50070\",\"security.admin.operations.protocol.acl\":\"hadoop\",\"dfs.client.retry.policy.enabled\":\"false\",\"dfs.namenode.inode.attributes.provider.class\":\"org.apache.ranger.authorization.hadoop.RangerHdfsAuthorizer\",\"hadoop.proxyuser.livy.groups\":\"*\",\"dfs.namenode.startup.delay.block.deletion.sec\":\"3600\",\"hadoop.proxyuser.hbase.groups\":\"*\",\"hadoop.proxyuser.root.hosts\":\"sandbox.hortonworks.com\",\"dfs.permissions.superusergroup\":\"hdfs\",\"ha.failover-controller.active-standby-elector.zk.op.retries\":\"120\",\"dfs.namenode.checkpoint.edits.dir\":\"${dfs.namenode.checkpoint.dir}\",\"hadoop_root_logger\":\"INFO,RFA\",\"dfs.blockreport.initialDelay\":\"120\",\"dfs.namenode.name.dir.restore\":\"true\",\"hadoop.proxyuser.livy.hosts\":\"*\",\"dfs.heartbeat.interval\":\"3\",\"dfs.namenode.secondary.http-address\":\"sandbox.hortonworks.com:50090\",\"dfs.support.append\":\"true\",\"fs.permissions.umask-mode\":\"022\",\"hdfs_user_nofile_limit\":\"128000\",\"dfs.namenode.checkpoint.period\":\"21600\",\"dfs.datanode.http.address\":\"0.0.0.0:50075\",\"namenode_opt_permsize\":\"128m\"}"
                },
                "components": [
                    {
                        "id": 17,
                        "serviceId": 5,
                        "name": "NFS_GATEWAY",
                        "hosts": [
                            "sandbox.hortonworks.com"
                        ],
                        "port": null,
                        "timestamp": 1475225400365
                    },
                    {
                        "id": 19,
                        "serviceId": 5,
                        "name": "SECONDARY_NAMENODE",
                        "hosts": [
                            "sandbox.hortonworks.com"
                        ],
                        "port": null,
                        "timestamp": 1475225400387
                    },
                    {
                        "id": 13,
                        "serviceId": 5,
                        "name": "HDFS_CLIENT",
                        "hosts": [
                            "sandbox.hortonworks.com"
                        ],
                        "port": null,
                        "timestamp": 1475225400298
                    },
                    {
                        "id": 15,
                        "serviceId": 5,
                        "name": "NAMENODE",
                        "hosts": [
                            "sandbox.hortonworks.com"
                        ],
                        "port": null,
                        "timestamp": 1475225400342
                    },
                    {
                        "id": 11,
                        "serviceId": 5,
                        "name": "DATANODE",
                        "hosts": [
                            "sandbox.hortonworks.com"
                        ],
                        "port": null,
                        "timestamp": 1475225400274
                    }
                ]
            },
            {
                "service": {
                    "id": 7,
                    "clusterId": 1,
                    "name": "HBASE",
                    "description": "",
                    "timestamp": 1475225400458,
                    "configuration": "{\"hbase.coprocessor.master.classes\":\"org.apache.ranger.authorization.hbase.RangerAuthorizationCoprocessor\",\"hfile.block.cache.size\":\"0.4\",\"hbase_user\":\"hbase\",\"hbase.master.port\":\"16000\",\"hbase_master_heapsize\":\"1024m\",\"phoenix.functions.allowUserDefinedFunctions\":\" \",\"hbase.local.dir\":\"${hbase.tmp.dir}/local\",\"phoenix.query.timeoutMs\":\"60000\",\"hbase.regionserver.wal.codec\":\"org.apache.hadoop.hbase.regionserver.wal.WALCellCodec\",\"hbase.rpc.controllerfactory.class\":\"\",\"hbase.client.retries.number\":\"35\",\"phoenix_sql_enabled\":\"false\",\"hbase.hstore.compaction.max\":\"10\",\"hbase.zookeeper.quorum\":\"sandbox.hortonworks.com\",\"hbase_regionserver_xmn_max\":\"512\",\"hbase.regionserver.info.port\":\"16030\",\"security.masterregion.protocol.acl\":\"*\",\"hbase_regionserver_xmn_ratio\":\"0.2\",\"hbase.rpc.protection\":\"authentication\",\"zookeeper.znode.parent\":\"/hbase-unsecure\",\"hbase.master.info.port\":\"16010\",\"hbase.rootdir\":\"hdfs://sandbox.hortonworks.com:8020/apps/hbase/data\",\"hbase.cluster.distributed\":\"true\",\"hbase_java_io_tmpdir\":\"/tmp\",\"hbase.hregion.majorcompaction\":\"604800000\",\"hbase.hregion.memstore.mslab.enabled\":\"true\",\"hbase.security.authentication\":\"simple\",\"hbase_regionserver_heapsize\":\"1024m\",\"hbase.bucketcache.percentage.in.combinedcache\":\"\",\"hbase.security.authorization\":\"true\",\"hbase.hstore.blockingStoreFiles\":\"10\",\"hbase.zookeeper.useMulti\":\"true\",\"dfs.domain.socket.path\":\"/var/lib/hadoop-hdfs/dn_socket\",\"hbase.region.server.rpc.scheduler.factory.class\":\"\",\"zookeeper.session.timeout\":\"90000\",\"security.client.protocol.acl\":\"*\",\"content\":\"\\n# Set environment variables here.\\n\\n# The java implementation to use. Java 1.6 required.\\nexport JAVA_HOME={{java64_home}}\\n\\n# HBase Configuration directory\\nexport HBASE_CONF_DIR=${HBASE_CONF_DIR:-{{hbase_conf_dir}}}\\n\\n# Extra Java CLASSPATH elements. Optional.\\nexport HBASE_CLASSPATH=${HBASE_CLASSPATH}\\n\\n\\n# The maximum amount of heap to use, in MB. Default is 1000.\\n# export HBASE_HEAPSIZE=1000\\n\\n# Extra Java runtime options.\\n# Below are what we set by default. May only work with SUN JVM.\\n# For more on why as well as other possible settings,\\n# see http://wiki.apache.org/hadoop/PerformanceTuning\\nexport SERVER_GC_OPTS=\\\"-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:{{log_dir}}/gc.log-`date +'%Y%m%d%H%M'`\\\"\\n# Uncomment below to enable java garbage collection logging.\\n# export HBASE_OPTS=\\\"$HBASE_OPTS -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:$HBASE_HOME/logs/gc-hbase.log\\\"\\n\\n# Uncomment and adjust to enable JMX exporting\\n# See jmxremote.password and jmxremote.access in $JRE_HOME/lib/management to configure remote password access.\\n# More details at: http://java.sun.com/javase/6/docs/technotes/guides/management/agent.html\\n#\\n# export HBASE_JMX_BASE=\\\"-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false\\\"\\n# If you want to configure BucketCache, specify '-XX: MaxDirectMemorySize=' with proper direct memory size\\n# export HBASE_THRIFT_OPTS=\\\"$HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10103\\\"\\n# export HBASE_ZOOKEEPER_OPTS=\\\"$HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10104\\\"\\n\\n# File naming hosts on which HRegionServers will run. $HBASE_HOME/conf/regionservers by default.\\nexport HBASE_REGIONSERVERS=${HBASE_CONF_DIR}/regionservers\\n\\n# Extra ssh options. Empty by default.\\n# export HBASE_SSH_OPTS=\\\"-o ConnectTimeout=1 -o SendEnv=HBASE_CONF_DIR\\\"\\n\\n# Where log files are stored. $HBASE_HOME/logs by default.\\nexport HBASE_LOG_DIR={{log_dir}}\\n\\n# A string representing this instance of hbase. $USER by default.\\n# export HBASE_IDENT_STRING=$USER\\n\\n# The scheduling priority for daemon processes. See 'man nice'.\\n# export HBASE_NICENESS=10\\n\\n# The directory where pid files are stored. /tmp by default.\\nexport HBASE_PID_DIR={{pid_dir}}\\n\\n# Seconds to sleep between slave commands. Unset by default. This\\n# can be useful in large clusters, where, e.g., slave rsyncs can\\n# otherwise arrive faster than the master can service them.\\n# export HBASE_SLAVE_SLEEP=0.1\\n\\n# Tell HBase whether it should manage it's own instance of Zookeeper or not.\\nexport HBASE_MANAGES_ZK=false\\n\\n{% if java_version < 8 %}\\nJDK_DEPENDED_OPTS=\\\"-XX:PermSize=128m -XX:MaxPermSize=128m\\\"\\n{% endif %}\\n      \\n{% if security_enabled %}\\nexport HBASE_OPTS=\\\"$HBASE_OPTS -XX:+UseConcMarkSweepGC -XX:ErrorFile={{log_dir}}/hs_err_pid%p.log -Djava.security.auth.login.config={{client_jaas_config_file}} -Djava.io.tmpdir={{java_io_tmpdir}}\\\"\\nexport HBASE_MASTER_OPTS=\\\"$HBASE_MASTER_OPTS -Xmx{{master_heapsize}} -Djava.security.auth.login.config={{master_jaas_config_file}} $JDK_DEPENDED_OPTS\\\"\\nexport HBASE_REGIONSERVER_OPTS=\\\"$HBASE_REGIONSERVER_OPTS -Xmn{{regionserver_xmn_size}} -XX:CMSInitiatingOccupancyFraction=70  -Xms{{regionserver_heapsize}} -Xmx{{regionserver_heapsize}} -Djava.security.auth.login.config={{regionserver_jaas_config_file}} $JDK_DEPENDED_OPTS\\\"\\nexport PHOENIX_QUERYSERVER_OPTS=\\\"$PHOENIX_QUERYSERVER_OPTS -Djava.security.auth.login.config={{queryserver_jaas_config_file}}\\\"\\n{% else %}\\nexport HBASE_OPTS=\\\"$HBASE_OPTS -XX:+UseConcMarkSweepGC -XX:ErrorFile={{log_dir}}/hs_err_pid%p.log -Djava.io.tmpdir={{java_io_tmpdir}}\\\"\\nexport HBASE_MASTER_OPTS=\\\"$HBASE_MASTER_OPTS -Xmx{{master_heapsize}} $JDK_DEPENDED_OPTS\\\"\\nexport HBASE_REGIONSERVER_OPTS=\\\"$HBASE_REGIONSERVER_OPTS -Xmn{{regionserver_xmn_size}} -XX:CMSInitiatingOccupancyFraction=70  -Xms{{regionserver_heapsize}} -Xmx{{regionserver_heapsize}} $JDK_DEPENDED_OPTS\\\"\\n{% endif %}\\n\\n# HBase off-heap MaxDirectMemorySize\\nexport HBASE_REGIONSERVER_OPTS=\\\"$HBASE_REGIONSERVER_OPTS {% if hbase_max_direct_memory_size %} -XX:MaxDirectMemorySize={{hbase_max_direct_memory_size}}m {% endif %}\\\"\\nexport HBASE_MASTER_OPTS=\\\"$HBASE_MASTER_OPTS {% if hbase_max_direct_memory_size %} -XX:MaxDirectMemorySize={{hbase_max_direct_memory_size}}m {% endif %}\\\"\",\"hbase.master.info.bindAddress\":\"0.0.0.0\",\"hbase.coprocessor.regionserver.classes\":\"org.apache.ranger.authorization.hbase.RangerAuthorizationCoprocessor\",\"hbase.master.ui.readonly\":\"false\",\"hbase.bucketcache.size\":\"1024\",\"hbase_pid_dir\":\"/var/run/hbase\",\"hbase_regionserver_shutdown_timeout\":\"30\",\"hbase_log_dir\":\"/var/log/hbase\",\"hbase.hregion.majorcompaction.jitter\":\"0.50\",\"hbase.hregion.memstore.flush.size\":\"134217728\",\"hbase.hregion.max.filesize\":\"10737418240\",\"zookeeper.recovery.retry\":\"6\",\"hbase.regionserver.global.memstore.size\":\"0.4\",\"security.admin.protocol.acl\":\"*\",\"hbase_max_direct_memory_size\":\"1048\",\"hbase.client.keyvalue.maxsize\":\"1048576\",\"hbase.tmp.dir\":\"/tmp/hbase-${user.name}\",\"hbase.client.scanner.caching\":\"100\",\"hbase.hstore.compactionThreshold\":\"3\",\"hbase_user_nproc_limit\":\"16000\",\"hbase.rpc.timeout\":\"90000\",\"hbase.superuser\":\"hbase\",\"hbase.coprocessor.region.classes\":\"org.apache.hadoop.hbase.security.access.SecureBulkLoadEndpoint,org.apache.ranger.authorization.hbase.RangerAuthorizationCoprocessor\",\"hbase.regionserver.handler.count\":\"30\",\"hbase_user_nofile_limit\":\"32000\",\"hbase.bulkload.staging.dir\":\"/apps/hbase/staging\",\"hbase.regionserver.port\":\"16020\",\"hbase.zookeeper.property.clientPort\":\"2181\",\"hbase.defaults.for.version.skip\":\"true\",\"hbase.hregion.memstore.block.multiplier\":\"4\",\"hbase.bucketcache.ioengine\":\"offheap\"}"
                },
                "components": [
                    {
                        "id": 25,
                        "serviceId": 7,
                        "name": "HBASE_REGIONSERVER",
                        "hosts": [
                            "sandbox.hortonworks.com"
                        ],
                        "port": null,
                        "timestamp": 1475225400524
                    },
                    {
                        "id": 21,
                        "serviceId": 7,
                        "name": "HBASE_CLIENT",
                        "hosts": [
                            "sandbox.hortonworks.com"
                        ],
                        "port": null,
                        "timestamp": 1475225400488
                    },
                    {
                        "id": 23,
                        "serviceId": 7,
                        "name": "HBASE_MASTER",
                        "hosts": [
                            "sandbox.hortonworks.com"
                        ],
                        "port": null,
                        "timestamp": 1475225400504
                    }
                ]
            },
            {
                "service": {
                    "id": 1,
                    "clusterId": 1,
                    "name": "STORM",
                    "description": "",
                    "timestamp": 1475225399770,
                    "configuration": "{\"storm.messaging.netty.min_wait_ms\":\"100\",\"storm_pid_dir\":\"/var/run/storm\",\"topology.enable.message.timeouts\":\"true\",\"storm.messaging.netty.buffer_size\":\"5242880\",\"client.jartransformer.class\":\"org.apache.storm.hack.StormShadeTransformer\",\"storm.topology.submission.notifier.plugin.class\":\"org.apache.atlas.storm.hook.StormAtlasHook\",\"ui.filter\":\"null\",\"storm.messaging.netty.client_worker_threads\":\"1\",\"storm_user_nofile_limit\":\"128000\",\"transactional.zookeeper.root\":\"/transactional\",\"topology.metrics.aggregate.metric.evict.secs\":\"5\",\"topology.tuple.serializer\":\"org.apache.storm.serialization.types.ListDelegateSerializer\",\"topology.spout.wait.strategy\":\"org.apache.storm.spout.SleepSpoutWaitStrategy\",\"drpc.port\":\"3772\",\"topology.max.spout.pending\":\"1000\",\"topology.transfer.buffer.size\":\"1024\",\"supervisor.worker.timeout.secs\":\"30\",\"logviewer.port\":\"8005\",\"metrics.reporter.register\":\"org.apache.hadoop.metrics2.sink.storm.StormTimelineMetricsReporter\",\"atlas.cluster.name\":\"{{cluster_name}}\",\"worker.childopts\":\"-Xmx768m _JAAS_PLACEHOLDER -javaagent:/usr/hdp/current/storm-client/contrib/storm-jmxetric/lib/jmxetric-1.0.4.jar=host=localhost,port=8650,wireformat31x=true,mode=multicast,config=/usr/hdp/current/storm-client/contrib/storm-jmxetric/conf/jmxetric-conf.xml,process=Worker_%ID%_JVM\",\"nimbus.file.copy.expiration.secs\":\"600\",\"drpc.childopts\":\"-Xmx220m\",\"logviewer.childopts\":\"-Xmx128m _JAAS_PLACEHOLDER\",\"nimbus.task.launch.secs\":\"120\",\"storm.zookeeper.servers\":\"['sandbox.hortonworks.com']\",\"storm.messaging.transport\":\"org.apache.storm.messaging.netty.Context\",\"topology.workers\":\"1\",\"drpc.invocations.port\":\"3773\",\"topology.kryo.factory\":\"org.apache.storm.serialization.DefaultKryoFactory\",\"nimbus.cleanup.inbox.freq.secs\":\"600\",\"_storm.thrift.secure.transport\":\"org.apache.storm.security.auth.kerberos.KerberosSaslTransportPlugin\",\"topology.fall.back.on.java.serialization\":\"true\",\"logviewer.appender.name\":\"A1\",\"storm.messaging.netty.server_worker_threads\":\"1\",\"supervisor.slots.ports\":\"[6700, 6701]\",\"storm.zookeeper.connection.timeout\":\"15000\",\"topology.tick.tuple.freq.secs\":\"null\",\"storm.cluster.metrics.consumer.register\":\"[{\\\"class\\\": \\\"org.apache.hadoop.metrics2.sink.storm.StormTimelineMetricsReporter\\\"}]\",\"topology.stats.sample.rate\":\"0.05\",\"storm.local.dir\":\"/hadoop/storm\",\"nimbus.inbox.jar.expiration.secs\":\"3600\",\"topology.max.replication.wait.time.sec.default\":\"60\",\"storm.messaging.netty.max_retries\":\"30\",\"topology.debug\":\"false\",\"storm.zookeeper.retry.interval\":\"1000\",\"topology.receiver.buffer.size\":\"8\",\"storm.zookeeper.retry.times\":\"5\",\"java.library.path\":\"/usr/local/lib:/opt/local/lib:/usr/lib:/usr/hdp/current/storm-client/lib\",\"zmq.linger.millis\":\"5000\",\"drpc.request.timeout.secs\":\"600\",\"zmq.threads\":\"1\",\"topology.state.synchronization.timeout.secs\":\"60\",\"topology.worker.shared.thread.pool.size\":\"4\",\"topology.executor.receive.buffer.size\":\"1024\",\"supervisor.monitor.frequency.secs\":\"3\",\"topology.optimize\":\"true\",\"transactional.zookeeper.port\":\"null\",\"storm.zookeeper.port\":\"2181\",\"storm.zookeeper.retry.intervalceiling.millis\":\"30000\",\"nimbus.thrift.port\":\"6627\",\"nimbus.thrift.threads\":\"196\",\"_storm.thrift.nonsecure.transport\":\"org.apache.storm.security.auth.SimpleTransportPlugin\",\"nimbus.seeds\":\"[sandbox.hortonworks.com]\",\"topology.min.replication.count\":\"{{actual_topology_min_replication_count}}\",\"topology.worker.childopts\":\"null\",\"topology.max.replication.wait.time.sec\":\"{{actual_topology_max_replication_wait_time_sec}}\",\"topology.min.replication.count.default\":\"1\",\"topology.max.task.parallelism\":\"null\",\"topology.acker.executors\":\"null\",\"supervisor.worker.start.timeout.secs\":\"120\",\"_storm.min.ruid\":\"null\",\"nimbus_seeds_supported\":\"true\",\"nimbus.reassign\":\"true\",\"supervisor.heartbeat.frequency.secs\":\"5\",\"topology.metrics.aggregate.per.worker\":\"true\",\"topology.trident.batch.emit.interval.millis\":\"500\",\"task.heartbeat.frequency.secs\":\"3\",\"jmxremote_port\":\"56431\",\"storm.thrift.transport\":\"{{storm_thrift_transport}}\",\"drpc.worker.threads\":\"64\",\"ui.port\":\"8744\",\"drpc.queue.size\":\"128\",\"topology.message.timeout.secs\":\"30\",\"topology.error.throttle.interval.secs\":\"10\",\"nimbus.childopts\":\"-Xmx220m -javaagent:/usr/hdp/current/storm-client/contrib/storm-jmxetric/lib/jmxetric-1.0.4.jar=host=sandbox.hortonworks.com,port=8649,wireformat31x=true,mode=multicast,config=/usr/hdp/current/storm-client/contrib/storm-jmxetric/conf/jmxetric-conf.xml,process=Nimbus_JVM\",\"storm.log.dir\":\"{{log_dir}}\",\"topology.builtin.metrics.bucket.size.secs\":\"60\",\"nimbus.monitor.freq.secs\":\"120\",\"storm_logs_supported\":\"true\",\"topology.executor.send.buffer.size\":\"1024\",\"storm.local.mode.zmq\":\"false\",\"content\":\"\\n      #!/bin/bash\\n\\n      # Set Storm specific environment variables here.\\n\\n      # The java implementation to use.\\n      export JAVA_HOME={{java64_home}}\\n\\n      export STORM_CONF_DIR={{conf_dir}}\\n      export STORM_HOME={{storm_component_home_dir}}\\n\\n      export STORM_JAR_JVM_OPTS={{jar_jvm_opts}}\",\"transactional.zookeeper.servers\":\"null\",\"nimbus.task.timeout.secs\":\"30\",\"topology.metrics.consumer.register\":\"[{\\\"class\\\": \\\"org.apache.hadoop.metrics2.sink.storm.StormTimelineMetricsSink\\\", \\\"parallelism.hint\\\": 1, \\\"whitelist\\\": [\\\"kafkaOffset\\\\\\\\..+/\\\", \\\"__complete-latency\\\", \\\"__process-latency\\\", \\\"__receive\\\\\\\\.population$\\\", \\\"__sendqueue\\\\\\\\.population$\\\", \\\"__execute-count\\\", \\\"__emit-count\\\", \\\"__ack-count\\\", \\\"__fail-count\\\", \\\"memory/heap\\\\\\\\.usedBytes$\\\", \\\"memory/nonHeap\\\\\\\\.usedBytes$\\\", \\\"GC/.+\\\\\\\\.count$\\\", \\\"GC/.+\\\\\\\\.timeMs$\\\"]}]\",\"dev.zookeeper.path\":\"/tmp/dev-storm-zookeeper\",\"topology.metrics.expand.map.type\":\"true\",\"nimbus.supervisor.timeout.secs\":\"60\",\"topology.skip.missing.kryo.registrations\":\"false\",\"storm.zookeeper.root\":\"/storm\",\"storm.zookeeper.session.timeout\":\"20000\",\"topology.disruptor.wait.strategy\":\"com.lmax.disruptor.BlockingWaitStrategy\",\"zmq.hwm\":\"0\",\"topology.sleep.spout.wait.strategy.time.ms\":\"1\",\"nimbus.topology.validator\":\"org.apache.storm.nimbus.DefaultTopologyValidator\",\"storm_log_dir\":\"/var/log/storm\",\"storm.cluster.mode\":\"distributed\",\"task.refresh.poll.secs\":\"10\",\"ui.childopts\":\"-Xmx220m\",\"storm.messaging.netty.max_wait_ms\":\"1000\",\"supervisor.childopts\":\"-Xmx256m _JAAS_PLACEHOLDER -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port={{jmxremote_port}} -javaagent:/usr/hdp/current/storm-supervisor/contrib/storm-jmxetric/lib/jmxetric-1.0.4.jar=host=localhost,port=8650,wireformat31x=true,mode=multicast,config=/usr/hdp/current/storm-supervisor/contrib/storm-jmxetric/conf/jmxetric-conf.xml,process=Supervisor_JVM\",\"worker.heartbeat.frequency.secs\":\"1\",\"topology.max.error.report.per.interval\":\"5\",\"nimbus.thrift.max_buffer_size\":\"1048576\",\"storm_user\":\"storm\",\"topology.metrics.metric.name.separator\":\".\",\"storm_user_nproc_limit\":\"65536\"}"
                },
                "components": [
                    {
                        "id": 5,
                        "serviceId": 1,
                        "name": "STORM_UI_SERVER",
                        "hosts": [
                            "sandbox.hortonworks.com"
                        ],
                        "port": 8744,
                        "timestamp": 1475225399926
                    },
                    {
                        "id": 7,
                        "serviceId": 1,
                        "name": "SUPERVISOR",
                        "hosts": [
                            "sandbox.hortonworks.com"
                        ],
                        "port": null,
                        "timestamp": 1475225399959
                    },
                    {
                        "id": 1,
                        "serviceId": 1,
                        "name": "DRPC_SERVER",
                        "hosts": [
                            "sandbox.hortonworks.com"
                        ],
                        "port": 3772,
                        "timestamp": 1475225399887
                    },
                    {
                        "id": 3,
                        "serviceId": 1,
                        "name": "NIMBUS",
                        "hosts": [
                            "sandbox.hortonworks.com"
                        ],
                        "port": 6627,
                        "timestamp": 1475225399908
                    }
                ]
            },
            {
                "service": {
                    "id": 3,
                    "clusterId": 1,
                    "name": "KAFKA",
                    "description": "",
                    "timestamp": 1475225400057,
                    "configuration": "{\"replica.high.watermark.checkpoint.interval.ms\":\"5000\",\"offsets.topic.num.partitions\":\"50\",\"auto.create.topics.enable\":\"true\",\"controller.socket.timeout.ms\":\"30000\",\"external.kafka.metrics.include.prefix\":\"kafka.network.RequestMetrics.ResponseQueueTimeMs.request.OffsetCommit.98percentile,kafka.network.RequestMetrics.ResponseQueueTimeMs.request.Offsets.95percentile,kafka.network.RequestMetrics.ResponseSendTimeMs.request.Fetch.95percentile,kafka.network.RequestMetrics.RequestsPerSec.request\",\"replica.socket.receive.buffer.bytes\":\"65536\",\"min.insync.replicas\":\"1\",\"kafka.timeline.metrics.maxRowCacheSize\":\"10000\",\"zookeeper.connection.timeout.ms\":\"25000\",\"controlled.shutdown.retry.backoff.ms\":\"5000\",\"replica.fetch.wait.max.ms\":\"500\",\"num.recovery.threads.per.data.dir\":\"1\",\"kafka.timeline.metrics.reporter.sendInterval\":\"5900\",\"kafka.ganglia.metrics.host\":\"localhost\",\"log.roll.hours\":\"168\",\"default.replication.factor\":\"1\",\"kafka.timeline.metrics.port\":\"{{metric_collector_port}}\",\"offsets.topic.segment.bytes\":\"104857600\",\"fetch.purgatory.purge.interval.requests\":\"10000\",\"is_supported_kafka_ranger\":\"true\",\"replica.socket.timeout.ms\":\"30000\",\"message.max.bytes\":\"1000000\",\"replica.lag.max.messages\":\"4000\",\"kafka.ganglia.metrics.port\":\"8671\",\"num.io.threads\":\"8\",\"offsets.commit.required.acks\":\"-1\",\"delete.topic.enable\":\"false\",\"kafka_user_nproc_limit\":\"65536\",\"log.index.interval.bytes\":\"4096\",\"offsets.commit.timeout.ms\":\"5000\",\"log.segment.bytes\":\"1073741824\",\"offset.metadata.max.bytes\":\"4096\",\"zookeeper.connect\":\"sandbox.hortonworks.com:2181\",\"port\":\"6667\",\"zookeeper.sync.time.ms\":\"2000\",\"kafka_pid_dir\":\"/var/run/kafka\",\"num.replica.fetchers\":\"1\",\"kafka_log_dir\":\"/var/log/kafka\",\"log.dirs\":\"/kafka-logs\",\"controlled.shutdown.enable\":\"true\",\"kafka.timeline.metrics.host\":\"{{metric_collector_host}}\",\"compression.type\":\"producer\",\"offsets.load.buffer.size\":\"5242880\",\"controlled.shutdown.max.retries\":\"3\",\"offsets.topic.replication.factor\":\"3\",\"queued.max.requests\":\"500\",\"auto.leader.rebalance.enable\":\"true\",\"leader.imbalance.check.interval.seconds\":\"300\",\"content\":\"\\n#!/bin/bash\\n\\n# Set KAFKA specific environment variables here.\\n\\n# The java implementation to use.\\nexport JAVA_HOME={{java64_home}}\\nexport PATH=$PATH:$JAVA_HOME/bin\\nexport PID_DIR={{kafka_pid_dir}}\\nexport LOG_DIR={{kafka_log_dir}}\\nexport KAFKA_KERBEROS_PARAMS={{kafka_kerberos_params}}\\n# Add kafka sink to classpath and related depenencies\\nif [ -e \\\"/usr/lib/ambari-metrics-kafka-sink/ambari-metrics-kafka-sink.jar\\\" ]; then\\n  export CLASSPATH=$CLASSPATH:/usr/lib/ambari-metrics-kafka-sink/ambari-metrics-kafka-sink.jar\\n  export CLASSPATH=$CLASSPATH:/usr/lib/ambari-metrics-kafka-sink/lib/*\\nfi\\nif [ -f /etc/kafka/conf/kafka-ranger-env.sh ]; then\\n. /etc/kafka/conf/kafka-ranger-env.sh\\nfi\",\"kafka_user\":\"kafka\",\"replica.lag.time.max.ms\":\"10000\",\"socket.request.max.bytes\":\"104857600\",\"zookeeper.session.timeout.ms\":\"30000\",\"kafka.timeline.metrics.truststore.path\":\"{{metric_truststore_path}}\",\"log.retention.bytes\":\"-1\",\"num.network.threads\":\"3\",\"kafka.timeline.metrics.protocol\":\"{{metric_collector_protocol}}\",\"offsets.retention.minutes\":\"86400000\",\"kafka.metrics.reporters\":\"org.apache.hadoop.metrics2.sink.kafka.KafkaTimelineMetricsReporter\",\"log.cleanup.interval.mins\":\"10\",\"socket.send.buffer.bytes\":\"102400\",\"log.retention.hours\":\"168\",\"kafka.timeline.metrics.reporter.enabled\":\"true\",\"kafka.timeline.metrics.truststore.password\":\"{{metric_truststore_password}}\",\"num.partitions\":\"1\",\"listeners\":\"PLAINTEXT://localhost:6667\",\"socket.receive.buffer.bytes\":\"102400\",\"kafka_user_nofile_limit\":\"128000\",\"replica.fetch.min.bytes\":\"1\",\"external.kafka.metrics.exclude.prefix\":\"kafka.network.RequestMetrics,kafka.server.DelayedOperationPurgatory,kafka.server.BrokerTopicMetrics.BytesRejectedPerSec\",\"controller.message.queue.size\":\"10\",\"kafka.ganglia.metrics.reporter.enabled\":\"true\",\"log.index.size.max.bytes\":\"10485760\",\"offsets.retention.check.interval.ms\":\"600000\",\"producer.purgatory.purge.interval.requests\":\"10000\",\"kafka.ganglia.metrics.group\":\"kafka\",\"offsets.topic.compression.codec\":\"0\",\"replica.fetch.max.bytes\":\"1048576\",\"leader.imbalance.per.broker.percentage\":\"10\",\"kafka.timeline.metrics.truststore.type\":\"{{metric_truststore_type}}\"}"
                },
                "components": [
                    {
                        "id": 9,
                        "serviceId": 3,
                        "name": "KAFKA_BROKER",
                        "hosts": [
                            "sandbox.hortonworks.com"
                        ],
                        "port": null,
                        "timestamp": 1475225400115
                    }
                ]
            }
        ]
    }
}
```
