### PR TITLE
Add MySQL connector to storage-core dependency

### DIFF
--- a/storage/core/pom.xml
+++ b/storage/core/pom.xml
@@ -61,6 +61,10 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
WIthout this patch, Streamline webservice fails to start with mysql storage configuration.