### PR TITLE
Fix Topology list with metrics API bugs

### DIFF
--- a/streams/runners/storm/common/src/main/java/org/apache/streamline/streams/storm/common/StormRestAPIClient.java
+++ b/streams/runners/storm/common/src/main/java/org/apache/streamline/streams/storm/common/StormRestAPIClient.java
@@ -24,6 +24,10 @@ public class StormRestAPIClient {
         return doGetRequest(getTopologyUrl(topologyId));
     }
 
+    public Map getComponent(String topologyId, String componentId) {
+        return doGetRequest(getComponentUrl(topologyId, componentId));
+    }
+
     public boolean killTopology(String stormTopologyId, int waitTime) {
         Map result = doPostRequestWithEmptyBody(getTopologyKillUrl(stormTopologyId, waitTime));
         return isPostOperationSuccess(result);
@@ -69,6 +73,10 @@ public class StormRestAPIClient {
 
     private String getTopologyUrl(String topologyId) {
         return stormApiRootUrl + "/topology/" + topologyId;
+    }
+
+    private String getComponentUrl(String topologyId, String componentId) {
+        return getTopologyUrl(topologyId) + "/component/" + componentId;
     }
 
     private String getTopologyKillUrl(String topologyId, int waitTime) {

--- a/streams/runners/storm/common/src/main/java/org/apache/streamline/streams/storm/common/StormRestAPIConstant.java
+++ b/streams/runners/storm/common/src/main/java/org/apache/streamline/streams/storm/common/StormRestAPIConstant.java
@@ -14,6 +14,7 @@ public class StormRestAPIConstant {
     public static final String TOPOLOGY_JSON_SPOUT_ID = "spoutId";
     public static final String TOPOLOGY_JSON_BOLTS = "bolts";
     public static final String TOPOLOGY_JSON_BOLT_ID = "boltId";
+    public static final String TOPOLOGY_JSON_COMPONENT_ERRORS = "componentErrors";
 
     public static final String STATS_JSON_EXECUTED_TUPLES = "executed";
     public static final String STATS_JSON_EMITTED_TUPLES = "emitted";
@@ -22,6 +23,7 @@ public class StormRestAPIConstant {
     public static final String STATS_JSON_COMPLETE_LATENCY = "completeLatency";
     public static final String STATS_JSON_ACKED_TUPLES = "acked";
     public static final String STATS_JSON_FAILED_TUPLES = "failed";
+    public static final String STATS_JSON_TOPOLOGY_ERROR_COUNT = "errors";
 
     public static final String TOPOLOGY_SUMMARY_JSON_TOPOLOGIES = "topologies";
     public static final String TOPOLOGY_SUMMARY_JSON_TOPOLOGY_NAME = "name";


### PR DESCRIPTION
This is the fix of STREAMLINE-507 but actually it doesn't address main issue on [STREAMLINE-507](https://hwxiot.atlassian.net/browse/STREAMLINE-507) (these are about 'more items') so don't add issue prefix. Please let me know this change needs to be filed to issue.

* component name had '-' on first (fixed)
* default sort order was not last updated & desc (fixed)
  * set default sort to last updated
  * add sort option 'ascending': default value is 'false'
* add 'errors' on misc metrics
  * it's sum of error count on all components in topology

Change-Id: Iddadbcac027260c41ed5d0eadb0ec87a5d81dbd5

@harshach 
To summarize error count, it calls `component info` REST API for all of components for all of topologies. For current patch, requests are occurred sequentially. Please let me know if we want to try multiple requests simultaneously.

EDITED: STREAMLINE-507, not 502.