### PR TITLE
STREAMLINE-632 Remove dependency between streamline-catalog and streamline-runtime

### DIFF
--- a/streams/common/pom.xml
+++ b/streams/common/pom.xml
@@ -16,6 +16,10 @@
             <artifactId>streamline-sdk</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.streamline</groupId>
             <artifactId>common</artifactId>
         </dependency>

--- a/streams/common/src/main/java/org/apache/streamline/streams/common/utils/CatalogRestClient.java
+++ b/streams/common/src/main/java/org/apache/streamline/streams/common/utils/CatalogRestClient.java
@@ -16,20 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.streamline.streams.catalog;
+package org.apache.streamline.streams.common.utils;
 
-import org.apache.streamline.common.JsonClientUtil;
-import org.apache.streamline.common.exception.WrappedWebApplicationException;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import java.io.InputStream;
-import java.util.List;
 
 /**
  * TODO: All the configs should be read from some config file.
@@ -54,11 +49,6 @@ public class CatalogRestClient {
         client.register(MultiPartFeature.class);
     }
 
-    public NotifierInfo getNotifierInfo(String notifierName) {
-        return getEntities(client.target(String.format("%s/%s/?name=%s", rootCatalogURL, NOTIFIER_URL, notifierName)),
-                            NotifierInfo.class).get(0);
-    }
-
     public InputStream getFile(Long jarId) {
         return getInputStream(jarId.toString(), FILE_DOWNLOAD_URL);
     }
@@ -71,9 +61,5 @@ public class CatalogRestClient {
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }
-    }
-
-    private <T> List<T> getEntities(WebTarget target, Class<T> clazz) {
-        return JsonClientUtil.getEntities(target, "entities", clazz);
     }
 }

--- a/streams/runtime/pom.xml
+++ b/streams/runtime/pom.xml
@@ -22,20 +22,6 @@
             <artifactId>streamline-layout</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.streamline</groupId>
-            <artifactId>streamline-catalog</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.streamline</groupId>
-                    <artifactId>storage-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.streamline</groupId>
-                    <artifactId>tag-registry</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/streams/runtime/src/main/java/org/apache/streamline/streams/runtime/splitjoin/AbstractSplitJoinActionRuntime.java
+++ b/streams/runtime/src/main/java/org/apache/streamline/streams/runtime/splitjoin/AbstractSplitJoinActionRuntime.java
@@ -20,7 +20,7 @@ package org.apache.streamline.streams.runtime.splitjoin;
 
 import org.apache.streamline.common.Constants;
 import org.apache.streamline.common.util.ProxyUtil;
-import org.apache.streamline.streams.catalog.CatalogRestClient;
+import org.apache.streamline.streams.common.utils.CatalogRestClient;
 import org.apache.streamline.streams.layout.component.rule.action.Action;
 import org.apache.streamline.streams.runtime.rule.action.AbstractActionRuntime;
 import org.apache.streamline.streams.runtime.rule.action.ActionRuntime;

--- a/streams/runtime/src/test/java/org/apache/streamline/streams/runtime/splitjoin/SplitJoinTest.java
+++ b/streams/runtime/src/test/java/org/apache/streamline/streams/runtime/splitjoin/SplitJoinTest.java
@@ -23,7 +23,7 @@ import com.google.common.collect.Sets;
 import org.apache.streamline.common.Constants;
 import org.apache.streamline.streams.StreamlineEvent;
 import org.apache.streamline.streams.Result;
-import org.apache.streamline.streams.catalog.CatalogRestClient;
+import org.apache.streamline.streams.common.utils.CatalogRestClient;
 import org.apache.streamline.streams.common.StreamlineEventImpl;
 import org.apache.streamline.streams.layout.Transform;
 import org.apache.streamline.streams.layout.component.impl.splitjoin.JoinAction;


### PR DESCRIPTION
* streamline-runtime and dependents refer streamline-catalog only because of CatalogRestClient
  * referring streamline-catalog brings numerous transitive dependencies
  * so try to avoid it
* Move CatalogRestClient to streamline-common