### PR TITLE
STREAMLINE-536 Send requests to Ambari concurrently when importing cluster from Ambari

### DIFF
--- a/streams/cluster/src/main/java/org/apache/streamline/streams/cluster/discovery/ambari/ServiceConfigurations.java
+++ b/streams/cluster/src/main/java/org/apache/streamline/streams/cluster/discovery/ambari/ServiceConfigurations.java
@@ -25,4 +25,14 @@ public enum ServiceConfigurations {
   public String[] getConfNames() {
     return confNames;
   }
+
+  public static boolean contains(String serviceName) {
+    try {
+      ServiceConfigurations.valueOf(serviceName);
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+
+    return true;
+  }
 }


### PR DESCRIPTION
* use parallelStream() to handle querying Ambari REST API in parallel

Same enhancement on STREAMLINE-548 (#376). We're querying so many Ambari REST API during import Ambari cluster so this improvement is more efficient thing.