### PR TITLE
STREAMLINE-579 Response for GET request of topology api returns data in old format

### DIFF
--- a/streams/service/src/main/java/org/apache/streamline/streams/service/TopologyCatalogResource.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/TopologyCatalogResource.java
@@ -139,9 +139,9 @@ public class TopologyCatalogResource {
     @Timed
     public Response getTopologyByIdAndVersion(@PathParam("topologyId") Long topologyId,
                                               @PathParam("versionId") Long versionId,
-                                              @javax.ws.rs.QueryParam("withMetric") Boolean withMetric,
+                                              @javax.ws.rs.QueryParam("detail") Boolean detail,
                                               @javax.ws.rs.QueryParam("latencyTopN") Integer latencyTopN) {
-        Response response = getTopologyByIdAndVersionId(topologyId, versionId, withMetric, latencyTopN);
+        Response response = getTopologyByIdAndVersionId(topologyId, versionId, detail, latencyTopN);
         if (response != null) {
             return response;
         }


### PR DESCRIPTION
* FIX: "/topologies/:topologyId/versions/:versionId" still uses withMetric instead of detail
  * kind of issues on works in parallel