### PR TITLE
STREAMLINE-548 Send requests to AMS concurrently when querying time-series Topology Metrics or Component Stats

### DIFF
--- a/streams/service/src/main/java/org/apache/streamline/streams/service/MetricsResource.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/MetricsResource.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static javax.ws.rs.core.Response.Status.OK;
 
@@ -132,8 +133,8 @@ public class MetricsResource {
             topologyComponents.addAll(catalogService.listTopologyProcessors(queryParams));
             topologyComponents.addAll(catalogService.listTopologySinks(queryParams));
 
-            Map<String, TopologyTimeSeriesMetrics.TimeSeriesComponentMetric> topologyMetrics = new HashMap<>();
-            topologyComponents.stream().map(c -> {
+            Map<String, TopologyTimeSeriesMetrics.TimeSeriesComponentMetric> topologyMetrics = new ConcurrentHashMap<>();
+            topologyComponents.parallelStream().map(c -> {
                 try {
                     return Pair.of(c, catalogService.getComponentStats(topology, c, from, to));
                 } catch (IOException e) {


### PR DESCRIPTION
* use parallelStream() to handle querying time-series DB in parallel

> run with my laptop: availableProcessor = CPU 4 * hyperthreading (2) - 1 = 7 threads

```
DEBUG [2016-12-06 11:51:45,727] org.apache.streamline.streams.metrics.storm.ambari.AmbariMetricsServiceWithStormQuerier: Calling http://jlim-storm-3.openstacklocal:6188/ws/v1/timeline/metrics?appId=nimbus&hostname=&metricNames=topology.streamline-1-TopoTest.2-IDENTITY.%25.--fail-count.%25&startTime=1481025000&endTime=1481025094&seriesAggregateFunction=SUM for querying metric
DEBUG [2016-12-06 11:51:45,727] org.apache.streamline.streams.metrics.storm.ambari.AmbariMetricsServiceWithStormQuerier: Calling http://jlim-storm-3.openstacklocal:6188/ws/v1/timeline/metrics?appId=nimbus&hostname=&metricNames=topology.streamline-1-TopoTest.2-IDENTITY.%25.--execute-count.%25&startTime=1481025000&endTime=1481025094&seriesAggregateFunction=SUM for querying metric
DEBUG [2016-12-06 11:51:45,728] org.apache.streamline.streams.metrics.storm.ambari.AmbariMetricsServiceWithStormQuerier: Calling http://jlim-storm-3.openstacklocal:6188/ws/v1/timeline/metrics?appId=nimbus&hostname=&metricNames=topology.streamline-1-TopoTest.2-IDENTITY.%25.--ack-count.%25&startTime=1481025000&endTime=1481025094&seriesAggregateFunction=SUM for querying metric
DEBUG [2016-12-06 11:51:45,728] org.apache.streamline.streams.metrics.storm.ambari.AmbariMetricsServiceWithStormQuerier: Calling http://jlim-storm-3.openstacklocal:6188/ws/v1/timeline/metrics?appId=nimbus&hostname=&metricNames=topology.streamline-1-TopoTest.2-IDENTITY.%25.--emit-count.%25&startTime=1481025000&endTime=1481025094&seriesAggregateFunction=SUM for querying metric
DEBUG [2016-12-06 11:51:45,728] org.apache.streamline.streams.metrics.storm.ambari.AmbariMetricsServiceWithStormQuerier: Calling http://jlim-storm-3.openstacklocal:6188/ws/v1/timeline/metrics?appId=nimbus&hostname=&metricNames=topology.streamline-1-TopoTest.2-IDENTITY.%25.--process-latency.%25&startTime=1481025000&endTime=1481025094&seriesAggregateFunction=AVG for querying metric
DEBUG [2016-12-06 11:51:45,728] org.apache.streamline.streams.metrics.storm.ambari.AmbariMetricsServiceWithStormQuerier: Calling http://jlim-storm-3.openstacklocal:6188/ws/v1/timeline/metrics?appId=nimbus&hostname=&metricNames=topology.streamline-1-TopoTest.2-IDENTITY.%25.--receive.population&startTime=1481025000&endTime=1481025094&seriesAggregateFunction=AVG for querying metric
DEBUG [2016-12-06 11:51:46,414] org.apache.streamline.streams.metrics.storm.ambari.AmbariMetricsServiceWithStormQuerier: Calling http://jlim-storm-3.openstacklocal:6188/ws/v1/timeline/metrics?appId=nimbus&hostname=&metricNames=topology.streamline-1-TopoTest.1-SOURCE.%25.--fail-count.%25&startTime=1481025000&endTime=1481025094&seriesAggregateFunction=SUM for querying metric
DEBUG [2016-12-06 11:51:46,414] org.apache.streamline.streams.metrics.storm.ambari.AmbariMetricsServiceWithStormQuerier: Calling http://jlim-storm-3.openstacklocal:6188/ws/v1/timeline/metrics?appId=nimbus&hostname=&metricNames=topology.streamline-1-TopoTest.1-SOURCE.%25.--receive.population&startTime=1481025000&endTime=1481025094&seriesAggregateFunction=AVG for querying metric
DEBUG [2016-12-06 11:51:46,414] org.apache.streamline.streams.metrics.storm.ambari.AmbariMetricsServiceWithStormQuerier: Calling http://jlim-storm-3.openstacklocal:6188/ws/v1/timeline/metrics?appId=nimbus&hostname=&metricNames=topology.streamline-1-TopoTest.1-SOURCE.%25.--process-latency.%25&startTime=1481025000&endTime=1481025094&seriesAggregateFunction=AVG for querying metric
DEBUG [2016-12-06 11:51:46,414] org.apache.streamline.streams.metrics.storm.ambari.AmbariMetricsServiceWithStormQuerier: Calling http://jlim-storm-3.openstacklocal:6188/ws/v1/timeline/metrics?appId=nimbus&hostname=&metricNames=topology.streamline-1-TopoTest.1-SOURCE.%25.--emit-count.%25&startTime=1481025000&endTime=1481025094&seriesAggregateFunction=SUM for querying metric
DEBUG [2016-12-06 11:51:46,414] org.apache.streamline.streams.metrics.storm.ambari.AmbariMetricsServiceWithStormQuerier: Calling http://jlim-storm-3.openstacklocal:6188/ws/v1/timeline/metrics?appId=nimbus&hostname=&metricNames=topology.streamline-1-TopoTest.1-SOURCE.%25.--execute-count.%25&startTime=1481025000&endTime=1481025094&seriesAggregateFunction=SUM for querying metric
DEBUG [2016-12-06 11:51:46,414] org.apache.streamline.streams.metrics.storm.ambari.AmbariMetricsServiceWithStormQuerier: Calling http://jlim-storm-3.openstacklocal:6188/ws/v1/timeline/metrics?appId=nimbus&hostname=&metricNames=topology.streamline-1-TopoTest.1-SOURCE.%25.--ack-count.%25&startTime=1481025000&endTime=1481025094&seriesAggregateFunction=SUM for querying metric
0:0:0:0:0:0:0:1 - - [06/Dec/2016:11:51:46 +0000] "GET /api/v1/metrics/topologies/timeseries/1?from=1481025000&to=1481025094 HTTP/1.1" 200 317 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36" 2111
```

We can even increase the value `java.util.concurrent.ForkJoinPool.common.parallelism` to higher (multiple of available processors) if we restrict to use parallelStream() to I/O workloads.