### PR TITLE
STREAMLINE-558 Time-series DB version of Topology Metrics API (aggregated ver.)

### DIFF
--- a/streams/catalog/src/main/java/org/apache/streamline/streams/catalog/service/StreamCatalogService.java
+++ b/streams/catalog/src/main/java/org/apache/streamline/streams/catalog/service/StreamCatalogService.java
@@ -1265,6 +1265,10 @@ public class StreamCatalogService {
         return this.topologyMetrics.getCompleteLatency(getTopologyLayout(topology), getComponentLayout(component), from, to);
     }
 
+    public TopologyTimeSeriesMetrics.TimeSeriesComponentMetric getTopologyStats(Topology topology, Long from, Long to) throws IOException {
+        return this.topologyMetrics.getTopologyStats(getTopologyLayout(topology), from, to);
+    }
+
     public TopologyTimeSeriesMetrics.TimeSeriesComponentMetric getComponentStats(Topology topology, TopologyComponent component, Long from, Long to) throws IOException {
         return this.topologyMetrics.getComponentStats(getTopologyLayout(topology), getComponentLayout(component), from, to);
     }
@@ -2948,8 +2952,9 @@ public class StreamCatalogService {
         return new StorableKey(NAMESPACE_SERVICE_CLUSTER_MAPPING_NAMESPACE,
                 mapping.getPrimaryKey());
     }
-    
+
     private Collection<FileInfo> listFiles(List<QueryParam> queryParams) {
         return dao.find( FileInfo.NAME_SPACE, queryParams);
     }
+
 }

--- a/streams/metrics/src/main/java/org/apache/streamline/streams/metrics/TimeSeriesQuerier.java
+++ b/streams/metrics/src/main/java/org/apache/streamline/streams/metrics/TimeSeriesQuerier.java
@@ -20,6 +20,18 @@ public interface TimeSeriesQuerier {
     void init (Map<String, String> conf) throws ConfigException;
 
     /**
+     * Query metrics to time-series DB. The result should aggregate all components metrics to one (meaning topology level).
+     *
+     * @param topologyName  topology name (not ID)
+     * @param metricName    metric name
+     * @param aggrFunction  function to apply while aggregating task level series
+     * @param from          beginning of the time period: timestamp (in milliseconds)
+     * @param to            end of the time period: timestamp (in milliseconds)
+     * @return Map of data points which are paired to (timestamp, value)
+     */
+    Map<Long, Double> getTopologyLevelMetrics(String topologyName, String metricName, AggregateFunction aggrFunction, long from, long to);
+
+    /**
      * Query metrics to time-series DB.
      *
      * @param topologyName  topology name (not ID)

--- a/streams/metrics/src/main/java/org/apache/streamline/streams/metrics/topology/TopologyTimeSeriesMetrics.java
+++ b/streams/metrics/src/main/java/org/apache/streamline/streams/metrics/topology/TopologyTimeSeriesMetrics.java
@@ -19,6 +19,18 @@ public interface TopologyTimeSeriesMetrics {
     void setTimeSeriesQuerier(TimeSeriesQuerier timeSeriesQuerier);
 
     /**
+     * Retrieve "topology stats" on topology.
+     * Implementator should aggregate all components' metrics values to make topology stats.
+     * The return value is a TimeSeriesComponentMetric which value of componentName is dummy or topology name.
+     *
+     * @param topology      topology catalog instance
+     * @param from          beginning of the time period: timestamp (in milliseconds)
+     * @param to            end of the time period: timestamp (in milliseconds)
+     * @return Map of metric name and Map of data points which are paired to (timestamp, value).
+     */
+    TimeSeriesComponentMetric getTopologyStats(TopologyLayout topology, long from, long to);
+
+    /**
      * Retrieve "complete latency" on source.
      *
      * @param topology  topology catalog instance
@@ -62,7 +74,6 @@ public interface TopologyTimeSeriesMetrics {
      * Get instance of TimeSeriesQuerier.
      */
     TimeSeriesQuerier getTimeSeriesQuerier();
-
 
     /**
      * Data structure of Metrics for each component on topology.

--- a/streams/runners/storm/metrics/src/main/java/org/apache/streamline/streams/metrics/storm/ambari/AmbariMetricsServiceWithStormQuerier.java
+++ b/streams/runners/storm/metrics/src/main/java/org/apache/streamline/streams/metrics/storm/ambari/AmbariMetricsServiceWithStormQuerier.java
@@ -41,6 +41,7 @@ public class AmbariMetricsServiceWithStormQuerier extends AbstractTimeSeriesQuer
             "__process-latency", "__execute-count", "__execute-latency"
     );
     public static final String DEFAULT_APP_ID = "nimbus";
+    public static final String WILDCARD_ALL_COMPONENTS = "%";
 
     private Client client;
     private URI collectorApiUri;
@@ -66,6 +67,12 @@ public class AmbariMetricsServiceWithStormQuerier extends AbstractTimeSeriesQuer
             }
         }
         client = ClientBuilder.newClient(new ClientConfig());
+    }
+
+    @Override
+    public Map<Long, Double> getTopologyLevelMetrics(String topologyName, String metricName,
+                                                     AggregateFunction aggrFunction, long from, long to) {
+        return getMetrics(topologyName, WILDCARD_ALL_COMPONENTS, metricName, aggrFunction, from, to);
     }
 
     /**

--- a/streams/runners/storm/metrics/src/main/java/org/apache/streamline/streams/metrics/storm/graphite/GraphiteWithStormQuerier.java
+++ b/streams/runners/storm/metrics/src/main/java/org/apache/streamline/streams/metrics/storm/graphite/GraphiteWithStormQuerier.java
@@ -42,6 +42,7 @@ public class GraphiteWithStormQuerier extends AbstractTimeSeriesQuerier {
             "__complete-latency", "__emit-count", "__ack-count", "__fail-count",
             "__process-latency", "__execute-count", "__execute-latency"
     );
+    public static final String WILDCARD_ALL_COMPONENTS = "*";
 
     private Client client;
     private URI renderApiUrl;
@@ -66,6 +67,12 @@ public class GraphiteWithStormQuerier extends AbstractTimeSeriesQuerier {
             }
         }
         client = ClientBuilder.newClient(new ClientConfig());
+    }
+
+    @Override
+    public Map<Long, Double> getTopologyLevelMetrics(String topologyName, String metricName,
+                                                     AggregateFunction aggrFunction, long from, long to) {
+        return getMetrics(topologyName, WILDCARD_ALL_COMPONENTS, metricName, aggrFunction, from, to);
     }
 
     /**

--- a/streams/runners/storm/metrics/src/main/java/org/apache/streamline/streams/metrics/storm/opentsdb/OpenTSDBWithStormQuerier.java
+++ b/streams/runners/storm/metrics/src/main/java/org/apache/streamline/streams/metrics/storm/opentsdb/OpenTSDBWithStormQuerier.java
@@ -3,6 +3,7 @@ package org.apache.streamline.streams.metrics.storm.opentsdb;
 import com.google.common.base.Joiner;
 import org.apache.streamline.streams.exception.ConfigException;
 import org.apache.streamline.streams.metrics.AbstractTimeSeriesQuerier;
+import org.apache.streamline.streams.metrics.TimeSeriesQuerier;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.uri.internal.JerseyUriBuilder;
 import org.slf4j.Logger;
@@ -47,6 +48,11 @@ public class OpenTSDBWithStormQuerier extends AbstractTimeSeriesQuerier {
             }
         }
         client = ClientBuilder.newClient(new ClientConfig());
+    }
+
+    @Override
+    public Map<Long, Double> getTopologyLevelMetrics(String topologyName, String metricName, AggregateFunction aggrFunction, long from, long to) {
+        throw new UnsupportedOperationException("OpenTSDBWithStormQuerier only supports raw query");
     }
 
     /**

--- a/streams/runners/storm/metrics/src/main/java/org/apache/streamline/streams/metrics/storm/topology/StormTopologyMetricsImpl.java
+++ b/streams/runners/storm/metrics/src/main/java/org/apache/streamline/streams/metrics/storm/topology/StormTopologyMetricsImpl.java
@@ -206,6 +206,14 @@ public class StormTopologyMetricsImpl implements TopologyMetrics {
      * {@inheritDoc}
      */
     @Override
+    public TimeSeriesComponentMetric getTopologyStats(TopologyLayout topology, long from, long to) {
+        return timeSeriesMetrics.getTopologyStats(topology, from, to);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public TimeSeriesComponentMetric getComponentStats(TopologyLayout topology, Component component, long from, long to) {
         return timeSeriesMetrics.getComponentStats(topology, component, from, to);
     }


### PR DESCRIPTION
* change behavior of API endpoint: /metrics/topologies/timeseries/:topologyId
  * it returns 'aggregated' metrics value for all components
* change path of previous time-series DB version of Topology Metrics API
  * /topologies/:topologyId/components/all/component_stats

Example of output:
`http://localhost:8080/api/v1/metrics/topologies/201/timeseries?from=1480665632583&to=1480666432584`

```
{
   "componentName":"test-gk",
   "inputRecords":{
      "1480665660000":6040.0,
      "1480665690000":5720.0,
      "1480665720000":5400.0,
      "1480665750000":5400.0,
      "1480665780000":6060.0,
      "1480665810000":5740.0,
      "1480665840000":5420.0,
      "1480665870000":5420.0,
      "1480665900000":5620.0,
      "1480665930000":5720.0,
      "1480665960000":5820.0,
      "1480665990000":5820.0,
      "1480666020000":5360.0,
      "1480666050000":5730.0,
      "1480666080000":6100.0,
      "1480666110000":6100.0,
      "1480666140000":5380.0,
      "1480666170000":5720.0,
      "1480666200000":6060.0,
      "1480666230000":6060.0,
      "1480666260000":5420.0,
      "1480666290000":5390.0,
      "1480666320000":5360.0,
      "1480666350000":5360.0,
      "1480666380000":6080.0,
      "1480666410000":5730.0
   },
   "outputRecords":{
      "1480665660000":7660.0,
      "1480665690000":7410.0,
      "1480665720000":7160.0,
      "1480665750000":7160.0,
      "1480665780000":8060.0,
      "1480665810000":7620.0,
      "1480665840000":7180.0,
      "1480665870000":7180.0,
      "1480665900000":7840.0,
      "1480665930000":7620.0,
      "1480665960000":7400.0,
      "1480665990000":7400.0,
      "1480666020000":7600.0,
      "1480666050000":7630.0,
      "1480666080000":7660.0,
      "1480666110000":7660.0,
      "1480666140000":7320.0,
      "1480666170000":7620.0,
      "1480666200000":7920.0,
      "1480666230000":7920.0,
      "1480666260000":7160.0,
      "1480666290000":7390.0,
      "1480666320000":7620.0,
      "1480666350000":7620.0,
      "1480666380000":7620.0,
      "1480666410000":7400.0
   },
   "failedRecords":{

   },
   "processedTime":{
      "1480665660000":0.0019801980198019802,
      "1480665690000":0.0032123212321232123,
      "1480665720000":0.0044444444444444444,
      "1480665750000":0.0044444444444444444,
      "1480665780000":0.0037383177570093455,
      "1480665810000":0.004091381100726895,
      "1480665840000":0.0044444444444444444,
      "1480665870000":0.0044444444444444444,
      "1480665900000":0.0019801980198019802,
      "1480665930000":9.900990099009901E-4,
      "1480665960000":0.0,
      "1480665990000":0.0,
      "1480666020000":0.0,
      "1480666050000":0.0,
      "1480666080000":0.0,
      "1480666110000":0.0,
      "1480666140000":0.0022222222222222222,
      "1480666170000":0.0011111111111111111,
      "1480666200000":0.0,
      "1480666230000":0.0,
      "1480666260000":0.0,
      "1480666290000":0.0011111111111111111,
      "1480666320000":0.0022222222222222222,
      "1480666350000":0.0022222222222222222,
      "1480666380000":0.0039603960396039604,
      "1480666410000":0.004202420242024203
   },
   "recordsInWaitQueue":{
      "1480665660000":1.0,
      "1480665690000":1.0,
      "1480665720000":1.0,
      "1480665750000":1.0,
      "1480665780000":1.0,
      "1480665810000":1.0,
      "1480665840000":1.0,
      "1480665870000":1.0,
      "1480665900000":1.0,
      "1480665930000":1.0,
      "1480665960000":1.0,
      "1480665990000":1.0,
      "1480666020000":1.0,
      "1480666050000":1.0,
      "1480666080000":1.0,
      "1480666110000":1.0,
      "1480666140000":1.0,
      "1480666170000":1.0,
      "1480666200000":1.0,
      "1480666230000":1.0,
      "1480666260000":1.0,
      "1480666290000":1.0,
      "1480666320000":1.0,
      "1480666350000":1.0,
      "1480666380000":1.0,
      "1480666410000":1.0
   },
   "misc":{
      "ackedRecords":{
         "1480665660000":7840.0,
         "1480665690000":7510.0,
         "1480665720000":7180.0,
         "1480665750000":7180.0,
         "1480665780000":8060.0,
         "1480665810000":7630.0,
         "1480665840000":7200.0,
         "1480665870000":7200.0,
         "1480665900000":7620.0,
         "1480665930000":7620.0,
         "1480665960000":7620.0,
         "1480665990000":7620.0,
         "1480666020000":7400.0,
         "1480666050000":7620.0,
         "1480666080000":7840.0,
         "1480666110000":7840.0,
         "1480666140000":7240.0,
         "1480666170000":7620.0,
         "1480666200000":8000.0,
         "1480666230000":8000.0,
         "1480666260000":7200.0,
         "1480666290000":7300.0,
         "1480666320000":7400.0,
         "1480666350000":7400.0,
         "1480666380000":7860.0,
         "1480666410000":7520.0
      }
   }
}
```

Please see the difference with example of #355.

@harshach @shahsank3t 
Please take a look. Please note that if we already use previous version of time-series DB topology metrics API, we should fix it to refer changed path.