### PR TITLE
STREAMLINE-543 Time-series AMS querier: Adjust precision automatically based on time range

### DIFF
--- a/streams/runners/storm/metrics/src/main/java/org/apache/streamline/streams/metrics/storm/ambari/AmbariMetricsServiceWithStormQuerier.java
+++ b/streams/runners/storm/metrics/src/main/java/org/apache/streamline/streams/metrics/storm/ambari/AmbariMetricsServiceWithStormQuerier.java
@@ -156,7 +156,6 @@ public class AmbariMetricsServiceWithStormQuerier extends AbstractTimeSeriesQuer
                 .queryParam("hostname", "")
                 .queryParam("metricNames", actualMetricName)
                 .queryParam("startTime", String.valueOf(from))
-                .queryParam("precision", "seconds")
                 .queryParam("endTime", String.valueOf(to))
                 .queryParam("seriesAggregateFunction", aggrFunction.name())
                 .build();

--- a/streams/runners/storm/metrics/src/test/java/org/apache/streamline/streams/metrics/storm/ambari/AmbariMetricsServiceWithStormQuerierTest.java
+++ b/streams/runners/storm/metrics/src/test/java/org/apache/streamline/streams/metrics/storm/ambari/AmbariMetricsServiceWithStormQuerierTest.java
@@ -63,7 +63,6 @@ public class AmbariMetricsServiceWithStormQuerierTest {
                 .withQueryParam("hostname", equalTo(""))
                 .withQueryParam("metricNames", equalTo("topology.testTopology.testComponent.%.--test.metric.name"))
                 .withQueryParam("startTime", equalTo("1234"))
-                .withQueryParam("precision", equalTo("seconds"))
                 .withQueryParam("endTime", equalTo("5678"))
                 .withQueryParam("seriesAggregateFunction", equalTo("SUM")));
     }
@@ -88,7 +87,6 @@ public class AmbariMetricsServiceWithStormQuerierTest {
                 .withQueryParam("hostname", equalTo(""))
                 .withQueryParam("metricNames", equalTo("topology.testTopology.testComponent.%.--complete-latency.%"))
                 .withQueryParam("startTime", equalTo("1234"))
-                .withQueryParam("precision", equalTo("seconds"))
                 .withQueryParam("endTime", equalTo("5678"))
                 .withQueryParam("seriesAggregateFunction", equalTo("AVG")));
     }
@@ -109,8 +107,7 @@ public class AmbariMetricsServiceWithStormQuerierTest {
                 .withQueryParam("appId", equalTo("appId"))
                 .withQueryParam("metricNames", equalTo("metric"))
                 .withQueryParam("startTime", equalTo("1234"))
-                .withQueryParam("endTime", equalTo("5678"))
-                .withQueryParam("precision", equalTo("seconds")));
+                .withQueryParam("endTime", equalTo("5678")));
     }
 
 


### PR DESCRIPTION
* Just rely on AMS to pick proper precision

@shahsank3t @harshach Please let me know if it would be better to also append this to #355 