### PR TITLE
Fix missing registring Cluster related entities to props

### DIFF
--- a/streams/catalog/src/main/resources/streamcatalogstorables.props
+++ b/streams/catalog/src/main/resources/streamcatalogstorables.props
@@ -1,5 +1,7 @@
 org.apache.streamline.streams.catalog.Component
 org.apache.streamline.streams.catalog.Cluster
+org.apache.streamline.streams.catalog.Service
+org.apache.streamline.streams.catalog.ServiceConfiguration
 org.apache.streamline.streams.catalog.TopologyEditorMetadata
 org.apache.streamline.streams.catalog.Topology
 org.apache.streamline.streams.catalog.StreamInfo


### PR DESCRIPTION
This is a quick fix.
@harshach Please take a look.