### PR TITLE
STREAMLINE-498 Storm Runner Time-series API should handle the differe…

### DIFF
--- a/streams/metrics/src/main/java/org/apache/streamline/streams/metrics/topology/TopologyMetrics.java
+++ b/streams/metrics/src/main/java/org/apache/streamline/streams/metrics/topology/TopologyMetrics.java
@@ -141,8 +141,8 @@ public interface TopologyMetrics extends TopologyTimeSeriesMetrics {
         /**
          * Constructor.
          *
-         * @param componentName 'component name' for Streams.
-         *                      If component name for streaming framework is different from component name for Streams,
+         * @param componentName 'component name' for Streamline.
+         *                      If component name for streaming framework is different from component name for Streamline,
          *                      implementation of TopologyMetrics should match the relation.
          * @param inputRecords  Count of input records.
          * @param outputRecords Count of output records.

--- a/streams/metrics/src/main/java/org/apache/streamline/streams/metrics/topology/TopologyTimeSeriesMetrics.java
+++ b/streams/metrics/src/main/java/org/apache/streamline/streams/metrics/topology/TopologyTimeSeriesMetrics.java
@@ -1,5 +1,6 @@
 package org.apache.streamline.streams.metrics.topology;
 
+import org.apache.streamline.streams.layout.component.Component;
 import org.apache.streamline.streams.layout.component.TopologyLayout;
 import org.apache.streamline.streams.metrics.TimeSeriesQuerier;
 
@@ -21,12 +22,12 @@ public interface TopologyTimeSeriesMetrics {
      * Retrieve "complete latency" on source.
      *
      * @param topology  topology catalog instance
-     * @param sourceId  source id (same to component id)
+     * @param component component layout instance
      * @param from      beginning of the time period: timestamp (in milliseconds)
      * @param to        end of the time period: timestamp (in milliseconds)
      * @return Map of data points which are paired to (timestamp, value)
      */
-    Map<Long, Double> getCompleteLatency(TopologyLayout topology, String sourceId, long from, long to);
+    Map<Long, Double> getCompleteLatency(TopologyLayout topology, Component component, long from, long to);
 
     /**
      * Retrieve "kafka topic offsets" on source.
@@ -38,13 +39,13 @@ public interface TopologyTimeSeriesMetrics {
      * <p/>
      * That source should be "KAFKA" type and have topic name from configuration.
      *
-     * @param topology  topology catalog instance
-     * @param sourceId  source id (same to component id)
+     * @param topology  topology layout instance
+     * @param component component layout instance
      * @param from      beginning of the time period: timestamp (in milliseconds)
      * @param to        end of the time period: timestamp (in milliseconds)
      * @return Map of metric name and Map of data points which are paired to (timestamp, value).
      */
-    Map<String, Map<Long, Double>> getkafkaTopicOffsets(TopologyLayout topology, String sourceId, long from, long to);
+    Map<String, Map<Long, Double>> getkafkaTopicOffsets(TopologyLayout topology, Component component, long from, long to);
 
     /**
      * Retrieve "component stats" on component.
@@ -57,12 +58,12 @@ public interface TopologyTimeSeriesMetrics {
      * 5) "recordsInWaitQueue": Count of records waiting in queue<br/>
      *
      * @param topology      topology catalog instance
-     * @param componentId   component id
+     * @param component     component layout instance
      * @param from          beginning of the time period: timestamp (in milliseconds)
      * @param to            end of the time period: timestamp (in milliseconds)
      * @return Map of metric name and Map of data points which are paired to (timestamp, value).
      */
-    Map<String, Map<Long, Double>> getComponentStats(TopologyLayout topology, String componentId, long from, long to);
+    Map<String, Map<Long, Double>> getComponentStats(TopologyLayout topology, Component component, long from, long to);
 
     /**
      * Get instance of TimeSeriesQuerier.

--- a/streams/runners/storm/metrics/src/main/java/org/apache/streamline/streams/metrics/storm/topology/StormTopologyMetricsImpl.java
+++ b/streams/runners/storm/metrics/src/main/java/org/apache/streamline/streams/metrics/storm/topology/StormTopologyMetricsImpl.java
@@ -2,6 +2,7 @@ package org.apache.streamline.streams.metrics.storm.topology;
 
 import org.apache.streamline.streams.exception.ConfigException;
 import org.apache.streamline.streams.layout.TopologyLayoutConstants;
+import org.apache.streamline.streams.layout.component.Component;
 import org.apache.streamline.streams.layout.component.TopologyLayout;
 import org.apache.streamline.streams.metrics.TimeSeriesQuerier;
 import org.apache.streamline.streams.metrics.storm.StormRestAPIClient;
@@ -163,24 +164,24 @@ public class StormTopologyMetricsImpl implements TopologyMetrics {
      * {@inheritDoc}
      */
     @Override
-    public Map<Long, Double> getCompleteLatency(TopologyLayout topology, String sourceId, long from, long to) {
-        return timeSeriesMetrics.getCompleteLatency(topology, sourceId, from, to);
+    public Map<Long, Double> getCompleteLatency(TopologyLayout topology, Component component, long from, long to) {
+        return timeSeriesMetrics.getCompleteLatency(topology, component, from, to);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public Map<String, Map<Long, Double>> getkafkaTopicOffsets(TopologyLayout topology, String sourceId, long from, long to) {
-        return timeSeriesMetrics.getkafkaTopicOffsets(topology, sourceId, from, to);
+    public Map<String, Map<Long, Double>> getkafkaTopicOffsets(TopologyLayout topology, Component component, long from, long to) {
+        return timeSeriesMetrics.getkafkaTopicOffsets(topology, component, from, to);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public Map<String, Map<Long, Double>> getComponentStats(TopologyLayout topology, String componentId, long from, long to) {
-        return timeSeriesMetrics.getComponentStats(topology, componentId, from, to);
+    public Map<String, Map<Long, Double>> getComponentStats(TopologyLayout topology, Component component, long from, long to) {
+        return timeSeriesMetrics.getComponentStats(topology, component, from, to);
     }
 
     private ComponentMetric extractMetric(String componentName, Map<String, ?> componentMap) {

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/MetricsResource.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/MetricsResource.java
@@ -21,6 +21,7 @@ package org.apache.streamline.streams.service;
 import com.codahale.metrics.annotation.Timed;
 import org.apache.streamline.common.util.WSUtils;
 import org.apache.streamline.streams.catalog.Topology;
+import org.apache.streamline.streams.catalog.TopologyComponent;
 import org.apache.streamline.streams.catalog.service.StreamCatalogService;
 import org.apache.streamline.streams.metrics.topology.TopologyMetrics;
 import org.slf4j.Logger;
@@ -76,10 +77,10 @@ public class MetricsResource {
     }
 
     @GET
-    @Path("/topologies/{id}/sources/{sourceId}/complete_latency")
+    @Path("/topologies/{id}/components/{topologyComponentId}/complete_latency")
     @Timed
     public Response getCompleteLatency(@PathParam("id") Long id,
-                                       @PathParam("sourceId") String sourceId,
+                                       @PathParam("topologyComponentId") Long topologyComponentId,
                                        @QueryParam("from") Long from,
                                        @QueryParam("to") Long to) {
         if (from == null) {
@@ -91,22 +92,27 @@ public class MetricsResource {
 
         try {
             Topology topology = catalogService.getTopology(id);
-            if (topology != null) {
-                Map<Long, Double> metrics = catalogService.getCompleteLatency(topology, sourceId, from, to);
+            TopologyComponent topologyComponent = catalogService.getTopologyComponent(topologyComponentId);
+            if (topology != null && topologyComponent != null) {
+                Map<Long, Double> metrics = catalogService.getCompleteLatency(topology, topologyComponent, from, to);
                 return WSUtils.respond(metrics, OK, SUCCESS);
+            } else if (topology == null) {
+                return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, "Topology: " + id.toString());
+            } else {
+                // topologyComponent == null
+                return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, "TopologyComponent: " + id.toString());
             }
         } catch (Exception ex) {
             LOG.error("Got exception", ex);
             return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, id.toString());
     }
 
     @GET
-    @Path("/topologies/{id}/sources/{sourceId}/component_stats")
+    @Path("/topologies/{id}/components/{topologyComponentId}/component_stats")
     @Timed
     public Response getComponentStats(@PathParam("id") Long id,
-                                      @PathParam("sourceId") String sourceId,
+                                      @PathParam("topologyComponentId") Long topologyComponentId,
                                       @QueryParam("from") Long from,
                                       @QueryParam("to") Long to) {
         if (from == null) {
@@ -118,22 +124,27 @@ public class MetricsResource {
 
         try {
             Topology topology = catalogService.getTopology(id);
-            if (topology != null) {
-                Map<String, Map<Long, Double>> metrics = catalogService.getComponentStats(topology, sourceId, from, to);
+            TopologyComponent topologyComponent = catalogService.getTopologyComponent(topologyComponentId);
+            if (topology != null && topologyComponent != null) {
+                Map<String, Map<Long, Double>> metrics = catalogService.getComponentStats(topology, topologyComponent, from, to);
                 return WSUtils.respond(metrics, OK, SUCCESS);
+            } else if (topology == null) {
+                return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, "Topology: " + id.toString());
+            } else {
+                // topologyComponent == null
+                return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, "TopologyComponent: " + id.toString());
             }
         } catch (Exception ex) {
             LOG.error("Got exception", ex);
             return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, id.toString());
     }
 
     @GET
-    @Path("/topologies/{id}/sources/{sourceId}/kafka_topic_offsets")
+    @Path("/topologies/{id}/components/{topologyComponentId}/kafka_topic_offsets")
     @Timed
     public Response getKafkaTopicOffsets(@PathParam("id") Long id,
-                                         @PathParam("sourceId") String sourceId,
+                                         @PathParam("topologyComponentId") Long topologyComponentId,
                                          @QueryParam("from") Long from,
                                          @QueryParam("to") Long to) {
         if (from == null) {
@@ -145,15 +156,20 @@ public class MetricsResource {
 
         try {
             Topology topology = catalogService.getTopology(id);
-            if (topology != null) {
-                Map<String, Map<Long, Double>> metrics = catalogService.getKafkaTopicOffsets(topology, sourceId, from, to);
+            TopologyComponent topologyComponent = catalogService.getTopologyComponent(topologyComponentId);
+            if (topology != null && topologyComponent != null) {
+                Map<String, Map<Long, Double>> metrics = catalogService.getKafkaTopicOffsets(topology, topologyComponent, from, to);
                 return WSUtils.respond(metrics, OK, SUCCESS);
+            } else if (topology == null) {
+                return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, "Topology: " + id.toString());
+            } else {
+                // topologyComponent == null
+                return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, "TopologyComponent: " + id.toString());
             }
         } catch (Exception ex) {
             LOG.error("Got exception", ex);
             return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
         }
-        return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, id.toString());
     }
 
     @GET


### PR DESCRIPTION
…nce between component name from Streamline and Storm

* This also handles the change of Topology layout
  * Metrics API now requires the ID of topology component (source, sink, processor)
  * API paths are changed too (no longer using source name)

Change-Id: I1f0911beecae6408b377571eaf01ca58af9b3b1d