### PR TITLE
STREAMLINE-488 Fix NormalizationProcessor errors while deploying topology

### DIFF
--- a/streams/catalog/src/main/java/org/apache/streamline/streams/catalog/service/StreamCatalogService.java
+++ b/streams/catalog/src/main/java/org/apache/streamline/streams/catalog/service/StreamCatalogService.java
@@ -1454,6 +1454,15 @@ public class StreamCatalogService {
         return dao.get(new StorableKey(STREAMINFO_NAMESPACE, streamInfo.getPrimaryKey()));
     }
 
+    public StreamInfo getStreamInfoByName(String streamId) {
+      for (StreamInfo streamInfo : listStreamInfos()) {
+        if (streamInfo.getStreamId().equals(streamId)) {
+          return streamInfo;
+        }
+      }
+      return null;
+    }
+
     public StreamInfo addStreamInfo(Long topologyId, StreamInfo streamInfo) {
         if (streamInfo.getId() == null) {
             streamInfo.setId(dao.nextId(STREAMINFO_NAMESPACE));

--- a/streams/catalog/src/main/java/org/apache/streamline/streams/catalog/topology/component/TopologyComponentFactory.java
+++ b/streams/catalog/src/main/java/org/apache/streamline/streams/catalog/topology/component/TopologyComponentFactory.java
@@ -258,7 +258,7 @@ public class TopologyComponentFactory {
     private void updateWithSchemas(Map<String, NormalizationConfig> normalizationConfigRead) {
         for (Map.Entry<String, NormalizationConfig> entry : normalizationConfigRead.entrySet()) {
             NormalizationConfig normalizationConfig = entry.getValue();
-            normalizationConfig.setInputSchema(catalogService.getStreamInfo(Long.parseLong(entry.getKey())).getSchema());
+            normalizationConfig.setInputSchema(catalogService.getStreamInfoByName(entry.getKey()).getSchema());
         }
     }
 

--- a/streams/layout/src/main/java/org/apache/streamline/streams/layout/component/impl/normalization/NormalizationProcessor.java
+++ b/streams/layout/src/main/java/org/apache/streamline/streams/layout/component/impl/normalization/NormalizationProcessor.java
@@ -35,7 +35,7 @@ import java.util.Map;
  */
 public class NormalizationProcessor extends StreamlineProcessor {
     public static final String DEFAULT_STREAM_ID = "default";
-    public static final String CONFIG_KEY_TYPE = "normalizationProcessorType";
+    public static final String CONFIG_KEY_TYPE = "type";
     public static final String CONFIG_KEY_NORMALIZATION = "normalizationConfig";
 
     /**

--- a/streams/runners/storm/runtime/src/test/java/org/apache/streamline/streams/runtime/storm/bolt/normalization/NormalizationBoltTest.java
+++ b/streams/runners/storm/runtime/src/test/java/org/apache/streamline/streams/runtime/storm/bolt/normalization/NormalizationBoltTest.java
@@ -102,7 +102,7 @@ public class NormalizationBoltTest {
                 put("new-field", "new value");
             }}, INPUT_STREAMLINE_EVENT.getDataSourceId(), INPUT_STREAMLINE_EVENT.getId());
 
-    private static final String INPUT_STREAM_ID = "inputStream";
+    private static final String INPUT_STREAM_ID = String.valueOf(1L);
     @Test
     public void testFieldBasedNormalization() throws NormalizationException {
         testNormalizationBolt(createNormalizationBolt(createFieldBasedNormalizationProcessor("normalized-output")));


### PR DESCRIPTION
- Stream has its own incrementing id: streamId is no longer a key.
- there's no 'normalizationProcessorType' but just 'type'

Change-Id: Ia131123dda97b93f933cf515780120439d29cef6

Confirmed that there's no error while deploying topology, but worker is not working due to another issue (might be jersey version issue) so couldn't check it.
