### PR TITLE
STREAMLINE-591 add 'verify' API for Ambari REST API URL

### DIFF
--- a/streams/cluster/src/main/java/org/apache/streamline/streams/cluster/discovery/ambari/AmbariServiceNodeDiscoverer.java
+++ b/streams/cluster/src/main/java/org/apache/streamline/streams/cluster/discovery/ambari/AmbariServiceNodeDiscoverer.java
@@ -271,6 +271,12 @@ public class AmbariServiceNodeDiscoverer implements ServiceNodeDiscoverer {
     client = ClientBuilder.newClient(clientConfig);
   }
 
+  public void validateApiUrl() {
+    // just calling getServices() to retrieve service list from Ambari REST API
+    // it also parses the response, so if API is not valid, any exceptions should be thrown
+    getServices();
+  }
+
   @Provider
   public static class JsonToMapProvider implements MessageBodyReader<Map> {
     private ObjectMapper objectMapper = new ObjectMapper();


### PR DESCRIPTION
* URL PATH: /api/v1/catalog/cluster/import/ambari/verify/url
* METHOD: POST
* PARAM: same as Ambari cluster import API
* RESPONSE: 200 (verified) or others

@shahsank3t @harshach Please take a look. Thanks.

@shahsank3t Please call this API and check Ambari URL before calling cluster create API.