### PR TITLE
Reapply STREAMLINE-582 to streamline.yaml

### DIFF
--- a/conf/streamline.yaml
+++ b/conf/streamline.yaml
@@ -6,12 +6,9 @@ modules:
   - name: streams
     className: org.apache.streamline.streams.service.StreamsModule
     config:
-      topologyActionsImpl: org.apache.streamline.streams.layout.storm.StormTopologyActionsImpl
-      topologyMetricsImpl: org.apache.streamline.streams.metrics.storm.topology.StormTopologyMetricsImpl
       #change the below to the path on your local machine
       streamlineStormJar: /tmp/streamline-runtime-storm-0.1.0-SNAPSHOT.jar
       stormHomeDir: /usr/local/Cellar/storm/0.10.0/
-      stormApiRootUrl: "http://localhost:8888/api/v1"
       # schema registry configuration
       schemaRegistryUrl: "http://localhost:9090/api/v1"
       #Custom processor upload configuration


### PR DESCRIPTION
Don't know why it is rolled back only from streamline.yaml, but anyway it is needed to prevent the bug due to refer Storm API URL local configuration.