### PR TITLE
Remove streamline-sdk on test scope from webservice pom

### DIFF
--- a/webservice/pom.xml
+++ b/webservice/pom.xml
@@ -81,12 +81,6 @@
         <!-- test dependency -->
         <dependency>
             <groupId>org.apache.streamline</groupId>
-            <artifactId>streamline-sdk</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.streamline</groupId>
             <artifactId>streamline-examples-processors</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>


### PR DESCRIPTION
* It prevented running StreamlineApplication from IntelliJ and this patch fixes it

`streamline-sdk` is needed from compile scope. Why it was working well with Maven but it doesn't work with IntelliJ anyway. 

Please let me know if current pom works with IntelliJ or any IDEs on your development environment. 