### PR TITLE
Reflect changed interface on Storm SQL DataSourcesProvider

### DIFF
--- a/streams/runtime/src/main/java/org/apache/streamline/streams/runtime/rule/sql/RulesDataSourcesProvider.java
+++ b/streams/runtime/src/main/java/org/apache/streamline/streams/runtime/rule/sql/RulesDataSourcesProvider.java
@@ -26,6 +26,7 @@ import org.apache.storm.sql.runtime.ISqlTridentDataSource;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Properties;
 
 public class RulesDataSourcesProvider implements DataSourcesProvider {
     private static final ThreadLocal<RulesDataSource> dataSource = new ThreadLocal<RulesDataSource>() {
@@ -45,8 +46,8 @@ public class RulesDataSourcesProvider implements DataSourcesProvider {
         return dataSource.get();
     }
 
-    @Override
-    public ISqlTridentDataSource constructTrident(URI uri, String s, String s1, String s2, List<FieldInfo> list) {
+    @Override public ISqlTridentDataSource constructTrident(URI uri, String s, String s1,
+        Properties properties, List<FieldInfo> list) {
         return null;
     }
 


### PR DESCRIPTION
There's API change on DataSourcesProvider on Storm SQL, and the change is published to 1.1.0-SNAPSHOT which breaks master branch. This is a quick fix.

Change-Id: I513b22c8ceb0213d1077dc873042e5f6ef2774c2