### PR TITLE
Quick Fix: wrong file name for model registry storables props

### DIFF
--- a/registries/model-registry/src/main/java/org/apache/streamline/registries/model/service/MLModelRegistryService.java
+++ b/registries/model-registry/src/main/java/org/apache/streamline/registries/model/service/MLModelRegistryService.java
@@ -156,7 +156,7 @@ public final class MLModelRegistryService {
     }
 
     private static Collection<Class<? extends Storable>> getStorableClasses() {
-        InputStream resourceAsStream = MLModelRegistryService.class.getClassLoader().getResourceAsStream("mlmodelregistrystorables.props");
+        InputStream resourceAsStream = MLModelRegistryService.class.getClassLoader().getResourceAsStream("modelregistrystorables.props");
         HashSet<Class<? extends Storable>> classes = new HashSet<>();
         try {
             List<String> classNames = IOUtils.readLines(resourceAsStream, Charset.defaultCharset());


### PR DESCRIPTION
Webservice got NPE due to reading non-existing file and not started. Prop file name is wrong.