### PR TITLE
Fix broken regex in streamline-server-start

### DIFF
--- a/bin/streamline-server-start.sh
+++ b/bin/streamline-server-start.sh
@@ -37,7 +37,7 @@ if [ ! -d "$LOG_DIR" ]; then
 fi
 
 # Exclude jars not necessary for running commands.
-regex="(-(test|src|javadoc|runtime-storm)\.jar|jar.asc)$"
+regex="\-(test|src|javadoc|runtime-storm).+(\.jar|\.jar\.asc)$"
 should_include_file() {
     if [ "$INCLUDE_TEST_JARS" = true ]; then
         return 0
@@ -58,6 +58,7 @@ do
     fi
 done
 
+echo "CLASSPATH: ${CLASSPATH}"
 
 COMMAND=$1
 case $COMMAND in


### PR DESCRIPTION
Before the fix, streamline-runtime-storm jar is included to the classpath whereas we should exclude this to the classpath.

How I found this: Starting streamline instance was failing because of HBase resource files which refers `jlim-hdp2-5-1.openstacklocal` in Storm runtime jar.

@harshach Please review this. Thanks.