### PR TITLE
STREAMLINE-487 Respond without metrics when topology API is called wi…

### DIFF
--- a/streams/runners/storm/metrics/src/main/java/org/apache/streamline/streams/metrics/storm/topology/StormNotReachableException.java
+++ b/streams/runners/storm/metrics/src/main/java/org/apache/streamline/streams/metrics/storm/topology/StormNotReachableException.java
@@ -1,0 +1,11 @@
+package org.apache.streamline.streams.metrics.storm.topology;
+
+public class StormNotReachableException extends RuntimeException {
+  public StormNotReachableException(String msg, Throwable e) {
+    super(msg, e);
+  }
+
+  public StormNotReachableException(String msg) {
+    super(msg);
+  }
+}


### PR DESCRIPTION
…th metrics but storm API endpoint is down
- When request to Storm API got IOException, wrap it into StormNotReachableException
- When StormNotReachableException is caught, mark status as "UNKNOWN" but return topology information

Change-Id: I76ae716d202cf6e7dbc9725b3b7ac764a0b71027

Quick fix for [STREAMLINE-486](https://hwxiot.atlassian.net/browse/STREAMLINE-486)
