### PR TITLE
STREAMLINE-529 - Call .toString() instead of casting value to String

### DIFF
--- a/common/src/main/java/org/apache/streamline/common/Config.java
+++ b/common/src/main/java/org/apache/streamline/common/Config.java
@@ -61,7 +61,7 @@ public class Config extends AbstractConfig {
 
     @Override
     public String get(String key, Object defaultValue) {
-        return (String) super.get(key, defaultValue);
+        return super.get(key, defaultValue).toString();
     }
 
     @Override


### PR DESCRIPTION
This bug was leading to class cast Exception