### PR TITLE
STREAMLINE-524 Provide 'Storm Ambari View' or 'Storm UI' URL via API

### DIFF
--- a/streams/catalog/src/test/java/org/apache/streamline/streams/catalog/service/metadata/StormMetadataServiceTest.java
+++ b/streams/catalog/src/test/java/org/apache/streamline/streams/catalog/service/metadata/StormMetadataServiceTest.java
@@ -35,6 +35,8 @@ public class StormMetadataServiceTest {
     @Injectable
     Client client;
     @Injectable
+    String mainPageUrl;
+    @Injectable
     Invocation.Builder builder;
 
     @Test

--- a/streams/cluster/src/main/java/org/apache/streamline/streams/cluster/discovery/ambari/AmbariRestAPIConstants.java
+++ b/streams/cluster/src/main/java/org/apache/streamline/streams/cluster/discovery/ambari/AmbariRestAPIConstants.java
@@ -12,6 +12,9 @@ public final class AmbariRestAPIConstants {
   public static final String AMBARI_JSON_SCHEMA_COMMON_TAG = "tag";
   public static final String AMBARI_JSON_SCHEMA_COMMON_HREF = "href";
   public static final String AMBARI_JSON_SCHEMA_COMMON_PROPERTIES = "properties";
+  public static final String AMBARI_JSON_SCHEMA_COMMON_VERSIONS = "versions";
+  public static final String AMBARI_JSON_SCHEMA_COMMON_INSTANCES = "instances";
+  public static final String AMBARI_JSON_SCHEMA_COMMON_VIEW_INSTANCE_INFO = "ViewInstanceInfo";
 
 
   public static final String AMBARI_JSON_SCHEMA_SERVICE_INFO = "ServiceInfo";
@@ -22,5 +25,5 @@ public final class AmbariRestAPIConstants {
   public static final String AMBARI_JSON_SCHEMA_HOST_COMPONENTS = "host_components";
   public static final String AMBARI_JSON_SCHEMA_HOST_ROLES = "HostRoles";
   public static final String AMBARI_JSON_SCHEMA_HOST_NAME = "host_name";
-
+  public static final String AMBARI_JSON_SCHEMA_CONTEXT_PATH = "context_path";
 }

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/metadata/StormMetadataResource.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/metadata/StormMetadataResource.java
@@ -3,10 +3,14 @@ package org.apache.streamline.streams.service.metadata;
 import com.codahale.metrics.annotation.Timed;
 import org.apache.streamline.common.util.WSUtils;
 import org.apache.streamline.streams.catalog.Cluster;
+import org.apache.streamline.streams.catalog.Service;
+import org.apache.streamline.streams.catalog.exception.ServiceNotFoundException;
 import org.apache.streamline.streams.catalog.service.StreamCatalogService;
 
 import org.apache.streamline.streams.catalog.exception.EntityNotFoundException;
 import org.apache.streamline.streams.catalog.service.metadata.StormMetadataService;
+import org.apache.streamline.streams.cluster.discovery.ambari.ComponentPropertyPattern;
+import org.apache.streamline.streams.cluster.discovery.ambari.ServiceConfigurations;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -50,6 +54,20 @@ public class StormMetadataResource {
         try {
             StormMetadataService stormMetadataService = new StormMetadataService.Builder(catalogService, clusterId).build();
             return WSUtils.respond(stormMetadataService.getTopologies(), OK, SUCCESS);
+        } catch (EntityNotFoundException ex) {
+            return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, ex.getMessage());
+        } catch (Exception ex) {
+            return WSUtils.respond(INTERNAL_SERVER_ERROR, EXCEPTION, ex.getMessage());
+        }
+    }
+
+    @GET
+    @Path("/clusters/{clusterId}/services/storm/mainpage/url")
+    @Timed
+    public Response getMainPageByClusterId(@PathParam("clusterId") Long clusterId) {
+        try {
+            StormMetadataService stormMetadataService = new StormMetadataService.Builder(catalogService, clusterId).build();
+            return WSUtils.respond(stormMetadataService.getMainPageUrl(), OK, SUCCESS);
         } catch (EntityNotFoundException ex) {
             return WSUtils.respond(NOT_FOUND, ENTITY_NOT_FOUND, ex.getMessage());
         } catch (Exception ex) {


### PR DESCRIPTION
* get 'Storm Ambari View' URL via Ambari REST API
  * if not found, fail back to 'Storm UI' URL
* add retrieved URL to one of ServiceConfiguration on Storm service
* add Storm Metadata API to provide the URL

I applied a hack which is only applicable to Ambari. I'm not sure we will support cluster discovery with another management frameworks/services.

Below is the test result on Storm View added Ambari Cluster:

> http://localhost:8080/api/v1/catalog/clusters/1/services/storm/mainpage/url

```
{
  "responseCode": 1000,
  "responseMessage": "Success",
  "entity": "http://jlim-storm-1.openstacklocal:8080/#/main/views/Storm_Monitoring/0.1.0/StormView"
}
```

And below is the result if Storm Ambari View instance is not added:

> http://localhost:8080/api/v1/catalog/clusters/1/services/storm/mainpage/url

```
{
  "responseCode": 1000,
  "responseMessage": "Success",
  "entity": "http://jlim-storm-2.openstacklocal:8744"
}
```

