### PR TITLE
Change Calcite version according to the change of Storm SQL (1.x branch)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <logback.version>1.1.3</logback.version>
         <mysql-connector.version>5.1.38</mysql-connector.version>
         <phoenix.version>4.4.0-HBase-1.1</phoenix.version>
-        <calcite.version>1.4.0-incubating</calcite.version>
+        <calcite.version>1.10.0</calcite.version>
         <commons.version>2.5</commons.version>
         <commons-cli.version>1.2</commons-cli.version>
     </properties>

--- a/streams/runners/storm/runtime/pom.xml
+++ b/streams/runners/storm/runtime/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <storm.version>1.1.0-SNAPSHOT</storm.version>
-        <calcite.version>1.4.0-incubating</calcite.version>     <!--StormSQL dependency-->
+        <calcite.version>1.10.0</calcite.version>     <!--StormSQL dependency-->
         <aws-java-sdk.version>1.10.77</aws-java-sdk.version>
     </properties>
 


### PR DESCRIPTION
This is needed to resolve build failure due to recent change of upstream Storm SQL.

As Storm SQL adopts Calcite 1.10.0, Streamline should follow this.

NOTE: After merging everyone should build and install Storm artifact from recent 1.x branch.
