### PR TITLE
STREAMLINE-609 Creating entities for Source/Processor/Sink gives same id

### DIFF
--- a/bootstrap/sql/mysql/create_tables.sql
+++ b/bootstrap/sql/mysql/create_tables.sql
@@ -185,7 +185,7 @@ CREATE TABLE IF NOT EXISTS topology_components (
 );
 
 CREATE TABLE IF NOT EXISTS topology_sources (
-    id BIGINT AUTO_INCREMENT NOT NULL,
+    id BIGINT NOT NULL,
     versionId BIGINT NOT NULL,
     topologyId BIGINT NOT NULL,
     topologyComponentBundleId BIGINT NOT NULL,
@@ -205,7 +205,7 @@ CREATE TABLE IF NOT EXISTS topology_source_stream_mapping (
 );
 
 CREATE TABLE IF NOT EXISTS topology_sinks (
-    id BIGINT AUTO_INCREMENT NOT NULL,
+    id BIGINT NOT NULL,
     versionId BIGINT NOT NULL,
     topologyId BIGINT NOT NULL,
     topologyComponentBundleId BIGINT NOT NULL,
@@ -217,7 +217,7 @@ CREATE TABLE IF NOT EXISTS topology_sinks (
 );
 
 CREATE TABLE IF NOT EXISTS topology_processors (
-    id BIGINT AUTO_INCREMENT NOT NULL,
+    id BIGINT NOT NULL,
     versionId BIGINT NOT NULL,
     topologyId BIGINT NOT NULL,
     topologyComponentBundleId BIGINT NOT NULL,

--- a/streams/catalog/src/main/java/org/apache/streamline/streams/catalog/service/StreamCatalogService.java
+++ b/streams/catalog/src/main/java/org/apache/streamline/streams/catalog/service/StreamCatalogService.java
@@ -1650,7 +1650,7 @@ public class StreamCatalogService {
         component.setId(id);
         dao.add(component);
         dao.remove(component.getStorableKey());
-        return id;
+        return component.getId();
     }
 
     /*


### PR DESCRIPTION
* use generated ID instead of result of nextId
  * since it returns null on MySQL and source/processor/sink will use their own auto increment ID
* change ID to non-auto-increment for topology source/processor/sink tables
  * it would be better to raise error instead of having bad ID

@shahsank3t @harshach Please take a look. Thanks.