### PR TITLE
Add Latitude Longitude Linear prediction pmml example

### DIFF
--- a/examples/mlmodel/pom.xml
+++ b/examples/mlmodel/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>streamline</artifactId>
+        <groupId>org.apache.streamline</groupId>
+        <version>0.1.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>streamline-examples-mlmodel</artifactId>
+    <packaging>jar</packaging>
+</project>

--- a/examples/mlmodel/src/resources/latlong-prediction.xml
+++ b/examples/mlmodel/src/resources/latlong-prediction.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<PMML version="4.1" xmlns="http://www.dmg.org/PMML-4_1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.dmg.org/PMML-4_1 http://www.dmg.org/v4-1/pmml-4-1.xsd">
+ <Header copyright="Copyright (c) 2017 schendamaraikannan" description="Linear Regression Model">
+  <Extension name="user" value="schendamaraikannan" extender="RR/PMML"/>
+  <Application name="RR/PMML" version="1.4"/>
+  <Timestamp>2017-01-05 10:49:33</Timestamp>
+ </Header>
+ <DataDictionary numberOfFields="2">
+  <DataField name="latitude" optype="continuous" dataType="double"/>
+  <DataField name="longitude" optype="continuous" dataType="double"/>
+ </DataDictionary>
+ <RegressionModel modelName="LatLongLM" functionName="regression" algorithmName="least squares">
+  <MiningSchema>
+   <MiningField name="latitude" usageType="predicted"/>
+   <MiningField name="longitude" usageType="active"/>
+  </MiningSchema>
+  <Output>
+   <OutputField name="Predicted_latitude" feature="predictedValue"/>
+  </Output>
+  <RegressionTable intercept="72.3115883524567">
+   <NumericPredictor name="longitude" exponent="1" coefficient="0.369252253452929"/>
+  </RegressionTable>
+ </RegressionModel>
+</PMML>


### PR DESCRIPTION
This is a simple linear regression based model, that predicts latitude of a particular truck driver given the longitude. I have trained it for a single truck driver. The demo can be used as an example to predict missing data if any (Latitude or Longitude) from the truckers csv.