### PR TITLE
Removing schema-registry-avro module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <calcite.version>1.10.0</calcite.version>
         <commons.version>2.5</commons.version>
         <commons-cli.version>1.2</commons-cli.version>
+        <schema-registry.version>0.1.0-SNAPSHOT</schema-registry.version>
     </properties>
 
     <distributionManagement>

--- a/streams/runners/storm/runtime/pom.xml
+++ b/streams/runners/storm/runtime/pom.xml
@@ -13,7 +13,6 @@
 
     <properties>
         <storm.version>1.1.0-SNAPSHOT</storm.version>
-        <schema-registry.version>0.1.0-SNAPSHOT</schema-registry.version>
         <aws-java-sdk.version>1.10.77</aws-java-sdk.version>
     </properties>
 
@@ -318,11 +317,6 @@
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.hortonworks.registries</groupId>
-            <artifactId>schema-registry-avro</artifactId>
-            <version>${schema-registry.version}</version>
         </dependency>
         <dependency>
             <groupId>com.hortonworks.registries</groupId>

--- a/streams/service/pom.xml
+++ b/streams/service/pom.xml
@@ -65,13 +65,8 @@
         </dependency>
         <dependency>
             <groupId>com.hortonworks.registries</groupId>
-            <artifactId>schema-registry-avro</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>com.hortonworks.registries</groupId>
             <artifactId>schema-registry-client</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>${schema-registry.version}</version>
         </dependency>
 
         <!-- test dependency -->


### PR DESCRIPTION
- Modules in schema registry are refactored, schema-registry-client module is sufficient for now. If there is any other module needed it can be added later.
