### PR TITLE
STREAMLINE-607 Clone topology should accept namespaceID

### DIFF
--- a/streams/catalog/src/main/java/org/apache/streamline/streams/catalog/service/StreamCatalogService.java
+++ b/streams/catalog/src/main/java/org/apache/streamline/streams/catalog/service/StreamCatalogService.java
@@ -1150,11 +1150,14 @@ public class StreamCatalogService {
         return newTopology;
     }
 
-    public Topology cloneTopology(Topology topology) throws Exception {
+    public Topology cloneTopology(Long namespaceId, Topology topology) throws Exception {
         Preconditions.checkNotNull(topology, "Topology does not exist");
         TopologyData exported = new TopologyData(doExportTopology(topology));
         exported.setTopologyName(exported.getTopologyName() + "-clone");
-        return importTopology(topology.getNamespaceId(), exported);
+        if (namespaceId == null) {
+            namespaceId = topology.getNamespaceId();
+        }
+        return importTopology(namespaceId, exported);
     }
 
     private void setUpExtraJars(Topology topology, TopologyActions topologyActions) throws IOException {

--- a/streams/service/src/main/java/org/apache/streamline/streams/service/TopologyCatalogResource.java
+++ b/streams/service/src/main/java/org/apache/streamline/streams/service/TopologyCatalogResource.java
@@ -47,6 +47,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.ByteArrayInputStream;
@@ -501,10 +502,10 @@ public class TopologyCatalogResource {
     @POST
     @Path("/topologies/{topologyId}/actions/clone")
     @Timed
-    public Response cloneTopology(@PathParam("topologyId") Long topologyId) throws Exception {
+    public Response cloneTopology(@PathParam("topologyId") Long topologyId, @QueryParam("namespaceId") Long namespaceId) throws Exception {
         Topology originalTopology = catalogService.getTopology(topologyId);
         if (originalTopology != null) {
-            Topology clonedTopology = catalogService.cloneTopology(originalTopology);
+            Topology clonedTopology = catalogService.cloneTopology(namespaceId, originalTopology);
             return WSUtils.respondEntity(clonedTopology, OK);
         }
 


### PR DESCRIPTION
* support query parameter 'namespaceId' to 'clone topology'

I add namespaceId to query parameter since adding it to path breaks the URL pattern on topology actions.

@shahsank3t @harshach Please take a look. Thanks.