### PR TITLE
STREAMLINE-500 Generalize the way of handling exception on service

### DIFF
--- a/common/src/main/java/org/apache/streamline/common/CollectionResponse.java
+++ b/common/src/main/java/org/apache/streamline/common/CollectionResponse.java
@@ -1,0 +1,51 @@
+package org.apache.streamline.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Collection;
+
+/**
+ * A wrapper entity for passing collection (more than one resource) back to the client.
+ * This response is used only for succeed requests.
+ * <p/>
+ * This can be expanded to handle paged result.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CollectionResponse {
+  /**
+   * For response that returns a collection of entities.
+   */
+  private Collection<?> entities;
+
+  private CollectionResponse() {}
+
+  public void setEntities(Collection<?> entities) {
+    this.entities = entities;
+  }
+
+  public Collection<?> getEntities() {
+    return entities;
+  }
+
+  public static Builder newResponse() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Collection<?> entities;
+
+    private Builder() {
+    }
+
+    public CollectionResponse.Builder entities(Collection<?> entities) {
+      this.entities = entities;
+      return this;
+    }
+
+    public CollectionResponse build() {
+      CollectionResponse response = new CollectionResponse();
+      response.setEntities(entities);
+      return response;
+    }
+  }
+}

--- a/common/src/main/java/org/apache/streamline/common/catalog/CatalogResponse.java
+++ b/common/src/main/java/org/apache/streamline/common/catalog/CatalogResponse.java
@@ -10,6 +10,7 @@ import java.util.Collection;
  * A wrapper entity for passing entities and status back to the client.
  * </p>
  *
+ * FIXME: This is used only from parser-registry and should be removed after STREAMLINE-435 is merged to master
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CatalogResponse {
@@ -24,16 +25,15 @@ public class CatalogResponse {
         ENTITY_NOT_FOUND(1101, "Entity with id [%s] not found.", 1),
         EXCEPTION(1102, "An exception with message [%s] was thrown while processing request.", 1),
         BAD_REQUEST_PARAM_MISSING(1103, "Bad request. Param [%s] is missing or empty.", 1),
-        DATASOURCE_TYPE_FILTER_NOT_FOUND(1104, "Datasource not found for type [%s], query params [%s].", 2),
         ENTITY_NOT_FOUND_FOR_FILTER(1105, "Entity not found for query params [%s].", 1),
         PARSER_SCHEMA_FOR_ENTITY_NOT_FOUND(1106, "Parser schema not found for entity with id [%s].", 1),
-        DATASOURCE_SCHEMA_NOT_UNIQUE(1107, "Datasource has [%s] datafeeds and cannot be mapped to a unique schema.", 1),
         CUSTOM_PROCESSOR_ONLY(1108, "Custom endpoint supported only for processors.", 0),
         UNSUPPORTED_MEDIA_TYPE(1109, "Unsupported Media Type", 0),
         BAD_REQUEST(1110, "Bad Request", 0),
         IMPORT_ALREADY_IN_PROGRESS(1111, "Cluster [%s] is already in progress of import.", 1),
         ENTITY_BY_NAME_NOT_FOUND(1112, "Entity with name [%s] not found.", 1),
-        ENTITY_VERSION_NOT_FOUND(1113, "Entity with id [%s] and version [%s] not found.", 2);
+        ENTITY_VERSION_NOT_FOUND(1113, "Entity with id [%s] and version [%s] not found.", 2),
+        ENTITY_BY_NAME_ALREADY_EXIST(1114, "Entity with name [%s] already exists.", 1);
 
         private final int code;
         private final String msg;

--- a/common/src/main/java/org/apache/streamline/common/util/WSUtils.java
+++ b/common/src/main/java/org/apache/streamline/common/util/WSUtils.java
@@ -19,6 +19,7 @@
 package org.apache.streamline.common.util;
 
 import com.google.common.io.ByteStreams;
+import org.apache.streamline.common.CollectionResponse;
 import org.apache.streamline.common.QueryParam;
 import org.apache.streamline.common.catalog.CatalogResponse;
 
@@ -48,21 +49,39 @@ public class WSUtils {
     private WSUtils() {
     }
 
+    @Deprecated
     public static Response respond(Collection<?> entities, Response.Status status, CatalogResponse.ResponseMessage msg, String... formatArgs) {
+        // FIXME: This is used only from parser-registry and should be removed after STREAMLINE-435 is merged to master
         return Response.status(status)
-                .entity(CatalogResponse.newResponse(msg).entities(entities).format(formatArgs))
-                .build();
+            .entity(CatalogResponse.newResponse(msg).entities(entities).format(formatArgs))
+            .build();
     }
 
+    @Deprecated
     public static Response respond(Object entity, Response.Status status, CatalogResponse.ResponseMessage msg, String... formatArgs) {
+        // FIXME: This is used only from parser-registry and should be removed after STREAMLINE-435 is merged to master
         return Response.status(status)
-                .entity(CatalogResponse.newResponse(msg).entity(entity).format(formatArgs))
-                .build();
+            .entity(CatalogResponse.newResponse(msg).entity(entity).format(formatArgs))
+            .build();
     }
 
+    @Deprecated
     public static Response respond(Response.Status status, CatalogResponse.ResponseMessage msg, String... formatArgs) {
+        // FIXME: This is used only from parser-registry and should be removed after STREAMLINE-435 is merged to master
         return Response.status(status)
-                .entity(CatalogResponse.newResponse(msg).entity(null).format(formatArgs))
+            .entity(CatalogResponse.newResponse(msg).entity(null).format(formatArgs))
+            .build();
+    }
+
+    public static Response respondEntities(Collection<?> entities, Response.Status status) {
+        return Response.status(status)
+            .entity(CollectionResponse.newResponse().entities(entities).build())
+            .build();
+    }
+
+    public static Response respondEntity(Object entity, Response.Status status) {
+        return Response.status(status)
+                .entity(entity)
                 .build();
     }
 

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/ClusterCatalogResource.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/ClusterCatalogResource.java
@@ -4,17 +4,18 @@ import com.codahale.metrics.annotation.Timed;
 import org.apache.commons.lang.StringUtils;
 import org.apache.streamline.common.QueryParam;
 import org.apache.streamline.common.util.WSUtils;
-import org.apache.streamline.storage.exception.AlreadyExistsException;
 import org.apache.streamline.streams.catalog.Cluster;
 import org.apache.streamline.streams.catalog.Component;
 import org.apache.streamline.streams.catalog.Service;
 import org.apache.streamline.streams.catalog.ServiceConfiguration;
 import org.apache.streamline.streams.catalog.service.StreamCatalogService;
 import org.apache.streamline.streams.catalog.service.metadata.StormMetadataService;
-import org.apache.streamline.streams.cluster.discovery.ServiceNodeDiscoverer;
 import org.apache.streamline.streams.cluster.discovery.ambari.AmbariServiceNodeDiscoverer;
 import org.apache.streamline.streams.cluster.discovery.ambari.ServiceConfigurations;
-import org.apache.streamline.streams.service.metadata.StormMetadataResource;
+import org.apache.streamline.streams.service.exception.request.BadRequestException;
+import org.apache.streamline.streams.service.exception.request.ClusterImportAlreadyInProgressException;
+import org.apache.streamline.streams.service.exception.request.EntityAlreadyExistsException;
+import org.apache.streamline.streams.service.exception.request.EntityNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,7 +25,6 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.ProcessingException;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
@@ -37,20 +37,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.BAD_REQUEST_PARAM_MISSING;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_BY_NAME_NOT_FOUND;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND_FOR_FILTER;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.EXCEPTION;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.IMPORT_ALREADY_IN_PROGRESS;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.SUCCESS;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CREATED;
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
-import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 
 @Path("/v1/catalog")
 @Produces(MediaType.APPLICATION_JSON)
@@ -71,89 +59,69 @@ public class ClusterCatalogResource {
     @Timed
     public Response listClusters(@Context UriInfo uriInfo) {
         List<QueryParam> queryParams = new ArrayList<>();
-        try {
-            MultivaluedMap<String, String> params = uriInfo.getQueryParameters();
-            Collection<Cluster> clusters;
-            if (params.isEmpty()) {
-                clusters = catalogService.listClusters();
-            } else {
-                queryParams = WSUtils.buildQueryParameters(params);
-                clusters = catalogService.listClusters(queryParams);
-            }
-            if (clusters != null) {
-                return WSUtils.respond(clusters, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        MultivaluedMap<String, String> params = uriInfo.getQueryParameters();
+        Collection<Cluster> clusters;
+        if (params.isEmpty()) {
+            clusters = catalogService.listClusters();
+        } else {
+            queryParams = WSUtils.buildQueryParameters(params);
+            clusters = catalogService.listClusters(queryParams);
+        }
+        if (clusters != null) {
+            return WSUtils.respondEntities(clusters, OK);
         }
 
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND_FOR_FILTER, queryParams.toString());
+        throw EntityNotFoundException.byFilter(queryParams.toString());
     }
 
     @GET
     @Path("/clusters/{id}")
     @Timed
     public Response getClusterById(@PathParam("id") Long clusterId) {
-        try {
-            Cluster result = catalogService.getCluster(clusterId);
-            if (result != null) {
-                return WSUtils.respond(result, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        Cluster result = catalogService.getCluster(clusterId);
+        if (result != null) {
+            return WSUtils.respondEntity(result, OK);
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, clusterId.toString());
+
+        throw EntityNotFoundException.byId(clusterId.toString());
     }
 
     @GET
     @Path("/clusters/name/{clusterName}")
     @Timed
     public Response getClusterByName(@PathParam("clusterName") String clusterName) {
-        try {
-            Cluster result = catalogService.getClusterByName(clusterName);
-            if (result != null) {
-                return WSUtils.respond(result, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        Cluster result = catalogService.getClusterByName(clusterName);
+        if (result != null) {
+            return WSUtils.respondEntity(result, OK);
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_BY_NAME_NOT_FOUND, clusterName);
+
+        throw EntityNotFoundException.byName(clusterName);
     }
 
     @Timed
     @POST
     @Path("/clusters")
     public Response addCluster(Cluster cluster) {
-        try {
-            String clusterName = cluster.getName();
-            Cluster result = catalogService.getClusterByName(clusterName);
-            if (result != null) {
-                throw new AlreadyExistsException("Cluster entity already exists with name " + clusterName);
-            }
-
-            Cluster createdCluster = catalogService.addCluster(cluster);
-            return WSUtils.respond(createdCluster, CREATED, SUCCESS);
-        } catch (ProcessingException ex) {
-            return WSUtils.respond(BAD_REQUEST, ResponseMessage.BAD_REQUEST);
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        String clusterName = cluster.getName();
+        Cluster result = catalogService.getClusterByName(clusterName);
+        if (result != null) {
+            throw EntityAlreadyExistsException.byName(clusterName);
         }
+
+        Cluster createdCluster = catalogService.addCluster(cluster);
+        return WSUtils.respondEntity(createdCluster, CREATED);
     }
 
     @DELETE
     @Path("/clusters/{id}")
     @Timed
     public Response removeCluster(@PathParam("id") Long clusterId) {
-        try {
-            Cluster removedCluster = catalogService.removeCluster(clusterId);
-            if (removedCluster != null) {
-                return WSUtils.respond(removedCluster, OK, SUCCESS);
-            } else {
-                return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, clusterId.toString());
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        Cluster removedCluster = catalogService.removeCluster(clusterId);
+        if (removedCluster != null) {
+            return WSUtils.respondEntity(removedCluster, OK);
         }
+
+        throw EntityNotFoundException.byId(clusterId.toString());
     }
 
     @PUT
@@ -161,35 +129,29 @@ public class ClusterCatalogResource {
     @Timed
     public Response addOrUpdateCluster(@PathParam("id") Long clusterId,
                                        Cluster cluster) {
-        try {
-            Cluster newCluster = catalogService.addOrUpdateCluster(clusterId, cluster);
-            return WSUtils.respond(newCluster, OK, SUCCESS);
-        } catch (ProcessingException ex) {
-            return WSUtils.respond(BAD_REQUEST, ResponseMessage.BAD_REQUEST);
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
-        }
+        Cluster newCluster = catalogService.addOrUpdateCluster(clusterId, cluster);
+        return WSUtils.respondEntity(newCluster, CREATED);
     }
 
     @POST
     @Path("/cluster/import/ambari")
     @Timed
-    public Response importServicesFromAmbari(AmbariClusterImportParams params) {
+    public Response importServicesFromAmbari(AmbariClusterImportParams params) throws Exception {
         Long clusterId = params.getClusterId();
         if (clusterId == null) {
-            return WSUtils.respond(BAD_REQUEST, BAD_REQUEST_PARAM_MISSING, "clusterId");
+            throw BadRequestException.missingParameter("clusterId");
         }
 
         Cluster retrievedCluster = catalogService.getCluster(clusterId);
         if (retrievedCluster == null) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, String.valueOf(clusterId));
+            throw EntityNotFoundException.byId(String.valueOf(clusterId));
         }
 
         boolean acquired = false;
         try {
             synchronized (importInProgressCluster) {
                 if (importInProgressCluster.contains(clusterId)) {
-                    return WSUtils.respond(SERVICE_UNAVAILABLE, IMPORT_ALREADY_IN_PROGRESS, String.valueOf(clusterId));
+                    throw new ClusterImportAlreadyInProgressException(String.valueOf(clusterId));
                 }
 
                 importInProgressCluster.add(clusterId);
@@ -212,18 +174,15 @@ public class ClusterCatalogResource {
                 Collection<ServiceConfiguration> configurations = catalogService.listServiceConfigurations(service.getId());
                 Collection<Component> components = catalogService.listComponents(service.getId());
 
-                ClusterServicesImportResult.ServiceWithComponents s =
-                    new ClusterServicesImportResult.ServiceWithComponents(service);
+                ClusterServicesImportResult.ServiceWithComponents s = new ClusterServicesImportResult.ServiceWithComponents(
+                    service);
                 s.setComponents(components);
                 s.setConfigurations(configurations);
 
                 result.addService(s);
             }
 
-            return WSUtils.respond(result, OK, SUCCESS);
-        } catch (Exception ex) {
-            LOG.error("Got exception", ex);
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+            return WSUtils.respondEntity(result, OK);
         } finally {
             if (acquired) {
                 synchronized (importInProgressCluster) {

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/ComponentCatalogResource.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/ComponentCatalogResource.java
@@ -3,11 +3,12 @@ package org.apache.streamline.streams.service;
 import com.codahale.metrics.annotation.Timed;
 import org.apache.streamline.common.QueryParam;
 import org.apache.streamline.common.util.WSUtils;
-import org.apache.streamline.storage.exception.AlreadyExistsException;
 import org.apache.streamline.streams.catalog.Cluster;
 import org.apache.streamline.streams.catalog.Component;
 import org.apache.streamline.streams.catalog.Service;
 import org.apache.streamline.streams.catalog.service.StreamCatalogService;
+import org.apache.streamline.streams.service.exception.request.EntityAlreadyExistsException;
+import org.apache.streamline.streams.service.exception.request.EntityNotFoundException;
 
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -25,16 +26,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_BY_NAME_NOT_FOUND;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND_FOR_FILTER;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.EXCEPTION;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.SUCCESS;
 import static javax.ws.rs.core.Response.Status.CREATED;
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
-
 
 @Path("/v1/catalog")
 @Produces(MediaType.APPLICATION_JSON)
@@ -54,17 +47,12 @@ public class ComponentCatalogResource {
     @Timed
     public Response listComponents(@PathParam("serviceId") Long serviceId, @Context UriInfo uriInfo) {
         List<QueryParam> queryParams = buildServiceIdAwareQueryParams(serviceId, uriInfo);
-
-        try {
-            Collection<Component> components = catalogService.listComponents(queryParams);
-            if (components != null) {
-                return WSUtils.respond(components, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        Collection<Component> components = catalogService.listComponents(queryParams);
+        if (components != null) {
+            return WSUtils.respondEntities(components, OK);
         }
 
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND_FOR_FILTER, queryParams.toString());
+        throw EntityNotFoundException.byFilter(queryParams.toString());
     }
 
     /**
@@ -77,44 +65,37 @@ public class ComponentCatalogResource {
         @PathParam("serviceName") String serviceName, @Context UriInfo uriInfo) {
         Cluster cluster = catalogService.getClusterByName(clusterName);
         if (cluster == null) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_BY_NAME_NOT_FOUND, "cluster name " + clusterName);
+            throw EntityNotFoundException.byName("cluster name " + clusterName);
         }
 
         Service service = catalogService.getServiceByName(cluster.getId(), serviceName);
         if (service == null) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_BY_NAME_NOT_FOUND, "service name " + serviceName);
+            throw EntityNotFoundException.byName("service name " + serviceName);
         }
 
         List<QueryParam> queryParams = buildServiceIdAwareQueryParams(service.getId(), uriInfo);
 
-        try {
-            Collection<Component> components = catalogService.listComponents(queryParams);
-            if (components != null) {
-                return WSUtils.respond(components, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        Collection<Component> components = catalogService.listComponents(queryParams);
+        if (components != null) {
+            return WSUtils.respondEntities(components, OK);
         }
 
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND_FOR_FILTER, queryParams.toString());
+        throw EntityNotFoundException.byFilter(queryParams.toString());
     }
 
     @GET
     @Path("/services/{serviceId}/components/{id}")
     @Timed
     public Response getComponentById(@PathParam("serviceId") Long serviceId, @PathParam("id") Long componentId) {
-        try {
-            Component component = catalogService.getComponent(componentId);
-            if (component != null) {
-                if (component.getServiceId() == null || !component.getServiceId().equals(serviceId)) {
-                    return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, "service: " + serviceId.toString());
-                }
-                return WSUtils.respond(component, OK, SUCCESS);
+        Component component = catalogService.getComponent(componentId);
+        if (component != null) {
+            if (component.getServiceId() == null || !component.getServiceId().equals(serviceId)) {
+                throw EntityNotFoundException.byId("service: " + serviceId.toString());
             }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+            return WSUtils.respondEntity(component, OK);
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, buildMessageForCompositeId(serviceId, componentId));
+
+        throw EntityNotFoundException.byId(buildMessageForCompositeId(serviceId, componentId));
     }
 
     @GET
@@ -124,23 +105,21 @@ public class ComponentCatalogResource {
         @PathParam("serviceName") String serviceName, @PathParam("componentName") String componentName) {
         Cluster cluster = catalogService.getClusterByName(clusterName);
         if (cluster == null) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_BY_NAME_NOT_FOUND, "cluster name " + clusterName);
+            throw EntityNotFoundException.byName("cluster name " + clusterName);
         }
 
         Service service = catalogService.getServiceByName(cluster.getId(), serviceName);
         if (service == null) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_BY_NAME_NOT_FOUND, "service name " + serviceName);
+            throw EntityNotFoundException.byName("service name " + serviceName);
         }
 
-        try {
-            Component component = catalogService.getComponentByName(service.getId(), componentName);
-            if (component != null) {
-                return WSUtils.respond(component, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        Component component = catalogService.getComponentByName(service.getId(), componentName);
+        if (component != null) {
+            return WSUtils.respondEntity(component, OK);
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, buildMessageForCompositeName(clusterName, serviceName, componentName));
+
+        throw EntityNotFoundException.byName(buildMessageForCompositeName(clusterName,
+            serviceName, componentName));
     }
 
     @POST
@@ -150,24 +129,20 @@ public class ComponentCatalogResource {
         // overwrite service id to given path param
         component.setServiceId(serviceId);
 
-        try {
-            Service service = catalogService.getService(serviceId);
-            if (service == null) {
-                return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, "service: " + serviceId.toString());
-            }
-
-            String componentName = component.getName();
-            Component result = catalogService.getComponentByName(serviceId, componentName);
-            if (result != null) {
-                throw new AlreadyExistsException("Component entity already exists with service id " +
-                    serviceId + " and component name " + componentName);
-            }
-
-            Component createdComponent = catalogService.addComponent(component);
-            return WSUtils.respond(createdComponent, CREATED, SUCCESS);
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        Service service = catalogService.getService(serviceId);
+        if (service == null) {
+            throw EntityNotFoundException.byId("service: " + serviceId.toString());
         }
+
+        String componentName = component.getName();
+        Component result = catalogService.getComponentByName(serviceId, componentName);
+        if (result != null) {
+            throw EntityAlreadyExistsException.byName("service id " + serviceId +
+                " and component name " + componentName);
+        }
+
+        Component createdComponent = catalogService.addComponent(component);
+        return WSUtils.respondEntity(createdComponent, CREATED);
     }
 
     @PUT
@@ -179,31 +154,23 @@ public class ComponentCatalogResource {
 
         Service service = catalogService.getService(serviceId);
         if (service == null) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, "service: " + serviceId.toString());
+            throw EntityNotFoundException.byId("service: " + serviceId.toString());
         }
 
-        try {
-            Component createdComponent = catalogService.addOrUpdateComponent(serviceId, component);
-            return WSUtils.respond(createdComponent, CREATED, SUCCESS);
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
-        }
+        Component createdComponent = catalogService.addOrUpdateComponent(serviceId, component);
+        return WSUtils.respondEntity(createdComponent, CREATED);
     }
 
     @DELETE
     @Path("/services/{serviceId}/components/{id}")
     @Timed
     public Response removeComponent(@PathParam("id") Long componentId) {
-        try {
-            Component removeComponent = catalogService.removeComponent(componentId);
-            if (removeComponent != null) {
-                return WSUtils.respond(removeComponent, OK, SUCCESS);
-            } else {
-                return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, componentId.toString());
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        Component removeComponent = catalogService.removeComponent(componentId);
+        if (removeComponent != null) {
+            return WSUtils.respondEntity(removeComponent, CREATED);
         }
+
+        throw EntityNotFoundException.byId(componentId.toString());
     }
 
     @PUT
@@ -214,12 +181,8 @@ public class ComponentCatalogResource {
         // overwrite service id to given path param
         component.setServiceId(serviceId);
 
-        try {
-            Component newComponent = catalogService.addOrUpdateComponent(serviceId, componentId, component);
-            return WSUtils.respond(newComponent, OK, SUCCESS);
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
-        }
+        Component newComponent = catalogService.addOrUpdateComponent(serviceId, componentId, component);
+        return WSUtils.respondEntity(newComponent, CREATED);
     }
 
     private List<QueryParam> buildServiceIdAwareQueryParams(Long serviceId, UriInfo uriInfo) {

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/GenericExceptionMapper.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/GenericExceptionMapper.java
@@ -1,0 +1,71 @@
+package org.apache.streamline.streams.service;
+
+import org.apache.streamline.streams.service.exception.StreamServiceException;
+import org.apache.streamline.streams.service.exception.request.BadRequestException;
+import org.apache.streamline.streams.service.exception.server.UnhandledServerException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class GenericExceptionMapper implements ExceptionMapper<Throwable> {
+  private static final Logger LOG = LoggerFactory.getLogger(GenericExceptionMapper.class);
+
+  @Override
+  public Response toResponse(Throwable ex) {
+    if (ex instanceof ProcessingException) {
+      return BadRequestException.of().getResponse();
+    } else if (ex instanceof StreamServiceException) {
+      return ((StreamServiceException) ex).getResponse();
+    }
+
+    logUnhandledException(ex);
+    return new UnhandledServerException(ex.getMessage()).getResponse();
+  }
+
+  private void logUnhandledException(Throwable ex) {
+    String errMessage = String.format("Got exception: [%s] / message [%s]",
+        ex.getClass().getSimpleName(), ex.getMessage());
+    StackTraceElement elem = findFirstResourceCallFromCallStack(ex.getStackTrace());
+    String resourceClassName = null;
+    if (elem != null) {
+      errMessage += String.format(" / related resource location: [%s.%s](%s:%d)",
+          elem.getClassName(), elem.getMethodName(), elem.getFileName(), elem.getLineNumber());
+      resourceClassName = elem.getClassName();
+    }
+
+    Logger log = getEffectiveLogger(resourceClassName);
+    log.error(errMessage, ex);
+  }
+
+  private StackTraceElement findFirstResourceCallFromCallStack(StackTraceElement[] stackTrace) {
+    for (StackTraceElement stackTraceElement : stackTrace) {
+      try {
+        Class<?> aClass = Class.forName(stackTraceElement.getClassName());
+        Path pathAnnotation = aClass.getAnnotation(Path.class);
+
+        if (pathAnnotation != null) {
+          return stackTraceElement;
+        }
+      } catch (ClassNotFoundException e) {
+        // skip
+      }
+    }
+
+    return null;
+  }
+
+  private Logger getEffectiveLogger(String resourceClassName) {
+    Logger log = LOG;
+    if (resourceClassName != null) {
+      log = LoggerFactory.getLogger(resourceClassName);
+    }
+    return log;
+  }
+
+}

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/SchemaResource.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/SchemaResource.java
@@ -18,10 +18,12 @@
 package org.apache.streamline.streams.service;
 
 import com.codahale.metrics.annotation.Timed;
-import org.apache.streamline.common.util.WSUtils;
-import org.apache.registries.schemaregistry.errors.SchemaNotFoundException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.registries.schemaregistry.SchemaVersionInfo;
 import org.apache.registries.schemaregistry.client.SchemaRegistryClient;
+import org.apache.registries.schemaregistry.errors.SchemaNotFoundException;
+import org.apache.streamline.common.util.WSUtils;
+import org.apache.streamline.streams.service.exception.request.EntityNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,11 +34,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.EXCEPTION;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.SUCCESS;
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 
 /**
@@ -59,7 +56,8 @@ public class SchemaResource {
     @Path("/{topicName}")
     @Timed
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getKafkaSourceSchema(@PathParam("topicName") String topicName) {
+    public Response getKafkaSourceSchema(@PathParam("topicName") String topicName)
+        throws JsonProcessingException {
         try {
             // for now, takes care of kafka for topic values. We will enhance to work this to get schema for different
             // sources based on given properties.
@@ -71,14 +69,14 @@ public class SchemaResource {
                 schema = avroStreamsSchemaConverter.convertAvro(schema);
             }
             LOG.debug("######### Converted schema: ", schema);
-            return WSUtils.respond(schema, OK, SUCCESS);
+            return WSUtils.respondEntity(schema, OK);
         } catch (SchemaNotFoundException e) {
             // ignore and log error
             LOG.error("Schema not found for name: [{}]", topicName, e);
-            return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, topicName);
-        } catch (Exception ex) {
+            throw EntityNotFoundException.byId(topicName);
+        } catch (JsonProcessingException ex) {
             LOG.error("Error occurred while retrieving schema with name [{}]", topicName, ex);
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+            throw ex;
         }
     }
 

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/ServiceCatalogResource.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/ServiceCatalogResource.java
@@ -3,10 +3,11 @@ package org.apache.streamline.streams.service;
 import com.codahale.metrics.annotation.Timed;
 import org.apache.streamline.common.QueryParam;
 import org.apache.streamline.common.util.WSUtils;
-import org.apache.streamline.storage.exception.AlreadyExistsException;
 import org.apache.streamline.streams.catalog.Cluster;
 import org.apache.streamline.streams.catalog.Service;
 import org.apache.streamline.streams.catalog.service.StreamCatalogService;
+import org.apache.streamline.streams.service.exception.request.EntityAlreadyExistsException;
+import org.apache.streamline.streams.service.exception.request.EntityNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,7 +17,6 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.ProcessingException;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
@@ -27,16 +27,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_BY_NAME_NOT_FOUND;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND_FOR_FILTER;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.EXCEPTION;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.SUCCESS;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CREATED;
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 
 @Path("/v1/catalog")
@@ -57,17 +48,13 @@ public class ServiceCatalogResource {
     @Timed
     public Response listServices(@PathParam("clusterId") Long clusterId, @Context UriInfo uriInfo) {
         List<QueryParam> queryParams = buildClusterIdAwareQueryParams(clusterId, uriInfo);
-        try {
-            Collection<Service> services;
-            services = catalogService.listServices(queryParams);
-            if (services != null) {
-                return WSUtils.respond(services, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        Collection<Service> services;
+        services = catalogService.listServices(queryParams);
+        if (services != null) {
+            return WSUtils.respondEntities(services, OK);
         }
 
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND_FOR_FILTER, queryParams.toString());
+        throw EntityNotFoundException.byFilter(queryParams.toString());
     }
 
     /**
@@ -79,39 +66,32 @@ public class ServiceCatalogResource {
     public Response listServicesByName(@PathParam("clusterName") String clusterName, @Context UriInfo uriInfo) {
         Cluster cluster = catalogService.getClusterByName(clusterName);
         if (cluster == null) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_BY_NAME_NOT_FOUND, "cluster name " + clusterName);
+            throw EntityNotFoundException.byName("cluster name " + clusterName);
         }
 
         List<QueryParam> queryParams = buildClusterIdAwareQueryParams(cluster.getId(), uriInfo);
-        try {
-            Collection<Service> services;
-            services = catalogService.listServices(queryParams);
-            if (services != null) {
-                return WSUtils.respond(services, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        Collection<Service> services;
+        services = catalogService.listServices(queryParams);
+        if (services != null) {
+            return WSUtils.respondEntities(services, OK);
         }
 
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND_FOR_FILTER, queryParams.toString());
+        throw EntityNotFoundException.byFilter(queryParams.toString());
     }
 
     @GET
     @Path("/clusters/{clusterId}/services/{id}")
     @Timed
     public Response getServiceById(@PathParam("clusterId") Long clusterId, @PathParam("id") Long serviceId) {
-        try {
-            Service result = catalogService.getService(serviceId);
-            if (result != null) {
-                if (result.getClusterId() == null || !result.getClusterId().equals(clusterId)) {
-                    return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, "cluster: " + clusterId.toString());
-                }
-                return WSUtils.respond(result, OK, SUCCESS);
+        Service result = catalogService.getService(serviceId);
+        if (result != null) {
+            if (result.getClusterId() == null || !result.getClusterId().equals(clusterId)) {
+                throw EntityNotFoundException.byId("cluster: " + clusterId.toString());
             }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+            return WSUtils.respondEntity(result, OK);
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, buildMessageForCompositeId(clusterId, serviceId));
+
+        throw EntityNotFoundException.byId(buildMessageForCompositeId(clusterId, serviceId));
     }
 
     @GET
@@ -121,18 +101,15 @@ public class ServiceCatalogResource {
         @PathParam("serviceName") String serviceName) {
         Cluster cluster = catalogService.getClusterByName(clusterName);
         if (cluster == null) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_BY_NAME_NOT_FOUND, "cluster name " + clusterName);
+            throw EntityNotFoundException.byName("cluster name " + clusterName);
         }
 
-        try {
-            Service result = catalogService.getServiceByName(cluster.getId(), serviceName);
-            if (result != null) {
-                return WSUtils.respond(result, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        Service result = catalogService.getServiceByName(cluster.getId(), serviceName);
+        if (result != null) {
+            return WSUtils.respondEntity(result, OK);
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, buildMessageForCompositeName(clusterName, serviceName));
+
+        throw EntityNotFoundException.byId(buildMessageForCompositeName(clusterName, serviceName));
     }
 
     @Timed
@@ -142,42 +119,32 @@ public class ServiceCatalogResource {
         // overwrite cluster id to given path param
         service.setClusterId(clusterId);
 
-        try {
-            Cluster cluster = catalogService.getCluster(clusterId);
-            if (cluster == null) {
-                return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, "cluster: " + clusterId.toString());
-            }
-
-            String serviceName = service.getName();
-            Service result = catalogService.getServiceByName(clusterId, serviceName);
-            if (result != null) {
-                throw new AlreadyExistsException("Service entity already exists with cluster id " +
-                    clusterId + " and service name " + serviceName);
-            }
-
-            Service createdService = catalogService.addService(service);
-            return WSUtils.respond(createdService, CREATED, SUCCESS);
-        } catch (ProcessingException ex) {
-            return WSUtils.respond(BAD_REQUEST, ResponseMessage.BAD_REQUEST);
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        Cluster cluster = catalogService.getCluster(clusterId);
+        if (cluster == null) {
+            throw EntityNotFoundException.byId("cluster: " + clusterId.toString());
         }
+
+        String serviceName = service.getName();
+        Service result = catalogService.getServiceByName(clusterId, serviceName);
+        if (result != null) {
+            throw EntityAlreadyExistsException.byName("cluster id " +
+                clusterId + " and service name " + serviceName);
+        }
+
+        Service createdService = catalogService.addService(service);
+        return WSUtils.respondEntity(createdService, CREATED);
     }
 
     @DELETE
     @Path("/clusters/{clusterId}/services/{id}")
     @Timed
     public Response removeService(@PathParam("id") Long serviceId) {
-        try {
-            Service removedService = catalogService.removeService(serviceId);
-            if (removedService != null) {
-                return WSUtils.respond(removedService, OK, SUCCESS);
-            } else {
-                return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, serviceId.toString());
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        Service removedService = catalogService.removeService(serviceId);
+        if (removedService != null) {
+            return WSUtils.respondEntity(removedService, OK);
         }
+
+        throw EntityNotFoundException.byId(serviceId.toString());
     }
 
     @PUT
@@ -188,19 +155,13 @@ public class ServiceCatalogResource {
         // overwrite cluster id to given path param
         service.setClusterId(clusterId);
 
-        try {
-            Cluster cluster = catalogService.getCluster(clusterId);
-            if (cluster == null) {
-                return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, "cluster: " + clusterId.toString());
-            }
-
-            Service newService = catalogService.addOrUpdateService(serviceId, service);
-            return WSUtils.respond(newService, OK, SUCCESS);
-        } catch (ProcessingException ex) {
-            return WSUtils.respond(BAD_REQUEST, ResponseMessage.BAD_REQUEST, ex.getMessage());
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        Cluster cluster = catalogService.getCluster(clusterId);
+        if (cluster == null) {
+            throw EntityNotFoundException.byId("cluster: " + clusterId.toString());
         }
+
+        Service newService = catalogService.addOrUpdateService(serviceId, service);
+        return WSUtils.respondEntity(newService, OK);
     }
 
     private List<QueryParam> buildClusterIdAwareQueryParams(Long clusterId, UriInfo uriInfo) {

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/StreamsModule.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/StreamsModule.java
@@ -20,7 +20,6 @@ import org.apache.streamline.streams.layout.storm.StormTopologyLayoutConstants;
 import org.apache.streamline.streams.metrics.TimeSeriesQuerier;
 import org.apache.streamline.streams.metrics.topology.TopologyMetrics;
 import org.apache.streamline.streams.notification.service.NotificationServiceImpl;
-import org.apache.streamline.streams.notification.service.NotificationsResource;
 import org.apache.registries.schemaregistry.client.SchemaRegistryClient;
 import org.apache.streamline.streams.service.metadata.HBaseMetadataResource;
 import org.apache.streamline.streams.service.metadata.HiveMetadataResource;

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/TopologyCatalogResource.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/TopologyCatalogResource.java
@@ -27,9 +27,11 @@ import org.apache.streamline.streams.catalog.Topology;
 import org.apache.streamline.streams.catalog.TopologyVersionInfo;
 import org.apache.streamline.streams.catalog.service.StreamCatalogService;
 import org.apache.streamline.streams.layout.component.TopologyActions;
-import org.apache.streamline.streams.storm.common.StormNotReachableException;
 import org.apache.streamline.streams.metrics.storm.topology.TopologyNotAliveException;
 import org.apache.streamline.streams.metrics.topology.TopologyMetrics;
+import org.apache.streamline.streams.service.exception.request.BadRequestException;
+import org.apache.streamline.streams.service.exception.request.EntityNotFoundException;
+import org.apache.streamline.streams.storm.common.StormNotReachableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,20 +49,12 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
 import static java.util.stream.Collectors.toList;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CREATED;
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.BAD_REQUEST_PARAM_MISSING;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_VERSION_NOT_FOUND;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.EXCEPTION;
 import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.SUCCESS;
 import static org.apache.streamline.streams.catalog.TopologyVersionInfo.VERSION_PREFIX;
 
@@ -84,28 +78,23 @@ public class TopologyCatalogResource {
     @Path("/topologies")
     @Timed
     public Response listTopologies (@javax.ws.rs.QueryParam("withMetric") Boolean withMetric,
-        @javax.ws.rs.QueryParam("sort") String sortType,
-        @javax.ws.rs.QueryParam("latencyTopN") Integer latencyTopN) {
-        try {
-            Collection<Topology> topologies = catalogService.listTopologies();
-            Response response;
-            if (topologies != null) {
-                if (withMetric == null || !withMetric) {
-                    response = WSUtils.respond(topologies, OK, SUCCESS);
-                } else {
-                    List<TopologyCatalogWithMetric> topologiesWithMetric = enrichMetricToTopologies(
-                        topologies, sortType, latencyTopN);
-                    response = WSUtils.respond(topologiesWithMetric, OK, SUCCESS);
-                }
+                                    @javax.ws.rs.QueryParam("sort") String sortType,
+                                    @javax.ws.rs.QueryParam("latencyTopN") Integer latencyTopN) {
+        Collection<Topology> topologies = catalogService.listTopologies();
+        Response response;
+        if (topologies != null) {
+            if (withMetric == null || !withMetric) {
+                response = WSUtils.respondEntities(topologies, OK);
             } else {
-                response = WSUtils.respond(Collections.emptyList(), OK, SUCCESS);
+                List<TopologyCatalogWithMetric> topologiesWithMetric = enrichMetricToTopologies(
+                        topologies, sortType, latencyTopN);
+                response = WSUtils.respondEntities(topologiesWithMetric, OK);
             }
-
-            return response;
-        } catch (Exception ex) {
-            LOG.error("unable to fetch topologies due to {} ", ex);
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        } else {
+            response = WSUtils.respondEntities(Collections.emptyList(), OK);
         }
+
+        return response;
     }
 
     @GET
@@ -114,18 +103,14 @@ public class TopologyCatalogResource {
     public Response getTopologyById(@PathParam("topologyId") Long topologyId,
                                     @javax.ws.rs.QueryParam("withMetric") Boolean withMetric,
                                     @javax.ws.rs.QueryParam("latencyTopN") Integer latencyTopN) {
-        try {
-            Response response = getTopologyByIdAndVersionId(topologyId,
-                    catalogService.getCurrentVersionId(topologyId),
-                    withMetric, latencyTopN);
-            if (response != null) {
-                return response;
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        Response response = getTopologyByIdAndVersionId(topologyId,
+                catalogService.getCurrentVersionId(topologyId),
+                withMetric, latencyTopN);
+        if (response != null) {
+            return response;
         }
 
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, topologyId.toString());
+        throw EntityNotFoundException.byId(topologyId.toString());
     }
 
     @GET
@@ -135,15 +120,12 @@ public class TopologyCatalogResource {
                                               @PathParam("versionId") Long versionId,
                                               @javax.ws.rs.QueryParam("withMetric") Boolean withMetric,
                                               @javax.ws.rs.QueryParam("latencyTopN") Integer latencyTopN) {
-        try {
-            Response response = getTopologyByIdAndVersionId(topologyId, versionId, withMetric, latencyTopN);
-            if (response != null) {
-                return response;
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        Response response = getTopologyByIdAndVersionId(topologyId, versionId, withMetric, latencyTopN);
+        if (response != null) {
+            return response;
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_VERSION_NOT_FOUND, topologyId.toString(), versionId.toString());
+
+        throw EntityNotFoundException.byVersion(topologyId.toString(), versionId.toString());
     }
 
     private Response getTopologyByIdAndVersionId(Long topologyId, Long versionId, Boolean withMetric,
@@ -151,11 +133,11 @@ public class TopologyCatalogResource {
         Topology result = catalogService.getTopology(topologyId, versionId);
         if (result != null) {
             if (withMetric == null || !withMetric) {
-                return WSUtils.respond(result, OK, SUCCESS);
+                return WSUtils.respondEntity(result, OK);
             } else {
                 TopologyCatalogWithMetric topologiesWithMetric = enrichMetricToTopology(
                         result, latencyTopN);
-                return WSUtils.respond(topologiesWithMetric, OK, SUCCESS);
+                return WSUtils.respondEntity(topologiesWithMetric, OK);
             }
         }
         return null;
@@ -165,19 +147,15 @@ public class TopologyCatalogResource {
     @Path("/topologies/{topologyId}/versions")
     @Timed
     public Response listTopologyVersions(@PathParam("topologyId") Long topologyId) {
-        try {
-                Collection<TopologyVersionInfo> versionInfos = catalogService.listTopologyVersionInfos(
-                    WSUtils.buildTopologyIdAwareQueryParams(topologyId, null));
-            Response response;
-            if (versionInfos != null) {
-                response = WSUtils.respond(versionInfos, OK, SUCCESS);
-            } else {
-                response = WSUtils.respond(Collections.emptyList(), OK, SUCCESS);
-            }
-            return response;
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        Collection<TopologyVersionInfo> versionInfos = catalogService.listTopologyVersionInfos(
+                WSUtils.buildTopologyIdAwareQueryParams(topologyId, null));
+        Response response;
+        if (versionInfos != null) {
+            response = WSUtils.respondEntities(versionInfos, OK);
+        } else {
+            response = WSUtils.respondEntities(Collections.emptyList(), OK);
         }
+        return response;
     }
 
 
@@ -185,28 +163,22 @@ public class TopologyCatalogResource {
     @Path("/topologies")
     @Timed
     public Response addTopology(Topology topology) {
-        try {
-            if (StringUtils.isEmpty(topology.getName())) {
-                return WSUtils.respond(BAD_REQUEST,
-                        BAD_REQUEST_PARAM_MISSING, Topology.NAME);
-            }
-            if (StringUtils.isEmpty(topology.getConfig())) {
-                return WSUtils.respond(BAD_REQUEST,
-                        BAD_REQUEST_PARAM_MISSING, Topology.CONFIG);
-            }
-            Topology createdTopology = catalogService.addTopology(topology);
-            return WSUtils.respond(createdTopology, CREATED, SUCCESS);
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        if (StringUtils.isEmpty(topology.getName())) {
+            throw BadRequestException.missingParameter(Topology.NAME);
         }
+        if (StringUtils.isEmpty(topology.getConfig())) {
+            throw BadRequestException.missingParameter(Topology.CONFIG);
+        }
+        Topology createdTopology = catalogService.addTopology(topology);
+        return WSUtils.respondEntity(createdTopology, CREATED);
     }
 
     @DELETE
     @Path("/topologies/{topologyId}")
     @Timed
     public Response removeTopology(@PathParam("topologyId") Long topologyId,
-                                    @javax.ws.rs.QueryParam("recurse") boolean recurse,
-                                    @javax.ws.rs.QueryParam("allVersions") boolean allVersions) {
+                                   @javax.ws.rs.QueryParam("recurse") boolean recurse,
+                                   @javax.ws.rs.QueryParam("allVersions") boolean allVersions) {
         if (allVersions) {
             return removeAllTopologyVersions(topologyId, recurse);
         } else {
@@ -219,48 +191,34 @@ public class TopologyCatalogResource {
                 WSUtils.topologyVersionsQueryParam(topologyId));
         List<Topology> removed = new ArrayList<>();
         for (TopologyVersionInfo version : versions) {
-            try {
-                removed.add(catalogService.removeTopology(topologyId, version.getId(), recurse));
-            } catch (Exception ex) {
-                return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
-            }
+            removed.add(catalogService.removeTopology(topologyId, version.getId(), recurse));
         }
-        return WSUtils.respond(removed, OK, SUCCESS);
+        return WSUtils.respondEntities(removed, OK);
     }
 
     private Response removeCurrentTopologyVersion(Long topologyId, boolean recurse) {
-        try {
-            Topology removedTopology = catalogService.removeTopology(topologyId, recurse);
-            if (removedTopology != null) {
-                return WSUtils.respond(removedTopology, OK, SUCCESS);
-            } else {
-                return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, topologyId.toString());
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        Topology removedTopology = catalogService.removeTopology(topologyId, recurse);
+        if (removedTopology != null) {
+            return WSUtils.respondEntity(removedTopology, OK);
         }
+
+        throw EntityNotFoundException.byId(topologyId.toString());
     }
 
     @PUT
     @Path("/topologies/{topologyId}")
     @Timed
     public Response addOrUpdateTopology (@PathParam("topologyId") Long topologyId,
-                                        Topology topology) {
-        try {
-            if (StringUtils.isEmpty(topology.getName())) {
-                return WSUtils.respond(BAD_REQUEST,
-                        BAD_REQUEST_PARAM_MISSING, Topology.NAME);
-            }
-            if (StringUtils.isEmpty(topology.getConfig())) {
-                return WSUtils.respond(BAD_REQUEST,
-                        BAD_REQUEST_PARAM_MISSING, Topology.CONFIG);
-            }
-            Topology result = catalogService.addOrUpdateTopology
-                    (topologyId, topology);
-            return WSUtils.respond(topology, OK, SUCCESS);
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+                                         Topology topology) {
+        if (StringUtils.isEmpty(topology.getName())) {
+            throw BadRequestException.missingParameter(Topology.NAME);
         }
+        if (StringUtils.isEmpty(topology.getConfig())) {
+            throw BadRequestException.missingParameter(Topology.CONFIG);
+        }
+        Topology result = catalogService.addOrUpdateTopology
+                (topologyId, topology);
+        return WSUtils.respondEntity(topology, OK);
     }
 
     /**
@@ -298,13 +256,13 @@ public class TopologyCatalogResource {
             TopologyVersionInfo savedVersion = catalogService.addOrUpdateTopologyVersionInfo(
                     currentVersion.get().getId(), versionInfo);
             catalogService.cloneTopologyVersion(topologyId, savedVersion.getId());
-            return WSUtils.respond(savedVersion, CREATED, SUCCESS);
+            return WSUtils.respondEntity(savedVersion, CREATED);
         } catch (Exception ex) {
             // restore the current version
             if (currentVersion.isPresent()) {
                 catalogService.addOrUpdateTopologyVersionInfo(currentVersion.get().getId(), currentVersion.get());
             }
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+            throw ex;
         }
     }
 
@@ -313,77 +271,64 @@ public class TopologyCatalogResource {
     @Timed
     public Response activateTopologyVersion(@PathParam("topologyId") Long topologyId,
                                             @PathParam("versionId") Long versionId) {
-        try {
-            Optional<TopologyVersionInfo> currentVersionInfo = catalogService.getCurrentTopologyVersionInfo(topologyId);
-            if (currentVersionInfo.isPresent() && currentVersionInfo.get().getId().equals(versionId)) {
-                throw new IllegalArgumentException("Version id " + versionId + " is already the current version");
-            }
-            TopologyVersionInfo savedVersion = catalogService.getTopologyVersionInfo(versionId);
-            if (savedVersion != null) {
-                catalogService.cloneTopologyVersion(topologyId, savedVersion.getId());
-                 /*
-                 * successfully cloned and set a new current version,
-                 * remove the old current version of topology and version info
-                 */
-                if (currentVersionInfo.isPresent()) {
-                    catalogService.removeTopology(topologyId, currentVersionInfo.get().getId(), true);
-                }
-            } else {
-                return WSUtils.respond(NOT_FOUND, ENTITY_VERSION_NOT_FOUND, topologyId.toString(), versionId.toString());
-            }
-            return WSUtils.respond(savedVersion, CREATED, SUCCESS);
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        Optional<TopologyVersionInfo> currentVersionInfo = catalogService.getCurrentTopologyVersionInfo(topologyId);
+        if (currentVersionInfo.isPresent() && currentVersionInfo.get().getId().equals(versionId)) {
+            throw new IllegalArgumentException("Version id " + versionId + " is already the current version");
         }
+        TopologyVersionInfo savedVersion = catalogService.getTopologyVersionInfo(versionId);
+        if (savedVersion != null) {
+            catalogService.cloneTopologyVersion(topologyId, savedVersion.getId());
+             /*
+             * successfully cloned and set a new current version,
+             * remove the old current version of topology and version info
+             */
+            if (currentVersionInfo.isPresent()) {
+                catalogService.removeTopology(topologyId, currentVersionInfo.get().getId(), true);
+            }
+            return WSUtils.respondEntity(savedVersion, CREATED);
+        }
+
+        throw EntityNotFoundException.byVersion(topologyId.toString(), versionId.toString());
     }
 
     @GET
     @Path("/topologies/{topologyId}/actions/status")
     @Timed
-    public Response topologyStatus (@PathParam("topologyId") Long topologyId) {
-        try {
-            Topology result = catalogService.getTopology(topologyId);
-            if (result != null) {
-                TopologyActions.Status status = catalogService.topologyStatus(result);
-                return WSUtils.respond(status, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+    public Response topologyStatus (@PathParam("topologyId") Long topologyId) throws Exception {
+        Topology result = catalogService.getTopology(topologyId);
+        if (result != null) {
+            TopologyActions.Status status = catalogService.topologyStatus(result);
+            return WSUtils.respondEntity(status, OK);
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, topologyId.toString());
+
+        throw EntityNotFoundException.byId(topologyId.toString());
     }
 
     @GET
     @Path("/topologies/{topologyId}/versions/{versionId}/actions/status")
     @Timed
     public Response topologyStatusVersion(@PathParam("topologyId") Long topologyId,
-                                          @PathParam("versionId") Long versionId) {
-        try {
-            Topology result = catalogService.getTopology(topologyId, versionId);
-            if (result != null) {
-                TopologyActions.Status status = catalogService.topologyStatus(result);
-                return WSUtils.respond(status, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+                                          @PathParam("versionId") Long versionId) throws Exception {
+        Topology result = catalogService.getTopology(topologyId, versionId);
+        if (result != null) {
+            TopologyActions.Status status = catalogService.topologyStatus(result);
+            return WSUtils.respondEntity(status, OK);
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_VERSION_NOT_FOUND, topologyId.toString(), versionId.toString());
+
+        throw EntityNotFoundException.byVersion(topologyId.toString(), versionId.toString());
     }
 
     @POST
     @Path("/topologies/{topologyId}/actions/validate")
     @Timed
     public Response validateTopology (@PathParam("topologyId") Long topologyId) {
-        try {
-            Topology result = catalogService.getTopology(topologyId);
-            if (result != null) {
-                //catalogService.validateTopology(SCHEMA, topologyId);
-                return WSUtils.respond(result, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        Topology result = catalogService.getTopology(topologyId);
+        if (result != null) {
+            //catalogService.validateTopology(SCHEMA, topologyId);
+            return WSUtils.respondEntity(result, OK);
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, topologyId.toString());
+
+        throw EntityNotFoundException.byId(topologyId.toString());
     }
 
     @POST
@@ -391,156 +336,127 @@ public class TopologyCatalogResource {
     @Timed
     public Response validateTopologyVersion(@PathParam("topologyId") Long topologyId,
                                             @PathParam("versionId") Long versionId) {
-        try {
-            Topology result = catalogService.getTopology(topologyId, versionId);
-            if (result != null) {
-                //catalogService.validateTopology(SCHEMA, topologyId);
-                return WSUtils.respond(result, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        Topology result = catalogService.getTopology(topologyId, versionId);
+        if (result != null) {
+            //catalogService.validateTopology(SCHEMA, topologyId);
+            return WSUtils.respondEntity(result, OK);
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_VERSION_NOT_FOUND, topologyId.toString(), versionId.toString());
+
+        throw EntityNotFoundException.byVersion(topologyId.toString(), versionId.toString());
     }
 
     @POST
     @Path("/topologies/{topologyId}/actions/deploy")
     @Timed
-    public Response deployTopology (@PathParam("topologyId") Long topologyId) {
-        try {
-            Topology result = catalogService.getTopology(topologyId);
-            if (result != null) {
+    public Response deployTopology (@PathParam("topologyId") Long topologyId) throws Exception {
+        Topology result = catalogService.getTopology(topologyId);
+        if (result != null) {
 //TODO: fix     catalogService.validateTopology(SCHEMA, topologyId);
-                catalogService.deployTopology(result);
-                return WSUtils.respond(result, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            LOG.error("Failed to deploy the topology ", topologyId, ex);
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+            catalogService.deployTopology(result);
+            return WSUtils.respondEntity(result, OK);
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, topologyId.toString());
+
+        throw EntityNotFoundException.byId(topologyId.toString());
     }
 
     @POST
     @Path("/topologies/{topologyId}/versions/{versionId}/actions/deploy")
     @Timed
     public Response deployTopologyVersion(@PathParam("topologyId") Long topologyId,
-                                          @PathParam("versionId") Long versionId) {
-        try {
-            Topology result = catalogService.getTopology(topologyId, versionId);
-            if (result != null) {
+                                          @PathParam("versionId") Long versionId) throws Exception {
+        Topology result = catalogService.getTopology(topologyId, versionId);
+        if (result != null) {
 //TODO: fix     catalogService.validateTopology(SCHEMA, topologyId);
-                catalogService.deployTopology(result);
-                return WSUtils.respond(result, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            LOG.error("Failed to deploy the topology ", topologyId, ex);
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+            catalogService.deployTopology(result);
+            return WSUtils.respondEntity(result, OK);
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_VERSION_NOT_FOUND, topologyId.toString(), versionId.toString());
+
+        throw EntityNotFoundException.byVersion(topologyId.toString(), versionId.toString());
     }
 
     @POST
     @Path("/topologies/{topologyId}/actions/kill")
     @Timed
-    public Response killTopology (@PathParam("topologyId") Long topologyId) {
-        try {
-            Topology result = catalogService.getTopology(topologyId);
-            if (result != null) {
-                catalogService.killTopology(result);
-                return WSUtils.respond(result, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+    public Response killTopology (@PathParam("topologyId") Long topologyId) throws Exception {
+        Topology result = catalogService.getTopology(topologyId);
+        if (result != null) {
+            catalogService.killTopology(result);
+            return WSUtils.respondEntity(result, OK);
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, topologyId.toString());
+
+        throw EntityNotFoundException.byId(topologyId.toString());
     }
 
     @POST
     @Path("/topologies/{topologyId}/versions/{versionId}/actions/kill")
     @Timed
     public Response killTopologyVersion(@PathParam("topologyId") Long topologyId,
-                                        @PathParam("versionId") Long versionId) {
-        try {
-            Topology result = catalogService.getTopology(topologyId, versionId);
-            if (result != null) {
-                catalogService.killTopology(result);
-                return WSUtils.respond(result, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+                                        @PathParam("versionId") Long versionId) throws Exception {
+        Topology result = catalogService.getTopology(topologyId, versionId);
+        if (result != null) {
+            catalogService.killTopology(result);
+            return WSUtils.respondEntity(result, OK);
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_VERSION_NOT_FOUND, topologyId.toString(), versionId.toString());
+
+        throw EntityNotFoundException.byVersion(topologyId.toString(), versionId.toString());
     }
 
     @POST
     @Path("/topologies/{topologyId}/actions/suspend")
     @Timed
-    public Response suspendTopology (@PathParam("topologyId") Long topologyId) {
-        try {
-            Topology result = catalogService.getTopology(topologyId);
-            if (result != null) {
-                catalogService.suspendTopology(result);
-                return WSUtils.respond(result, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+    public Response suspendTopology (@PathParam("topologyId") Long topologyId) throws Exception {
+        Topology result = catalogService.getTopology(topologyId);
+        if (result != null) {
+            catalogService.suspendTopology(result);
+            return WSUtils.respondEntity(result, OK);
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, topologyId.toString());
+
+        throw EntityNotFoundException.byId(topologyId.toString());
     }
 
     @POST
     @Path("/topologies/{topologyId}/versions/{versionId}/actions/suspend")
     @Timed
     public Response suspendTopologyVersion(@PathParam("topologyId") Long topologyId,
-                                           @PathParam("versionId") Long versionId) {
-        try {
-            Topology result = catalogService.getTopology(topologyId, versionId);
-            if (result != null) {
-                catalogService.suspendTopology(result);
-                return WSUtils.respond(result, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+                                           @PathParam("versionId") Long versionId) throws Exception {
+        Topology result = catalogService.getTopology(topologyId, versionId);
+        if (result != null) {
+            catalogService.suspendTopology(result);
+            return WSUtils.respondEntity(result, OK);
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_VERSION_NOT_FOUND, topologyId.toString(), versionId.toString());
+
+        throw EntityNotFoundException.byVersion(topologyId.toString(), versionId.toString());
     }
 
     @POST
     @Path("/topologies/{topologyId}/actions/resume")
     @Timed
-    public Response resumeTopology (@PathParam("topologyId") Long topologyId) {
-        try {
-            Topology result = catalogService.getTopology(topologyId);
-            if (result != null) {
-                catalogService.resumeTopology(result);
-                return WSUtils.respond(result, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+    public Response resumeTopology (@PathParam("topologyId") Long topologyId) throws Exception {
+        Topology result = catalogService.getTopology(topologyId);
+        if (result != null) {
+            catalogService.resumeTopology(result);
+            return WSUtils.respondEntity(result, OK);
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, topologyId.toString());
+
+        throw EntityNotFoundException.byId(topologyId.toString());
     }
 
     @POST
     @Path("/topologies/{topologyId}/versions/{versionId}/actions/resume")
     @Timed
     public Response resumeTopologyVersion(@PathParam("topologyId") Long topologyId,
-                                          @PathParam("versionId") Long versionId) {
-        try {
-            Topology result = catalogService.getTopology(topologyId, versionId);
-            if (result != null) {
-                catalogService.resumeTopology(result);
-                return WSUtils.respond(result, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+                                          @PathParam("versionId") Long versionId) throws Exception {
+        Topology result = catalogService.getTopology(topologyId, versionId);
+        if (result != null) {
+            catalogService.resumeTopology(result);
+            return WSUtils.respondEntity(result, OK);
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_VERSION_NOT_FOUND, topologyId.toString(), versionId.toString());
+
+        throw EntityNotFoundException.byVersion(topologyId.toString(), versionId.toString());
     }
 
     private List<TopologyCatalogWithMetric> enrichMetricToTopologies(
-        Collection<Topology> topologies, String sortType, Integer latencyTopN) {
+            Collection<Topology> topologies, String sortType, Integer latencyTopN) {
         // need to also provide Topology Metric
         List<TopologyCatalogWithMetric> topologiesWithMetric = new ArrayList<>(topologies.size());
         for (Topology topology : topologies) {
@@ -551,14 +467,14 @@ public class TopologyCatalogResource {
         if (sortType != null) {
             return topologiesWithMetric.stream().sorted((c1, c2) -> {
                 switch (TopologySortType.valueOf(sortType.toUpperCase())) {
-                case NAME:
-                    return c1.getTopology().getName().compareTo(c2.getTopology().getName());
-                case STATUS:
-                    return c1.getRunning().compareTo(c2.getRunning());
-                case LAST_UPDATED:
-                    return c1.getTopology().getVersionTimestamp().compareTo(c2.getTopology().getVersionTimestamp());
-                default:
-                    throw new IllegalStateException("Not supported SortType: " + sortType);
+                    case NAME:
+                        return c1.getTopology().getName().compareTo(c2.getTopology().getName());
+                    case STATUS:
+                        return c1.getRunning().compareTo(c2.getRunning());
+                    case LAST_UPDATED:
+                        return c1.getTopology().getVersionTimestamp().compareTo(c2.getTopology().getVersionTimestamp());
+                    default:
+                        throw new IllegalStateException("Not supported SortType: " + sortType);
                 }
             }).collect(toList());
         } else {
@@ -598,7 +514,7 @@ public class TopologyCatalogResource {
         private final List<Pair<String, Double>> latencyTopN;
 
         public TopologyCatalogWithMetric(Topology topology, TopologyRunningStatus running,
-            TopologyMetrics.TopologyMetric metric, List<Pair<String, Double>> latencyTopN) {
+                                         TopologyMetrics.TopologyMetric metric, List<Pair<String, Double>> latencyTopN) {
             this.topology = topology;
             this.running = running;
             this.metric = metric;
@@ -622,4 +538,3 @@ public class TopologyCatalogResource {
         }
     }
 }
-

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/UDFCatalogResource.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/UDFCatalogResource.java
@@ -7,7 +7,6 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import org.apache.streamline.common.QueryParam;
 import org.apache.streamline.common.Schema;
-import org.apache.streamline.common.catalog.CatalogResponse;
 import org.apache.streamline.common.exception.ParserException;
 import org.apache.streamline.common.util.FileStorage;
 import org.apache.streamline.common.util.FileUtil;
@@ -16,13 +15,14 @@ import org.apache.streamline.common.util.WSUtils;
 import org.apache.streamline.streams.catalog.UDFInfo;
 import org.apache.streamline.streams.catalog.service.StreamCatalogService;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.streamline.streams.service.exception.request.EntityNotFoundException;
+import org.apache.streamline.streams.service.exception.request.UnsupportedMediaTypeException;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -30,7 +30,6 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.ProcessingException;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
@@ -55,16 +54,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND_FOR_FILTER;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.EXCEPTION;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.SUCCESS;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CREATED;
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
-import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
 
 @Path("/v1/catalog/streams")
 @Produces(MediaType.APPLICATION_JSON)
@@ -110,23 +101,19 @@ public class UDFCatalogResource {
     @Timed
     public Response listUDFs(@Context UriInfo uriInfo) {
         List<QueryParam> queryParams = new ArrayList<>();
-        try {
-            MultivaluedMap<String, String> params = uriInfo.getQueryParameters();
-            Collection<UDFInfo> udfs;
-            if (params.isEmpty()) {
-                udfs = catalogService.listUDFs();
-            } else {
-                queryParams = WSUtils.buildQueryParameters(params);
-                udfs = catalogService.listUDFs(queryParams);
-            }
-            if (udfs != null) {
-                return WSUtils.respond(udfs, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        MultivaluedMap<String, String> params = uriInfo.getQueryParameters();
+        Collection<UDFInfo> udfs;
+        if (params.isEmpty()) {
+            udfs = catalogService.listUDFs();
+        } else {
+            queryParams = WSUtils.buildQueryParameters(params);
+            udfs = catalogService.listUDFs(queryParams);
+        }
+        if (udfs != null) {
+            return WSUtils.respondEntities(udfs, OK);
         }
 
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND_FOR_FILTER, queryParams.toString());
+        throw EntityNotFoundException.byFilter(queryParams.toString());
     }
 
     /**
@@ -153,15 +140,12 @@ public class UDFCatalogResource {
     @Path("/udfs/{id}")
     @Timed
     public Response getUDFById(@PathParam("id") Long id) {
-        try {
-            UDFInfo result = catalogService.getUDF(id);
-            if (result != null) {
-                return WSUtils.respond(result, OK, SUCCESS);
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        UDFInfo result = catalogService.getUDF(id);
+        if (result != null) {
+            return WSUtils.respondEntity(result, OK);
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, id.toString());
+
+        throw EntityNotFoundException.byId(id.toString());
     }
 
     /**
@@ -178,21 +162,16 @@ public class UDFCatalogResource {
     public Response addUDF(@FormDataParam("udfJarFile") final InputStream inputStream,
                            @FormDataParam("udfJarFile") final FormDataContentDisposition contentDispositionHeader,
                            @FormDataParam("udfConfig") final FormDataBodyPart udfConfig,
-                           @FormDataParam("builtin") final boolean builtin) {
-        try {
-            LOG.debug("Media type {}", udfConfig.getMediaType());
-            if (!udfConfig.getMediaType().equals(MediaType.APPLICATION_JSON_TYPE)) {
-                return WSUtils.respond(UNSUPPORTED_MEDIA_TYPE, CatalogResponse.ResponseMessage.UNSUPPORTED_MEDIA_TYPE);
-            }
-            UDFInfo udfInfo = udfConfig.getValueAs(UDFInfo.class);
-            processUdf(inputStream, udfInfo, true, builtin);
-            UDFInfo createdUdfInfo = catalogService.addUDF(udfInfo);
-            return WSUtils.respond(createdUdfInfo, CREATED, SUCCESS);
-        } catch (ProcessingException ex) {
-            return WSUtils.respond(BAD_REQUEST, CatalogResponse.ResponseMessage.BAD_REQUEST);
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+                           @FormDataParam("builtin") final boolean builtin) throws Exception {
+        MediaType mediaType = udfConfig.getMediaType();
+        LOG.debug("Media type {}", mediaType);
+        if (!mediaType.equals(MediaType.APPLICATION_JSON_TYPE)) {
+            throw new UnsupportedMediaTypeException(mediaType.toString());
         }
+        UDFInfo udfInfo = udfConfig.getValueAs(UDFInfo.class);
+        processUdf(inputStream, udfInfo, true, builtin);
+        UDFInfo createdUdfInfo = catalogService.addUDF(udfInfo);
+        return WSUtils.respondEntity(createdUdfInfo, CREATED);
     }
 
     /**
@@ -219,16 +198,12 @@ public class UDFCatalogResource {
     @Path("/udfs/{id}")
     @Timed
     public Response removeUDF(@PathParam("id") Long id) {
-        try {
-            UDFInfo removedUDF = catalogService.removeUDF(id);
-            if (removedUDF != null) {
-                return WSUtils.respond(removedUDF, OK, SUCCESS);
-            } else {
-                return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, id.toString());
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        UDFInfo removedUDF = catalogService.removeUDF(id);
+        if (removedUDF != null) {
+            return WSUtils.respondEntity(removedUDF, OK);
         }
+
+        throw EntityNotFoundException.byId(id.toString());
     }
 
     /**
@@ -261,21 +236,17 @@ public class UDFCatalogResource {
                                    @FormDataParam("udfJarFile") final InputStream inputStream,
                                    @FormDataParam("udfJarFile") final FormDataContentDisposition contentDispositionHeader,
                                    @FormDataParam("udfConfig") final FormDataBodyPart udfConfig,
-                                   @FormDataParam("builtin") final boolean builtin) {
-        try {
-            LOG.debug("Media type {}", udfConfig.getMediaType());
-            if (!udfConfig.getMediaType().equals(MediaType.APPLICATION_JSON_TYPE)) {
-                return WSUtils.respond(UNSUPPORTED_MEDIA_TYPE, CatalogResponse.ResponseMessage.UNSUPPORTED_MEDIA_TYPE);
-            }
-            UDFInfo udfInfo = udfConfig.getValueAs(UDFInfo.class);
-            processUdf(inputStream, udfInfo, false, builtin);
-            UDFInfo newUdfInfo = catalogService.addOrUpdateUDF(udfId, udfInfo);
-            return WSUtils.respond(newUdfInfo, OK, SUCCESS);
-        } catch (ProcessingException ex) {
-            return WSUtils.respond(BAD_REQUEST, CatalogResponse.ResponseMessage.BAD_REQUEST);
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+                                   @FormDataParam("builtin") final boolean builtin)
+        throws Exception {
+        MediaType mediaType = udfConfig.getMediaType();
+        LOG.debug("Media type {}", mediaType);
+        if (!mediaType.equals(MediaType.APPLICATION_JSON_TYPE)) {
+            throw new UnsupportedMediaTypeException(mediaType.toString());
         }
+        UDFInfo udfInfo = udfConfig.getValueAs(UDFInfo.class);
+        processUdf(inputStream, udfInfo, false, builtin);
+        UDFInfo newUdfInfo = catalogService.addOrUpdateUDF(udfId, udfInfo);
+        return WSUtils.respondEntity(newUdfInfo, CREATED);
     }
 
     /**
@@ -288,18 +259,15 @@ public class UDFCatalogResource {
     @GET
     @Produces({"application/java-archive", "application/json"})
     @Path("/udfs/download/{udfId}")
-    public Response downloadUdf(@PathParam("udfId") Long udfId) {
-        try {
-            UDFInfo udfInfo = catalogService.getUDF(udfId);
-            if (udfInfo != null) {
-                StreamingOutput streamOutput = WSUtils.wrapWithStreamingOutput(
-                        catalogService.downloadFileFromStorage(udfInfo.getJarStoragePath()));
-                return Response.ok(streamOutput).build();
-            }
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+    public Response downloadUdf(@PathParam("udfId") Long udfId) throws IOException {
+        UDFInfo udfInfo = catalogService.getUDF(udfId);
+        if (udfInfo != null) {
+            StreamingOutput streamOutput = WSUtils.wrapWithStreamingOutput(
+                    catalogService.downloadFileFromStorage(udfInfo.getJarStoragePath()));
+            return Response.ok(streamOutput).build();
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, udfId.toString());
+
+        throw EntityNotFoundException.byId(udfId.toString());
     }
 
     private void processUdf(InputStream inputStream,

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/exception/StreamServiceException.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/exception/StreamServiceException.java
@@ -1,0 +1,47 @@
+package org.apache.streamline.streams.service.exception;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+public abstract class StreamServiceException extends RuntimeException {
+  protected Response response;
+
+  protected StreamServiceException(Response.Status status, String msg) {
+    super(msg);
+    response = Response.status(status)
+        .entity(convertToErrorResponseMessage(msg))
+        .type(MediaType.APPLICATION_JSON_TYPE)
+        .build();
+  }
+
+  protected StreamServiceException(Response.Status status, String msg, Throwable cause) {
+    super(msg, cause);
+    response = Response.status(status)
+        .entity(convertToErrorResponseMessage(msg))
+        .type(MediaType.APPLICATION_JSON_TYPE)
+        .build();
+  }
+
+  public Response getResponse() {
+    return response;
+  }
+
+  private static ErrorResponse convertToErrorResponseMessage(String msg) {
+    return new ErrorResponse(msg);
+  }
+
+  private static class ErrorResponse {
+    /**
+     * Response message.
+     */
+    private String responseMessage;
+
+    public ErrorResponse(String responseMessage) {
+      this.responseMessage = responseMessage;
+    }
+
+    public String getResponseMessage() {
+      return responseMessage;
+    }
+  }
+}

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/exception/request/BadRequestException.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/exception/request/BadRequestException.java
@@ -1,0 +1,38 @@
+package org.apache.streamline.streams.service.exception.request;
+
+import org.apache.streamline.streams.service.exception.StreamServiceException;
+
+import javax.ws.rs.core.Response;
+
+public class BadRequestException extends StreamServiceException {
+  private static final String DEFAULT_MESSAGE = "Bad request.";
+  private static final String PARAMETER_MISSING_MESSAGE = "Bad request. Param [%s] is missing or empty.";
+
+  private BadRequestException(String message) {
+    super(Response.Status.BAD_REQUEST, message);
+  }
+
+  private BadRequestException(String message, Throwable cause) {
+    super(Response.Status.BAD_REQUEST, message, cause);
+  }
+
+  public static BadRequestException of() {
+    return new BadRequestException(DEFAULT_MESSAGE);
+  }
+
+  public static BadRequestException of(Throwable cause) {
+    return new BadRequestException(DEFAULT_MESSAGE, cause);
+  }
+
+  public static BadRequestException missingParameter(String parameterName) {
+    return new BadRequestException(buildParameterMissingMessage(parameterName));
+  }
+
+  public static BadRequestException missingParameter(String parameterName, Throwable cause) {
+    return new BadRequestException(buildParameterMissingMessage(parameterName), cause);
+  }
+
+  private static String buildParameterMissingMessage(String parameterName) {
+    return String.format(PARAMETER_MISSING_MESSAGE, parameterName);
+  }
+}

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/exception/request/ClusterImportAlreadyInProgressException.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/exception/request/ClusterImportAlreadyInProgressException.java
@@ -1,0 +1,17 @@
+package org.apache.streamline.streams.service.exception.request;
+
+import org.apache.streamline.streams.service.exception.StreamServiceException;
+
+import javax.ws.rs.core.Response;
+
+public class ClusterImportAlreadyInProgressException extends StreamServiceException {
+  private static final String MESSAGE = "Cluster [%s] is already in progress of import.";
+
+  public ClusterImportAlreadyInProgressException(String id) {
+    super(Response.Status.CONFLICT, String.format(MESSAGE, id));
+  }
+
+  public ClusterImportAlreadyInProgressException(String id, Throwable cause) {
+    super(Response.Status.CONFLICT, String.format(MESSAGE, id), cause);
+  }
+}

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/exception/request/CustomProcessorOnlyException.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/exception/request/CustomProcessorOnlyException.java
@@ -1,0 +1,17 @@
+package org.apache.streamline.streams.service.exception.request;
+
+import org.apache.streamline.streams.service.exception.StreamServiceException;
+
+import javax.ws.rs.core.Response;
+
+public class CustomProcessorOnlyException extends StreamServiceException {
+  private static final String MESSAGE = "Custom endpoint supported only for processors.";
+
+  public CustomProcessorOnlyException() {
+    super(Response.Status.BAD_REQUEST, MESSAGE);
+  }
+
+  public CustomProcessorOnlyException(Throwable cause) {
+    super(Response.Status.BAD_REQUEST, MESSAGE, cause);
+  }
+}

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/exception/request/EntityAlreadyExistsException.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/exception/request/EntityAlreadyExistsException.java
@@ -1,0 +1,42 @@
+package org.apache.streamline.streams.service.exception.request;
+
+import org.apache.streamline.streams.service.exception.StreamServiceException;
+
+import javax.ws.rs.core.Response;
+
+public class EntityAlreadyExistsException extends StreamServiceException {
+  private static final String BY_ID_MESSAGE = "Entity with id [%s] already exists.";
+  private static final String BY_NAME_MESSAGE = "Entity with name [%s] already exists.";
+
+  private EntityAlreadyExistsException(String message) {
+    super(Response.Status.CONFLICT, message);
+  }
+
+  private EntityAlreadyExistsException(String message, Throwable cause) {
+    super(Response.Status.CONFLICT, message, cause);
+  }
+
+  public static EntityAlreadyExistsException byId(String id) {
+    return new EntityAlreadyExistsException(buildMessageByID(id));
+  }
+
+  public static EntityAlreadyExistsException byId(String id, Throwable cause) {
+    return new EntityAlreadyExistsException(buildMessageByID(id), cause);
+  }
+
+  public static EntityAlreadyExistsException byName(String name) {
+    return new EntityAlreadyExistsException(buildMessageByName(name));
+  }
+
+  public static EntityAlreadyExistsException byName(String name, Throwable cause) {
+    return new EntityAlreadyExistsException(buildMessageByName(name), cause);
+  }
+
+  private static String buildMessageByID(String id) {
+    return String.format(BY_ID_MESSAGE, id);
+  }
+
+  private static String buildMessageByName(String name) {
+    return String.format(BY_NAME_MESSAGE, name);
+  }
+}

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/exception/request/EntityNotFoundException.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/exception/request/EntityNotFoundException.java
@@ -1,0 +1,68 @@
+package org.apache.streamline.streams.service.exception.request;
+
+import org.apache.streamline.streams.service.exception.StreamServiceException;
+
+import javax.ws.rs.core.Response;
+
+public class EntityNotFoundException extends StreamServiceException {
+  private static final String BY_ID_MESSAGE = "Entity with id [%s] not found.";
+  private static final String BY_NAME_MESSAGE = "Entity with name [%s] not found.";
+  private static final String BY_FILTER_MESSAGE = "Entity not found for query params [%s].";
+  private static final String BY_VERSION_MESSAGE = "Entity with id [%s] and version [%s] not found.";
+
+  private EntityNotFoundException(String message) {
+    super(Response.Status.NOT_FOUND, message);
+  }
+
+  private EntityNotFoundException(String message, Throwable cause) {
+    super(Response.Status.NOT_FOUND, message, cause);
+  }
+
+  public static EntityNotFoundException byId(String id) {
+    return new EntityNotFoundException(buildMessageByID(id));
+  }
+
+  public static EntityNotFoundException byId(String id, Throwable cause) {
+    return new EntityNotFoundException(buildMessageByID(id), cause);
+  }
+
+  public static EntityNotFoundException byName(String name) {
+    return new EntityNotFoundException(buildMessageByName(name));
+  }
+
+  public static EntityNotFoundException byName(String name, Throwable cause) {
+    return new EntityNotFoundException(buildMessageByName(name), cause);
+  }
+
+  public static EntityNotFoundException byFilter(String parameter) {
+    return new EntityNotFoundException(buildMessageByFilter(parameter));
+  }
+
+  public static EntityNotFoundException byFilter(String parameter, Throwable cause) {
+    return new EntityNotFoundException(buildMessageByFilter(parameter), cause);
+  }
+
+  public static EntityNotFoundException byVersion(String id, String version) {
+    return new EntityNotFoundException(buildMessageByVersion(id, version));
+  }
+
+  public static EntityNotFoundException byVersion(String id, String version, Throwable cause) {
+    return new EntityNotFoundException(buildMessageByVersion(id, version), cause);
+  }
+
+  private static String buildMessageByID(String id) {
+    return String.format(BY_ID_MESSAGE, id);
+  }
+
+  private static String buildMessageByName(String name) {
+    return String.format(BY_NAME_MESSAGE, name);
+  }
+
+  private static String buildMessageByFilter(String parameter) {
+    return String.format(BY_FILTER_MESSAGE, parameter);
+  }
+
+  private static String buildMessageByVersion(String id, String version) {
+    return String.format(BY_VERSION_MESSAGE, id, version);
+  }
+}

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/exception/request/ParserSchemaForEntityNotFoundException.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/exception/request/ParserSchemaForEntityNotFoundException.java
@@ -1,0 +1,17 @@
+package org.apache.streamline.streams.service.exception.request;
+
+import org.apache.streamline.streams.service.exception.StreamServiceException;
+
+import javax.ws.rs.core.Response;
+
+public class ParserSchemaForEntityNotFoundException extends StreamServiceException {
+  private static final String MESSAGE = "Parser schema not found for entity with id [%s].";
+
+  public ParserSchemaForEntityNotFoundException(String id) {
+    super(Response.Status.NOT_FOUND, String.format(MESSAGE, id));
+  }
+
+  public ParserSchemaForEntityNotFoundException(String id, Throwable cause) {
+    super(Response.Status.NOT_FOUND, String.format(MESSAGE, id), cause);
+  }
+}

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/exception/request/UnsupportedMediaTypeException.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/exception/request/UnsupportedMediaTypeException.java
@@ -1,0 +1,17 @@
+package org.apache.streamline.streams.service.exception.request;
+
+import org.apache.streamline.streams.service.exception.StreamServiceException;
+
+import javax.ws.rs.core.Response;
+
+public class UnsupportedMediaTypeException extends StreamServiceException {
+  private static final String MESSAGE = "Unsupported Media Type [%s]";
+
+  public UnsupportedMediaTypeException(String mediaType) {
+    super(Response.Status.UNSUPPORTED_MEDIA_TYPE, String.format(MESSAGE, mediaType));
+  }
+
+  public UnsupportedMediaTypeException(String mediaType, Throwable cause) {
+    super(Response.Status.UNSUPPORTED_MEDIA_TYPE, String.format(MESSAGE, mediaType));
+  }
+}

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/exception/server/UnhandledServerException.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/exception/server/UnhandledServerException.java
@@ -1,0 +1,17 @@
+package org.apache.streamline.streams.service.exception.server;
+
+import org.apache.streamline.streams.service.exception.StreamServiceException;
+
+import javax.ws.rs.core.Response;
+
+public class UnhandledServerException extends StreamServiceException {
+  private static final String MESSAGE = "An exception with message [%s] was thrown while processing request.";
+
+  public UnhandledServerException(String exceptionMessage) {
+    super(Response.Status.INTERNAL_SERVER_ERROR, String.format(MESSAGE, exceptionMessage));
+  }
+
+  public UnhandledServerException(String exceptionMessage, Throwable cause) {
+    super(Response.Status.INTERNAL_SERVER_ERROR, String.format(MESSAGE, exceptionMessage), cause);
+  }
+}

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/metadata/HBaseMetadataResource.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/metadata/HBaseMetadataResource.java
@@ -1,7 +1,6 @@
 package org.apache.streamline.streams.service.metadata;
 
 import com.codahale.metrics.annotation.Timed;
-
 import org.apache.streamline.common.util.WSUtils;
 import org.apache.streamline.streams.catalog.Cluster;
 import org.apache.streamline.streams.catalog.exception.EntityNotFoundException;
@@ -17,13 +16,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_BY_NAME_NOT_FOUND;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.EXCEPTION;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.SUCCESS;
 
 @Path("/v1/catalog")
 @Produces(MediaType.APPLICATION_JSON)
@@ -38,10 +31,11 @@ public class HBaseMetadataResource {
     @GET
     @Path("/clusters/name/{clusterName}/services/hbase/namespaces")
     @Timed
-    public Response getNamespacesByClusterName(@PathParam("clusterName") String clusterName) {
+    public Response getNamespacesByClusterName(@PathParam("clusterName") String clusterName)
+        throws Exception {
         final Cluster cluster = catalogService.getClusterByName(clusterName);
         if (cluster == null) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_BY_NAME_NOT_FOUND, "cluster name " + clusterName);
+            throw org.apache.streamline.streams.service.exception.request.EntityNotFoundException.byName("cluster name " + clusterName);
         }
         return getNamespacesByClusterId(cluster.getId());
     }
@@ -49,13 +43,12 @@ public class HBaseMetadataResource {
     @GET
     @Path("/clusters/{clusterId}/services/hbase/namespaces")
     @Timed
-    public Response getNamespacesByClusterId(@PathParam("clusterId") Long clusterId) {
+    public Response getNamespacesByClusterId(@PathParam("clusterId") Long clusterId)
+        throws Exception {
         try (HBaseMetadataService hbaseMetadataService = HBaseMetadataService.newInstance(catalogService, clusterId)) {
-            return WSUtils.respond(hbaseMetadataService.getHBaseNamespaces(), OK, SUCCESS);
+            return WSUtils.respondEntity(hbaseMetadataService.getHBaseNamespaces(), OK);
         } catch (EntityNotFoundException ex) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, ex.getMessage());
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+            throw org.apache.streamline.streams.service.exception.request.EntityNotFoundException.byId(ex.getMessage());
         }
     }
 
@@ -64,10 +57,11 @@ public class HBaseMetadataResource {
     @GET
     @Path("/clusters/name/{clusterName}/services/hbase/tables")
     @Timed
-    public Response getTablesByClusterName(@PathParam("clusterName") String clusterName) {
+    public Response getTablesByClusterName(@PathParam("clusterName") String clusterName)
+        throws Exception {
         final Cluster cluster = catalogService.getClusterByName(clusterName);
         if (cluster == null) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_BY_NAME_NOT_FOUND, "cluster name " + clusterName);
+            throw org.apache.streamline.streams.service.exception.request.EntityNotFoundException.byName(clusterName);
         }
         return getTablesByClusterId(cluster.getId());
     }
@@ -75,13 +69,11 @@ public class HBaseMetadataResource {
     @GET
     @Path("/clusters/{clusterId}/services/hbase/tables")
     @Timed
-    public Response getTablesByClusterId(@PathParam("clusterId") Long clusterId) {
+    public Response getTablesByClusterId(@PathParam("clusterId") Long clusterId) throws Exception {
         try (HBaseMetadataService hbaseMetadataService = HBaseMetadataService.newInstance(catalogService, clusterId)) {
-            return WSUtils.respond(hbaseMetadataService.getHBaseTables(), OK, SUCCESS);
+            return WSUtils.respondEntity(hbaseMetadataService.getHBaseTables(), OK);
         } catch (EntityNotFoundException ex) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, ex.getMessage());
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+            throw org.apache.streamline.streams.service.exception.request.EntityNotFoundException.byId(ex.getMessage());
         }
     }
 
@@ -90,10 +82,11 @@ public class HBaseMetadataResource {
     @GET
     @Path("/clusters/name/{clusterName}/services/hbase/namespaces/{namespace}/tables")
     @Timed
-    public Response getNamespaceTablesByClusterName(@PathParam("clusterName") String clusterName, @PathParam("namespace") String namespace) {
+    public Response getNamespaceTablesByClusterName(@PathParam("clusterName") String clusterName, @PathParam("namespace") String namespace)
+        throws Exception {
         final Cluster cluster = catalogService.getClusterByName(clusterName);
         if (cluster == null) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_BY_NAME_NOT_FOUND, "cluster name " + clusterName);
+            throw org.apache.streamline.streams.service.exception.request.EntityNotFoundException.byName(clusterName);
         }
         return getNamespaceTablesByClusterId(cluster.getId(), namespace);
     }
@@ -101,13 +94,12 @@ public class HBaseMetadataResource {
     @GET
     @Path("/clusters/{clusterId}/services/hbase/namespaces/{namespace}/tables")
     @Timed
-    public Response getNamespaceTablesByClusterId(@PathParam("clusterId") Long clusterId, @PathParam("namespace") String namespace) {
+    public Response getNamespaceTablesByClusterId(@PathParam("clusterId") Long clusterId, @PathParam("namespace") String namespace)
+        throws Exception {
         try (HBaseMetadataService hbaseMetadataService = HBaseMetadataService.newInstance(catalogService, clusterId)) {
-            return WSUtils.respond(hbaseMetadataService.getHBaseTables(namespace), OK, SUCCESS);
+            return WSUtils.respondEntity(hbaseMetadataService.getHBaseTables(namespace), OK);
         } catch (EntityNotFoundException ex) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, ex.getMessage());
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+            throw org.apache.streamline.streams.service.exception.request.EntityNotFoundException.byId(ex.getMessage());
         }
     }
 

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/metadata/HiveMetadataResource.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/metadata/HiveMetadataResource.java
@@ -15,12 +15,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_BY_NAME_NOT_FOUND;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.EXCEPTION;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.SUCCESS;
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 
 @Path("/v1/catalog")
@@ -35,10 +29,11 @@ public class HiveMetadataResource {
     @GET
     @Path("/clusters/name/{clusterName}/services/hive/databases")
     @Timed
-    public Response getDatabasesByClusterName(@PathParam("clusterName") String clusterName) {
+    public Response getDatabasesByClusterName(@PathParam("clusterName") String clusterName)
+        throws Exception {
         final Cluster cluster = catalogService.getClusterByName(clusterName);
         if (cluster == null) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_BY_NAME_NOT_FOUND, "cluster name " + clusterName);
+            throw org.apache.streamline.streams.service.exception.request.EntityNotFoundException.byName("cluster name " + clusterName);
         }
         return getDatabasesByClusterId(cluster.getId());
     }
@@ -46,23 +41,23 @@ public class HiveMetadataResource {
     @GET
     @Path("/clusters/{clusterId}/services/hive/databases")
     @Timed
-    public Response getDatabasesByClusterId(@PathParam("clusterId") Long clusterId) {
+    public Response getDatabasesByClusterId(@PathParam("clusterId") Long clusterId)
+        throws Exception {
         try(final HiveMetadataService hiveMetadataService = HiveMetadataService.newInstance(catalogService, clusterId)) {
-            return WSUtils.respond(hiveMetadataService.getHiveDatabases(), OK, SUCCESS);
+            return WSUtils.respondEntity(hiveMetadataService.getHiveDatabases(), OK);
         } catch (EntityNotFoundException ex) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, ex.getMessage());
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+            throw org.apache.streamline.streams.service.exception.request.EntityNotFoundException.byId(ex.getMessage());
         }
     }
 
     @GET
     @Path("/clusters/name/{clusterName}/services/hive/databases/{dbName}/tables")
     @Timed
-    public Response getDatabaseTablesByClusterName(@PathParam("clusterName") String clusterName, @PathParam("dbName") String dbName) {
+    public Response getDatabaseTablesByClusterName(@PathParam("clusterName") String clusterName, @PathParam("dbName") String dbName)
+        throws Exception {
         final Cluster cluster = catalogService.getClusterByName(clusterName);
         if (cluster == null) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_BY_NAME_NOT_FOUND, "cluster name " + clusterName);
+            throw org.apache.streamline.streams.service.exception.request.EntityNotFoundException.byName("cluster name " + clusterName);
         }
         return getDatabaseTablesByClusterId(cluster.getId(), dbName);
     }
@@ -70,13 +65,12 @@ public class HiveMetadataResource {
     @GET
     @Path("/clusters/{clusterId}/services/hive/databases/{dbName}/tables")
     @Timed
-    public Response getDatabaseTablesByClusterId(@PathParam("clusterId") Long clusterId, @PathParam("dbName") String dbName) {
+    public Response getDatabaseTablesByClusterId(@PathParam("clusterId") Long clusterId, @PathParam("dbName") String dbName)
+        throws Exception {
         try(final HiveMetadataService hiveMetadataService = HiveMetadataService.newInstance(catalogService, clusterId)) {
-            return WSUtils.respond(hiveMetadataService.getHiveTables(dbName), OK, SUCCESS);
+            return WSUtils.respondEntity(hiveMetadataService.getHiveTables(dbName), OK);
         } catch (EntityNotFoundException ex) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, ex.getMessage());
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+            throw org.apache.streamline.streams.service.exception.request.EntityNotFoundException.byId(ex.getMessage());
         }
     }
 }

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/metadata/KafkaMetadataResource.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/metadata/KafkaMetadataResource.java
@@ -17,12 +17,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_BY_NAME_NOT_FOUND;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.EXCEPTION;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.SUCCESS;
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 
 @Path("/v1/catalog")
@@ -38,10 +32,11 @@ public class KafkaMetadataResource {
     @GET
     @Path("/clusters/name/{clusterName}/services/kafka/brokers")
     @Timed
-    public Response getBrokersByClusterName(@PathParam("clusterName") String clusterName) {
+    public Response getBrokersByClusterName(@PathParam("clusterName") String clusterName)
+        throws Exception {
         final Cluster cluster = catalogService.getClusterByName(clusterName);
         if (cluster == null) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_BY_NAME_NOT_FOUND, "cluster name " + clusterName);
+            throw org.apache.streamline.streams.service.exception.request.EntityNotFoundException.byName("cluster name " + clusterName);
         }
         return getBrokersByClusterId(cluster.getId());
     }
@@ -49,23 +44,22 @@ public class KafkaMetadataResource {
     @GET
     @Path("/clusters/{clusterId}/services/kafka/brokers")
     @Timed
-    public Response getBrokersByClusterId(@PathParam("clusterId") Long clusterId) {
+    public Response getBrokersByClusterId(@PathParam("clusterId") Long clusterId) throws Exception {
         try(final KafkaMetadataService kafkaMetadataService = KafkaMetadataService.newInstance(catalogService, clusterId)) {
-            return WSUtils.respond(kafkaMetadataService.getBrokerHostPortFromStreamsJson(clusterId), OK, SUCCESS);
+            return WSUtils.respondEntity(kafkaMetadataService.getBrokerHostPortFromStreamsJson(clusterId), OK);
         } catch (EntityNotFoundException ex) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, ex.getMessage());
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+            throw org.apache.streamline.streams.service.exception.request.EntityNotFoundException.byId(ex.getMessage());
         }
     }
 
     @GET
     @Path("/clusters/name/{clusterName}/services/kafka/topics")
     @Timed
-    public Response getTopicsByClusterName(@PathParam("clusterName") String clusterName) {
+    public Response getTopicsByClusterName(@PathParam("clusterName") String clusterName)
+        throws Exception {
         final Cluster cluster = catalogService.getClusterByName(clusterName);
         if (cluster == null) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_BY_NAME_NOT_FOUND, "cluster name " + clusterName);
+            throw org.apache.streamline.streams.service.exception.request.EntityNotFoundException.byName("cluster name " + clusterName);
         }
         return getTopicsByClusterId(cluster.getId());
     }
@@ -73,13 +67,11 @@ public class KafkaMetadataResource {
     @GET
     @Path("/clusters/{clusterId}/services/kafka/topics")
     @Timed
-    public Response getTopicsByClusterId(@PathParam("clusterId") Long clusterId) {
+    public Response getTopicsByClusterId(@PathParam("clusterId") Long clusterId) throws Exception {
         try(final KafkaMetadataService kafkaMetadataService = KafkaMetadataService.newInstance(catalogService, clusterId)) {
-            return WSUtils.respond(kafkaMetadataService.getTopicsFromZk(), OK, SUCCESS);
+            return WSUtils.respondEntity(kafkaMetadataService.getTopicsFromZk(), OK);
         } catch (EntityNotFoundException ex) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, ex.getMessage());
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+            throw org.apache.streamline.streams.service.exception.request.EntityNotFoundException.byId(ex.getMessage());
         }
     }
 }

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/metadata/StormMetadataResource.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/metadata/StormMetadataResource.java
@@ -3,14 +3,9 @@ package org.apache.streamline.streams.service.metadata;
 import com.codahale.metrics.annotation.Timed;
 import org.apache.streamline.common.util.WSUtils;
 import org.apache.streamline.streams.catalog.Cluster;
-import org.apache.streamline.streams.catalog.Service;
-import org.apache.streamline.streams.catalog.exception.ServiceNotFoundException;
-import org.apache.streamline.streams.catalog.service.StreamCatalogService;
-
 import org.apache.streamline.streams.catalog.exception.EntityNotFoundException;
+import org.apache.streamline.streams.catalog.service.StreamCatalogService;
 import org.apache.streamline.streams.catalog.service.metadata.StormMetadataService;
-import org.apache.streamline.streams.cluster.discovery.ambari.ComponentPropertyPattern;
-import org.apache.streamline.streams.cluster.discovery.ambari.ServiceConfigurations;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -19,12 +14,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_BY_NAME_NOT_FOUND;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.ENTITY_NOT_FOUND;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.EXCEPTION;
-import static org.apache.streamline.common.catalog.CatalogResponse.ResponseMessage.SUCCESS;
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 
 @Path("/v1/catalog")
@@ -42,7 +31,7 @@ public class StormMetadataResource {
     public Response getTopologiesByClusterName(@PathParam("clusterName") String clusterName) {
         final Cluster cluster = catalogService.getClusterByName(clusterName);
         if (cluster == null) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_BY_NAME_NOT_FOUND, "cluster name " + clusterName);
+            throw org.apache.streamline.streams.service.exception.request.EntityNotFoundException.byName("cluster name " + clusterName);
         }
         return getTopologiesByClusterId(cluster.getId());
     }
@@ -53,11 +42,9 @@ public class StormMetadataResource {
     public Response getTopologiesByClusterId(@PathParam("clusterId") Long clusterId) {
         try {
             StormMetadataService stormMetadataService = new StormMetadataService.Builder(catalogService, clusterId).build();
-            return WSUtils.respond(stormMetadataService.getTopologies(), OK, SUCCESS);
+            return WSUtils.respondEntity(stormMetadataService.getTopologies(), OK);
         } catch (EntityNotFoundException ex) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, ex.getMessage());
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+            throw org.apache.streamline.streams.service.exception.request.EntityNotFoundException.byId(ex.getMessage());
         }
     }
 
@@ -67,11 +54,9 @@ public class StormMetadataResource {
     public Response getMainPageByClusterId(@PathParam("clusterId") Long clusterId) {
         try {
             StormMetadataService stormMetadataService = new StormMetadataService.Builder(catalogService, clusterId).build();
-            return WSUtils.respond(stormMetadataService.getMainPageUrl(), OK, SUCCESS);
+            return WSUtils.respondEntity(stormMetadataService.getMainPageUrl(), OK);
         } catch (EntityNotFoundException ex) {
-            return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, ex.getMessage());
-        } catch (Exception ex) {
-            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+            throw org.apache.streamline.streams.service.exception.request.EntityNotFoundException.byId(ex.getMessage());
         }
     }
 }

--- a/streams/service/src/test/java/org/apache/streamline/streams/service/NotificationsResourceTest.java
+++ b/streams/service/src/test/java/org/apache/streamline/streams/service/NotificationsResourceTest.java
@@ -16,13 +16,15 @@
  * limitations under the License.
  */
 
-package org.apache.streamline.streams.notification.service;
+package org.apache.streamline.streams.service;
 
-import org.apache.streamline.common.QueryParam;
 import mockit.Expectations;
 import mockit.Mocked;
 import mockit.Verifications;
 import mockit.integration.junit4.JMockit;
+import org.apache.streamline.common.QueryParam;
+import org.apache.streamline.streams.notification.service.NotificationService;
+import org.apache.streamline.streams.service.exception.request.EntityNotFoundException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,6 +35,7 @@ import javax.ws.rs.core.UriInfo;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 @RunWith(JMockit.class)
 public class NotificationsResourceTest {
@@ -68,15 +71,20 @@ public class NotificationsResourceTest {
             }
         };
 
-        resource.listNotifications(mockUriInfo);
+        try {
+            resource.listNotifications(mockUriInfo);
 
-        new Verifications() {
-            {
-                List<QueryParam> qps;
-                mockNotificationService.findNotifications(qps = withCapture());
-                //System.out.println(qps);
-                assertEquals(4, qps.size());
-            }
-        };
+            fail("We don't mock the result so it should throw entity not found");
+        } catch (EntityNotFoundException e) {
+            // expected
+            new Verifications() {
+                {
+                    List<QueryParam> qps;
+                    mockNotificationService.findNotifications(qps = withCapture());
+                    //System.out.println(qps);
+                    assertEquals(4, qps.size());
+                }
+            };
+        }
     }
 }

--- a/streams/service/src/test/java/org/apache/streamline/streams/service/NotifierInfoCatalogResourceTest.java
+++ b/streams/service/src/test/java/org/apache/streamline/streams/service/NotifierInfoCatalogResourceTest.java
@@ -1,5 +1,6 @@
 package org.apache.streamline.streams.service;
 
+import org.apache.streamline.common.CollectionResponse;
 import org.apache.streamline.common.QueryParam;
 import org.apache.streamline.common.catalog.CatalogResponse;
 import org.apache.streamline.common.util.FileStorage;
@@ -73,11 +74,10 @@ public class NotifierInfoCatalogResourceTest {
             }
         };
 
-        CatalogResponse catalogResponse = (CatalogResponse) resource.listNotifiers(mockUriInfo).getEntity();
+        CollectionResponse collectionResponse = (CollectionResponse) resource.listNotifiers(mockUriInfo).getEntity();
 
-        assertEquals(CatalogResponse.ResponseMessage.SUCCESS.getCode(), catalogResponse.getResponseCode());
-        assertEquals(1, catalogResponse.getEntities().size());
-        assertEquals(notifierInfo, catalogResponse.getEntities().iterator().next());
+        assertEquals(1, collectionResponse .getEntities().size());
+        assertEquals(notifierInfo, collectionResponse.getEntities().iterator().next());
     }
 
     @Test
@@ -90,10 +90,8 @@ public class NotifierInfoCatalogResourceTest {
             }
         };
 
-        CatalogResponse catalogResponse = (CatalogResponse) resource.getNotifierById(1L).getEntity();
-
-        assertEquals(CatalogResponse.ResponseMessage.SUCCESS.getCode(), catalogResponse.getResponseCode());
-        assertEquals(notifierInfo, catalogResponse.getEntity());
+        NotifierInfo result = (NotifierInfo) resource.getNotifierById(1L).getEntity();
+        assertEquals(notifierInfo, result);
     }
 
     @Test
@@ -114,13 +112,12 @@ public class NotifierInfoCatalogResourceTest {
             }
         };
 
-        CatalogResponse catalogResponse = (CatalogResponse) resource.addNotifier(
+        NotifierInfo result = (NotifierInfo) resource.addNotifier(
                 mockInputStream,
                 mockFormDataContentDisposition,
                 mockFormDataBodyPart).getEntity();
 
-        assertEquals(CatalogResponse.ResponseMessage.SUCCESS.getCode(), catalogResponse.getResponseCode());
-        assertEquals(notifierInfo, catalogResponse.getEntity());
+        assertEquals(notifierInfo, result);
     }
 
 }

--- a/webservice/src/main/java/org/apache/streamline/webservice/StreamlineApplication.java
+++ b/webservice/src/main/java/org/apache/streamline/webservice/StreamlineApplication.java
@@ -19,6 +19,7 @@
 package org.apache.streamline.webservice;
 
 import com.google.common.cache.CacheBuilder;
+import io.dropwizard.server.AbstractServerFactory;
 import org.apache.streamline.cache.Cache;
 import org.apache.streamline.common.Constants;
 import org.apache.streamline.common.ModuleRegistration;
@@ -39,6 +40,7 @@ import io.dropwizard.jetty.HttpConnectorFactory;
 import io.dropwizard.server.DefaultServerFactory;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import org.apache.streamline.streams.service.GenericExceptionMapper;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,6 +69,12 @@ public class StreamlineApplication extends Application<StreamlineConfiguration> 
 
     @Override
     public void run(StreamlineConfiguration configuration, Environment environment) throws Exception {
+        AbstractServerFactory sf = (AbstractServerFactory) configuration.getServerFactory();
+        // disable all default exception mappers
+        sf.setRegisterDefaultExceptionMappers(false);
+
+        environment.jersey().register(GenericExceptionMapper.class);
+
         registerResources(configuration, environment);
     }
 


### PR DESCRIPTION
This is not an enhancement of error messages. I think it is too ambitious to enhance error message and/or log message for all of cases in an issue, but we can talk about this again which this patch is live. If we want to handle error message enhancements in STREAMLINE-197, we can file a new issue for this change.

This patch is going to generalize handling errors on webservice, might be opposite way to what STREAMLINE-197 tries to achieve, but we can get rid of enclosing try-catch pattern for all of methods now, and leave log for all the case of exceptions.

For example, this is a log line written by GenericExceptionHandler:
```
ERROR [2016-11-03 09:54:57,402] org.apache.streamline.streams.service.TopologyCatalogResource: Got exception: exception [EntityNotFoundException] / message [Entity with id [4] not found.] / thrown location: [org.apache.streamline.streams.service.TopologyCatalogResource.getTopologyById](TopologyCatalogResource.java:297)
```
If it also has cause exception instance, it will be logged, too.

Response style is also changed, based on the discussion on STREAMLINE-197. Please refer commit log for details.

Here is the commit log:

* break down enum in CatalogResponse to multiple Exception classes
  * assign status code and message to each exception
* remove response code for now since caller (UI) doesn't have interest to see the code
* apply generic exception handler
  * leave log message with generic way
  * also create Response with generic way
* also change the way to represent output for single entity and entities
  * single entity: entity will be represented to JSON response directly
  * entities: same as now ('entities' field), but response code and message removed

Change-Id: Ic1b51b0bcb2663b91beb8f710e397e78986c113b