### PR TITLE
STREAMLINE-641: Exception thrown while exporting a topology containing a rule

### DIFF
--- a/streams/catalog/src/main/java/org/apache/streamline/streams/catalog/RuleInfo.java
+++ b/streams/catalog/src/main/java/org/apache/streamline/streams/catalog/RuleInfo.java
@@ -218,7 +218,11 @@ public class RuleInfo extends AbstractStorable {
     @JsonIgnore
     public Rule getRule() throws IOException {
         ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(getParsedRuleStr(), Rule.class);
+        Rule rule = mapper.readValue(getParsedRuleStr(), Rule.class);
+        if (rule.getId() == null) {
+            rule.setId(getId());
+        }
+        return rule;
     }
 
     public Window getWindow() {


### PR DESCRIPTION
parsedRuleString does not have ID set since nextId now returns 'null' for mysql. Modified RuleInfo.getRule() to fill the rule id.