### PR TITLE
STREAMLINE-502 Let Topology metrics find Storm topology by topology ID

### DIFF
--- a/streams/runners/storm/metrics/src/main/java/org/apache/streamline/streams/metrics/storm/StormRestAPIClient.java
+++ b/streams/runners/storm/metrics/src/main/java/org/apache/streamline/streams/metrics/storm/StormRestAPIClient.java
@@ -1,0 +1,46 @@
+package org.apache.streamline.streams.metrics.storm;
+
+import org.apache.streamline.streams.metrics.storm.topology.StormNotReachableException;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.util.Map;
+
+public class StormRestAPIClient {
+    private final String stormApiRootUrl;
+    private final Client client;
+
+    public StormRestAPIClient(Client client, String stormApiRootUrl) {
+        this.client = client;
+        this.stormApiRootUrl = stormApiRootUrl;
+    }
+
+    public Map getTopologySummary() {
+        return doGetRequest(getTopologySummaryUrl());
+    }
+
+    public Map getTopology(String topologyId) {
+        return doGetRequest(getTopologyUrl(topologyId));
+    }
+
+    private Map doGetRequest(String requestUrl) {
+        try {
+            return client.target(requestUrl).request(MediaType.APPLICATION_JSON_TYPE).get(Map.class);
+        } catch (javax.ws.rs.ProcessingException e) {
+            if (e.getCause() instanceof IOException) {
+                throw new StormNotReachableException("Exception while requesting " + requestUrl, e);
+            }
+
+            throw e;
+        }
+    }
+
+    private String getTopologySummaryUrl() {
+        return stormApiRootUrl + "/topology/summary";
+    }
+
+    private String getTopologyUrl(String topologyId) {
+        return stormApiRootUrl + "/topology/" + topologyId;
+    }
+}

--- a/streams/runners/storm/metrics/src/main/java/org/apache/streamline/streams/metrics/storm/StormTopologyUtil.java
+++ b/streams/runners/storm/metrics/src/main/java/org/apache/streamline/streams/metrics/storm/StormTopologyUtil.java
@@ -1,0 +1,60 @@
+package org.apache.streamline.streams.metrics.storm;
+
+import org.apache.streamline.streams.layout.component.TopologyLayout;
+import org.apache.streamline.streams.metrics.storm.topology.StormMetricsConstant;
+
+import java.util.List;
+import java.util.Map;
+
+public class StormTopologyUtil {
+    private StormTopologyUtil() {
+    }
+
+    public static String generateStormTopologyName(TopologyLayout topology) {
+        return "streamline-" + topology.getId() + "-" + topology.getName();
+    }
+
+    public static String generateUniqueStormTopologyNamePrefix(TopologyLayout topology) {
+        return "streamline-" + topology.getId() + "-";
+    }
+
+    public static String findStormTopologyId(StormRestAPIClient client, TopologyLayout topology) {
+        String topologyNamePrefix = generateUniqueStormTopologyNamePrefix(topology);
+        Map<?, ?> summaryMap = client.getTopologySummary();
+        List<Map<?, ?>> topologies = (List<Map<?, ?>>) summaryMap.get(StormMetricsConstant.TOPOLOGY_SUMMARY_JSON_TOPOLOGIES);
+        String topologyId = null;
+        for (Map<?, ?> topologyMap : topologies) {
+            String topologyNameForStorm = (String) topologyMap.get(StormMetricsConstant.TOPOLOGY_SUMMARY_JSON_TOPOLOGY_NAME);
+
+            if (topologyNameForStorm.startsWith(topologyNamePrefix)) {
+                topologyId = (String) topologyMap.get(StormMetricsConstant.TOPOLOGY_SUMMARY_JSON_TOPOLOGY_ID_ENCODED);
+                break;
+            }
+        }
+        return topologyId;
+    }
+
+    public static String findStormCompleteTopologyName(StormRestAPIClient client, TopologyLayout topology) {
+        String topologyNamePrefix = generateUniqueStormTopologyNamePrefix(topology);
+        Map<?, ?> summaryMap = client.getTopologySummary();
+        List<Map<?, ?>> topologies = (List<Map<?, ?>>) summaryMap.get(StormMetricsConstant.TOPOLOGY_SUMMARY_JSON_TOPOLOGIES);
+        String topologyName = null;
+        for (Map<?, ?> topologyMap : topologies) {
+            String topologyNameForStorm = (String) topologyMap.get(StormMetricsConstant.TOPOLOGY_SUMMARY_JSON_TOPOLOGY_NAME);
+
+            if (topologyNameForStorm.startsWith(topologyNamePrefix)) {
+                topologyName = topologyNameForStorm;
+                break;
+            }
+        }
+        return topologyName;
+    }
+
+    public static String findOrGenerateTopologyName(StormRestAPIClient client, TopologyLayout topology) {
+        String topologyName = findStormCompleteTopologyName(client, topology);
+        if (topologyName == null) {
+            topologyName = generateStormTopologyName(topology);
+        }
+        return topologyName;
+    }
+}

--- a/streams/runners/storm/metrics/src/test/java/org/apache/streamline/streams/metrics/storm/topology/StormTopologyTimeSeriesMetricsImplTest.java
+++ b/streams/runners/storm/metrics/src/test/java/org/apache/streamline/streams/metrics/storm/topology/StormTopologyTimeSeriesMetricsImplTest.java
@@ -1,17 +1,23 @@
 package org.apache.streamline.streams.metrics.storm.topology;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import mockit.Mock;
+import mockit.MockUp;
 import org.apache.streamline.streams.layout.TopologyLayoutConstants;
 import org.apache.streamline.streams.layout.component.TopologyLayout;
 import org.apache.streamline.streams.metrics.TimeSeriesQuerier;
 import mockit.Expectations;
 import mockit.Mocked;
+import org.apache.streamline.streams.metrics.storm.StormRestAPIClient;
+import org.apache.streamline.streams.metrics.storm.StormTopologyUtil;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
@@ -20,37 +26,64 @@ import static org.junit.Assert.fail;
 
 public class StormTopologyTimeSeriesMetricsImplTest {
     private StormTopologyTimeSeriesMetricsImpl stormTopologyTimeSeriesMetrics;
-
     @Mocked
     private TimeSeriesQuerier mockTimeSeriesQuerier;
     private Random random = new Random();
     private ObjectMapper mapper = new ObjectMapper();
 
+    private static final String SOURCE_ID = "device";
+    private static final String TOPIC_NAME = "topic";
+
+    private TopologyLayout topology;
+    private String mockedTopologyName;
+
     @Before
-    public void setUp() {
-        stormTopologyTimeSeriesMetrics = new StormTopologyTimeSeriesMetricsImpl();
+    public void setUp() throws IOException {
+        topology = getTopologyLayoutForTest();
+
+        String generatedTopologyName = StormTopologyUtil.generateStormTopologyName(topology);
+        mockedTopologyName = generatedTopologyName + "-old";
+
+        StormRestAPIClient mockClient = createMockStormRestAPIClient(mockedTopologyName);
+
+        stormTopologyTimeSeriesMetrics = new StormTopologyTimeSeriesMetricsImpl(mockClient);
         stormTopologyTimeSeriesMetrics.setTimeSeriesQuerier(mockTimeSeriesQuerier);
+    }
+
+    private StormRestAPIClient createMockStormRestAPIClient(final String mockTopologyName) {
+        return new MockUp<StormRestAPIClient>() {
+                @Mock
+                public Map getTopologySummary() {
+                    Map<String, Object> topologySummary = new HashMap<>();
+                    List<Map<String, Object>> topologies = new ArrayList<>();
+                    topologySummary.put(StormMetricsConstant.TOPOLOGY_SUMMARY_JSON_TOPOLOGIES, topologies);
+                    Map<String, Object> mockTopology = new HashMap<>();
+                    mockTopology.put(StormMetricsConstant.TOPOLOGY_SUMMARY_JSON_TOPOLOGY_NAME, mockTopologyName);
+                    mockTopology.put(StormMetricsConstant.TOPOLOGY_SUMMARY_JSON_TOPOLOGY_ID_ENCODED, mockTopologyName + "-1234567890");
+                    topologies.add(mockTopology);
+                    return topologySummary;
+                }
+            }.getMockInstance();
     }
 
     @Test(expected = IllegalStateException.class)
     public void testWithoutAssigningTimeSeriesQuerier() throws IOException {
         stormTopologyTimeSeriesMetrics.setTimeSeriesQuerier(null);
 
-        final TopologyLayout topology = new TopologyLayout(1L, "topology", null, null);
-        final String sourceId = "device";
-
         final long from = 1L;
         final long to = 3L;
 
-        stormTopologyTimeSeriesMetrics.getCompleteLatency(topology, sourceId, from, to);
+        stormTopologyTimeSeriesMetrics.getCompleteLatency(topology, SOURCE_ID, from, to);
         fail("It should throw Exception!");
+    }
+
+    private TopologyLayout getTopologyLayoutForTest() throws IOException {
+        Map<String, Object> configurations = buildTopologyConfigWithKafkaDataSource(SOURCE_ID, TOPIC_NAME);
+        return new TopologyLayout(1L, "topology", mapper.writeValueAsString(configurations), null);
     }
 
     @Test
     public void testGetCompleteLatency() throws Exception {
-        final TopologyLayout topology = new TopologyLayout(1L, "topology", null, null);
-        final String sourceId = "device";
-
         final long from = 1L;
         final long to = 3L;
 
@@ -59,8 +92,8 @@ public class StormTopologyTimeSeriesMetricsImplTest {
         // also verification
         new Expectations() {{
             mockTimeSeriesQuerier.getMetrics(
-                    withEqual("streamline-" + topology.getId() + "-" + topology.getName()),
-                    withEqual(sourceId),
+                    withEqual(mockedTopologyName),
+                    withEqual(SOURCE_ID),
                     withEqual(StormMappedMetric.completeLatency.getStormMetricName()),
                     withEqual(StormMappedMetric.completeLatency.getAggregateFunction()),
                     withEqual(from), withEqual(to)
@@ -69,19 +102,12 @@ public class StormTopologyTimeSeriesMetricsImplTest {
             result = expected;
         }};
 
-        Map<Long, Double> actual = stormTopologyTimeSeriesMetrics.getCompleteLatency(topology, sourceId, from, to);
+        Map<Long, Double> actual = stormTopologyTimeSeriesMetrics.getCompleteLatency(topology, SOURCE_ID, from, to);
         assertEquals(expected, actual);
     }
 
     @Test
     public void getKafkaTopicOffsets() throws Exception {
-        final String sourceId = "device";
-        final String topicName = "topic";
-
-        Map<String, Object> configurations = buildTopologyConfigWithKafkaDataSource(sourceId, topicName);
-        final TopologyLayout topology = new TopologyLayout(
-                1L, "topology", mapper.writeValueAsString(configurations), null);
-
         final long from = 1L;
         final long to = 3L;
 
@@ -94,9 +120,9 @@ public class StormTopologyTimeSeriesMetricsImplTest {
         // also verification
         new Expectations() {{
             mockTimeSeriesQuerier.getMetrics(
-                    withEqual("streamline-" + topology.getId() + "-" + topology.getName()),
-                    withEqual(sourceId),
-                    withEqual(String.format(StormMappedMetric.logsize.getStormMetricName(), topicName)),
+                    withEqual(mockedTopologyName),
+                    withEqual(SOURCE_ID),
+                    withEqual(String.format(StormMappedMetric.logsize.getStormMetricName(), TOPIC_NAME)),
                     withEqual(StormMappedMetric.logsize.getAggregateFunction()),
                     withEqual(from), withEqual(to)
             );
@@ -104,9 +130,9 @@ public class StormTopologyTimeSeriesMetricsImplTest {
             result = expected.get(StormMappedMetric.logsize.name());
 
             mockTimeSeriesQuerier.getMetrics(
-                    withEqual("streamline-" + topology.getId() + "-" + topology.getName()),
-                    withEqual(sourceId),
-                    withEqual(String.format(StormMappedMetric.offset.getStormMetricName(), topicName)),
+                    withEqual(mockedTopologyName),
+                    withEqual(SOURCE_ID),
+                    withEqual(String.format(StormMappedMetric.offset.getStormMetricName(), TOPIC_NAME)),
                     withEqual(StormMappedMetric.offset.getAggregateFunction()),
                     withEqual(from), withEqual(to)
             );
@@ -114,9 +140,9 @@ public class StormTopologyTimeSeriesMetricsImplTest {
             result = expected.get(StormMappedMetric.offset.name());
 
             mockTimeSeriesQuerier.getMetrics(
-                    withEqual("streamline-" + topology.getId() + "-" + topology.getName()),
-                    withEqual(sourceId),
-                    withEqual(String.format(StormMappedMetric.lag.getStormMetricName(), topicName)),
+                    withEqual(mockedTopologyName),
+                    withEqual(SOURCE_ID),
+                    withEqual(String.format(StormMappedMetric.lag.getStormMetricName(), TOPIC_NAME)),
                     withEqual(StormMappedMetric.lag.getAggregateFunction()),
                     withEqual(from), withEqual(to)
             );
@@ -124,15 +150,13 @@ public class StormTopologyTimeSeriesMetricsImplTest {
             result = expected.get(StormMappedMetric.lag.name());
         }};
 
-        Map<String, Map<Long, Double>> actual = stormTopologyTimeSeriesMetrics.getkafkaTopicOffsets(topology, sourceId, from, to);
+        Map<String, Map<Long, Double>> actual = stormTopologyTimeSeriesMetrics.getkafkaTopicOffsets(topology, SOURCE_ID, from, to);
         assertEquals(expected, actual);
     }
 
     @Test
     public void getComponentStats() throws Exception {
-        final TopologyLayout topology = new TopologyLayout(1L, "topology", null, null);
-
-        final String sourceId = "device";
+        final TopologyLayout topology = getTopologyLayoutForTest();
 
         final long from = 1L;
         final long to = 3L;
@@ -147,8 +171,8 @@ public class StormTopologyTimeSeriesMetricsImplTest {
 
         new Expectations() {{
             mockTimeSeriesQuerier.getMetrics(
-                    withEqual("streamline-" + topology.getId() + "-" + topology.getName()),
-                    withEqual(sourceId),
+                    withEqual(mockedTopologyName),
+                    withEqual(SOURCE_ID),
                     withEqual(StormMappedMetric.inputRecords.getStormMetricName()),
                     withEqual(StormMappedMetric.inputRecords.getAggregateFunction()),
                     withEqual(from), withEqual(to)
@@ -157,8 +181,8 @@ public class StormTopologyTimeSeriesMetricsImplTest {
             result = expected.get(StormMappedMetric.inputRecords.name());
 
             mockTimeSeriesQuerier.getMetrics(
-                    withEqual("streamline-" + topology.getId() + "-" + topology.getName()),
-                    withEqual(sourceId),
+                    withEqual(mockedTopologyName),
+                    withEqual(SOURCE_ID),
                     withEqual(StormMappedMetric.outputRecords.getStormMetricName()),
                     withEqual(StormMappedMetric.outputRecords.getAggregateFunction()),
                     withEqual(from), withEqual(to)
@@ -167,8 +191,8 @@ public class StormTopologyTimeSeriesMetricsImplTest {
             result = expected.get(StormMappedMetric.outputRecords.name());
 
             mockTimeSeriesQuerier.getMetrics(
-                    withEqual("streamline-" + topology.getId() + "-" + topology.getName()),
-                    withEqual(sourceId),
+                    withEqual(mockedTopologyName),
+                    withEqual(SOURCE_ID),
                     withEqual(StormMappedMetric.failedRecords.getStormMetricName()),
                     withEqual(StormMappedMetric.failedRecords.getAggregateFunction()),
                     withEqual(from), withEqual(to)
@@ -177,8 +201,8 @@ public class StormTopologyTimeSeriesMetricsImplTest {
             result = expected.get(StormMappedMetric.failedRecords.name());
 
             mockTimeSeriesQuerier.getMetrics(
-                    withEqual("streamline-" + topology.getId() + "-" + topology.getName()),
-                    withEqual(sourceId),
+                    withEqual(mockedTopologyName),
+                    withEqual(SOURCE_ID),
                     withEqual(StormMappedMetric.processedTime.getStormMetricName()),
                     withEqual(StormMappedMetric.processedTime.getAggregateFunction()),
                     withEqual(from), withEqual(to)
@@ -187,8 +211,8 @@ public class StormTopologyTimeSeriesMetricsImplTest {
             result = expected.get(StormMappedMetric.processedTime.name());
 
             mockTimeSeriesQuerier.getMetrics(
-                    withEqual("streamline-" + topology.getId() + "-" + topology.getName()),
-                    withEqual(sourceId),
+                    withEqual(mockedTopologyName),
+                    withEqual(SOURCE_ID),
                     withEqual(StormMappedMetric.recordsInWaitQueue.getStormMetricName()),
                     withEqual(StormMappedMetric.recordsInWaitQueue.getAggregateFunction()),
                     withEqual(from), withEqual(to)
@@ -197,7 +221,7 @@ public class StormTopologyTimeSeriesMetricsImplTest {
             result = expected.get(StormMappedMetric.recordsInWaitQueue.name());
         }};
 
-        Map<String, Map<Long, Double>> actual = stormTopologyTimeSeriesMetrics.getComponentStats(topology, sourceId, from, to);
+        Map<String, Map<Long, Double>> actual = stormTopologyTimeSeriesMetrics.getComponentStats(topology, SOURCE_ID, from, to);
         assertEquals(expected, actual);
     }
 


### PR DESCRIPTION
* Topology metrics finds Storm topology by topology name from TopologyLayout
  * this relation can be broken when user change topology name from Streamline
* Change the way to find Storm topology by topology ID as prefix

Change-Id: I567926da15112f6ae5c0fa0ec0fc3f10d5636d54

@harshach @shahsank3t 
This patch addresses topology name change issue for `topology metrics` and `topology time-series querier` by changing the way to find Storm topology. Please take a look and test to see this fixes origin issue of STREAMLINE-502.

Btw, `topology action` should be addressed too, but since it doesn't rely on Storm API it needs some more efforts to address. I'll file a new issue and address too.