### PR TITLE
IOT-440 Adding directory as another packaging format

### DIFF
--- a/iotas-dist/src/main/assembly/binary.xml
+++ b/iotas-dist/src/main/assembly/binary.xml
@@ -22,6 +22,7 @@
     <formats>
         <format>tar.gz</format>
         <format>zip</format>
+        <format>dir</format>
     </formats>
 
     <!-- put deps in the lib folder -->


### PR DESCRIPTION
Creates a distribution directory under target/ so that we dont need to manually unzip the distribution gz/zip files each time.
