### PR TITLE
IOT-386 Include topology Status information as part of topology listing api

### DIFF
--- a/streams/catalog/src/main/java/com/hortonworks/iotas/streams/catalog/service/StreamCatalogService.java
+++ b/streams/catalog/src/main/java/com/hortonworks/iotas/streams/catalog/service/StreamCatalogService.java
@@ -707,6 +707,10 @@ public class StreamCatalogService {
         return this.topologyMetrics.getTimeSeriesQuerier().getRawMetrics(metricName, parameters, from, to);
     }
 
+    public TopologyMetrics.TopologyMetric getTopologyMetric(Topology topology) {
+        return this.topologyMetrics.getTopologyMetric(getTopologyLayout(topology));
+    }
+
     public Collection<TopologyComponentDefinition.TopologyComponentType> listTopologyComponentTypes() {
         return Arrays.asList(TopologyComponentDefinition.TopologyComponentType.values());
     }

--- a/streams/metrics/src/main/java/com/hortonworks/iotas/streams/metrics/topology/TopologyMetrics.java
+++ b/streams/metrics/src/main/java/com/hortonworks/iotas/streams/metrics/topology/TopologyMetrics.java
@@ -22,6 +22,14 @@ public interface TopologyMetrics extends TopologyTimeSeriesMetrics {
     void init (Map<String, String> conf) throws ConfigException;
 
     /**
+     * Retrieves topology metric for IoTaS topology/
+     *
+     * @param topology topology catalog instance. Implementations should find actual runtime topology with provided topology.
+     * @return TopologyMetrics
+     */
+    TopologyMetric getTopologyMetric(TopologyLayout topology);
+
+    /**
      * Retrieves metrics data for IoTaS topology.
      *
      * @param topology topology catalog instance. Implementations should find actual runtime topology with provided topology.
@@ -30,6 +38,74 @@ public interface TopologyMetrics extends TopologyTimeSeriesMetrics {
      * so that it can be matched to IoTas topology.
      */
     Map<String, ComponentMetric> getMetricsForTopology(TopologyLayout topology);
+
+    /**
+     * Data structure of Metrics for each component on topology.
+     * Fields are extracted from common metrics among various streaming frameworks.
+     *
+     * Implementors of TopologyMetrics are encouraged to provide fields' value as many as possible.
+     * If field is not available for that streaming framework, implementator can leave it as null or default value.
+     */
+    class TopologyMetric {
+        private final String topologyName;
+        private final String status;
+        private final Long uptime;
+        private final Long windowSecs;
+        private final Double throughput;
+        private final Double latency;
+        private final Long failedRecords;
+
+        /**
+         * Constructor.
+         *  @param topologyName  'topology name' for Streams.
+         *                      If topology name for streaming framework is different from topology name for Streams,
+         *                      implementation of TopologyMetrics should match the relation.
+         * @param status        Status of the topology. Representation of status may be different among implementations.
+         * @param uptime        Uptime for Streams.
+         * @param windowSecs    Time window (seconds) for below metrics.
+         * @param throughput    Throughput for Streams in window, represented via tps (processed records per second).
+         * @param latency       Average latency of processed time (processing one record) in window.
+         * @param failedRecords Failed records in window.
+         */
+        public TopologyMetric(String topologyName, String status, Long uptime, Long windowSecs,
+            Double throughput, Double latency, Long failedRecords) {
+            this.topologyName = topologyName;
+            this.status = status;
+            this.uptime = uptime;
+            this.windowSecs = windowSecs;
+            this.throughput = throughput;
+            this.latency = latency;
+            this.failedRecords = failedRecords;
+        }
+
+        public String getTopologyName() {
+            return topologyName;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public Long getUptime() {
+            return uptime;
+        }
+
+        public Long getWindowSecs() {
+            return windowSecs;
+        }
+
+        public Double getThroughput() {
+            return throughput;
+        }
+
+        public Double getLatency() {
+            return latency;
+        }
+
+        public Long getFailedRecords() {
+            return failedRecords;
+        }
+    }
 
     /**
      * Data structure of Metrics for each component on topology.
@@ -48,13 +124,13 @@ public interface TopologyMetrics extends TopologyTimeSeriesMetrics {
         /**
          * Constructor.
          *
-         * @param componentName 'component name' for IoTaS.
-         *                      If component name for streaming framework is different from component name for IoTas,
+         * @param componentName 'component name' for Streams.
+         *                      If component name for streaming framework is different from component name for Streams,
          *                      implementation of TopologyMetrics should match the relation.
          * @param inputRecords  Count of input records.
          * @param outputRecords Count of output records.
          * @param failedRecords Count of failed records.
-         * @param processedTime Latency of processed time (processing one event).
+         * @param processedTime Average latency of processed time (processing one record).
          */
         public ComponentMetric(String componentName, Long inputRecords, Long outputRecords, Long failedRecords, Double processedTime) {
             this.componentName = componentName;

--- a/streams/runners/storm/metrics/src/main/java/com/hortonworks/iotas/streams/metrics/storm/topology/StormMetricsConstant.java
+++ b/streams/runners/storm/metrics/src/main/java/com/hortonworks/iotas/streams/metrics/storm/topology/StormMetricsConstant.java
@@ -4,10 +4,21 @@ public class StormMetricsConstant {
     private StormMetricsConstant() {
     }
 
-    public static final String COMPONENT_EXECUTED_TUPLES = "executed";
-    public static final String COMPONENT_EMITTED_TUPLES = "emitted";
-    public static final String COMPONENT_PROCESS_LATENCY = "processLatency";
-    public static final String COMPONENT_FAILED_TUPLES = "failed";
+    public static final String TOPOLOGY_JSON_UPTIME_SECS = "uptimeSeconds";
+    public static final String TOPOLOGY_JSON_STATUS = "status";
+    public static final String TOPOLOGY_JSON_STATS = "topologyStats";
+    public static final String TOPOLOGY_JSON_WINDOW = "window";
+    public static final String TOPOLOGY_JSON_SPOUTS = "spouts";
+    public static final String TOPOLOGY_JSON_SPOUT_ID = "spoutId";
+    public static final String TOPOLOGY_JSON_BOLTS = "bolts";
+    public static final String TOPOLOGY_JSON_BOLT_ID = "boltId";
+
+    public static final String STATS_JSON_EXECUTED_TUPLES = "executed";
+    public static final String STATS_JSON_EMITTED_TUPLES = "emitted";
+    public static final String STATS_JSON_PROCESS_LATENCY = "processLatency";
+    public static final String STATS_JSON_COMPLETE_LATENCY = "completeLatency";
+    public static final String STATS_JSON_ACKED_TUPLES = "acked";
+    public static final String STATS_JSON_FAILED_TUPLES = "failed";
 
     public static final String TOPOLOGY_SUMMARY_JSON_TOPOLOGIES = "topologies";
     public static final String TOPOLOGY_SUMMARY_JSON_TOPOLOGY_NAME = "name";

--- a/streams/runners/storm/metrics/src/main/java/com/hortonworks/iotas/streams/metrics/storm/topology/TopologyNotAliveException.java
+++ b/streams/runners/storm/metrics/src/main/java/com/hortonworks/iotas/streams/metrics/storm/topology/TopologyNotAliveException.java
@@ -1,0 +1,7 @@
+package com.hortonworks.iotas.streams.metrics.storm.topology;
+
+public class TopologyNotAliveException extends RuntimeException {
+  public TopologyNotAliveException(String msg) {
+    super(msg);
+  }
+}


### PR DESCRIPTION
Origin description of IOT-386 is "Include topology Status information as part of topology listing api", but I thought it's beyond the Catalog REST API, so create new kind of Resource API, `runtime` (`/api/v1/runtime/`).

Also Topology metrics (except `/raw`) and topology actions are candidates to be moved to here.
- Introduce topology runtime API
  - currently only 'topologies' are supported
  - topology actions and topology metrics are candidates to be moved to here
- /api/v1/runtime/topologies
  - response: TopologyMetric (topologyName, status, uptime, windowSecs, throughput, latency, failedRecords)
  - metrics are the value in the following window (not all time)
  - throughput is calculated via `acked in window / windowSecs`
  - It tries to select smallest available window.
