### PR TITLE
STREAMLINE-560: Clusters shouldn't be deleted with an active environment

### DIFF
--- a/common/src/main/java/org/apache/streamline/common/exception/service/exception/request/BadRequestException.java
+++ b/common/src/main/java/org/apache/streamline/common/exception/service/exception/request/BadRequestException.java
@@ -16,6 +16,14 @@ public class BadRequestException extends WebServiceException {
     super(Response.Status.BAD_REQUEST, message, cause);
   }
 
+  public static BadRequestException message(String message) {
+    return new BadRequestException(message);
+  }
+
+  public static BadRequestException message(String message, Throwable cause) {
+    return new BadRequestException(message, cause);
+  }
+
   public static BadRequestException of() {
     return new BadRequestException(DEFAULT_MESSAGE);
   }


### PR DESCRIPTION
This patch is on top of STREAMLINE-525 (#349).

* check any namespaces refer such cluster before removing cluster
* check any topologies refer such namespace before removing namespace
* add integration tests