### PR TITLE
STREAMLINE-610: Topology Flux doesn't associate a schemaRegistryUrl.

### DIFF
--- a/streams/catalog/src/main/java/org/apache/streamline/streams/catalog/container/TopologyActionsContainer.java
+++ b/streams/catalog/src/main/java/org/apache/streamline/streams/catalog/container/TopologyActionsContainer.java
@@ -89,6 +89,10 @@ public class TopologyActionsContainer extends NamespaceAwareContainer<TopologyAc
         conf.put(NIMBUS_PORT, String.valueOf(nimbusPort));
         conf.put(TopologyLayoutConstants.STORM_API_ROOT_URL_KEY, buildStormRestApiRootUrl(uiHost, uiPort));
 
+        // Topology during run-time will require few critical configs such as schemaRegistryUrl and catalogRootUrl
+        // Hence its important to pass StreamlineConfig to TopologyConfig
+        conf.putAll(streamlineConf);
+
         return conf;
     }
 


### PR DESCRIPTION
credit goes to @priyank5485

@priyank5485 @HeartSaVioR can you review this.