### PR TITLE
STREAMLINE-648: Made StreamlineEvent immutable w.r.t fieldsAndValues

### DIFF
--- a/streams/common/src/main/java/com/hortonworks/streamline/streams/common/StreamlineEventImpl.java
+++ b/streams/common/src/main/java/com/hortonworks/streamline/streams/common/StreamlineEventImpl.java
@@ -211,28 +211,28 @@ public final class StreamlineEventImpl extends ForwardingMap<String, Object> imp
      * {@inheritDoc}
      */
     public final Object put(String k, Object v) {
-        return super.put(k, v);
+        return StreamlineEvent.super.put(k, v);
     }
 
     /**
      * {@inheritDoc}
      */
     public final Object remove(Object o) {
-        return super.remove(o);
+        return StreamlineEvent.super.remove(o);
     }
 
     /**
      * {@inheritDoc}
      */
     public final void putAll(Map<? extends String, ? extends Object> map) {
-        super.putAll(map);
+        StreamlineEvent.super.putAll(map);
     }
 
     /**
      * {@inheritDoc}
      */
     public final void clear() {
-        super.clear();
+        StreamlineEvent.super.clear();
     }
 
 

--- a/streams/common/src/test/java/com/hortonworks/streamline/streams/common/StreamlineEventImplTest.java
+++ b/streams/common/src/test/java/com/hortonworks/streamline/streams/common/StreamlineEventImplTest.java
@@ -4,7 +4,9 @@ import com.hortonworks.streamline.streams.StreamlineEvent;
 import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
 
@@ -89,5 +91,54 @@ public class StreamlineEventImplTest {
         StreamlineEvent event2 = new StreamlineEventImpl(map, StringUtils.EMPTY, event1.getId());
 
         assertEquals(event1.hashCode(), event2.hashCode());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testPut() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("foo", "bar");
+
+        StreamlineEvent event = new StreamlineEventImpl(map, StringUtils.EMPTY);
+        event.put("key", "val");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testClear() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("foo", "bar");
+
+        StreamlineEvent event = new StreamlineEventImpl(map, StringUtils.EMPTY);
+        event.clear();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testPutAll() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("foo", "bar");
+
+        StreamlineEvent event = new StreamlineEventImpl(Collections.emptyMap(), StringUtils.EMPTY);
+        event.putAll(map);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRemove() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("foo", "bar");
+
+        StreamlineEvent event = new StreamlineEventImpl(Collections.emptyMap(), StringUtils.EMPTY);
+        event.remove("foo");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRemoveIterator() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("foo", "bar");
+
+        StreamlineEvent event = new StreamlineEventImpl(map, StringUtils.EMPTY);
+        Iterator<Map.Entry<String, Object>> it = event.entrySet().iterator();
+        while(it.hasNext()) {
+            it.next();
+            it.remove();
+        }
     }
 }

--- a/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/DruidEventMapper.java
+++ b/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/DruidEventMapper.java
@@ -18,9 +18,9 @@
  */
 package com.hortonworks.streamline.streams.layout.storm;
 
+import com.hortonworks.streamline.streams.StreamlineEvent;
 import org.apache.storm.druid.bolt.ITupleDruidEventMapper;
 import org.apache.storm.tuple.ITuple;
-import org.apache.streamline.streams.StreamlineEvent;
 
 import java.util.Map;
 

--- a/streams/sdk/src/main/java/com/hortonworks/streamline/streams/StreamlineEvent.java
+++ b/streams/sdk/src/main/java/com/hortonworks/streamline/streams/StreamlineEvent.java
@@ -119,7 +119,9 @@ public interface StreamlineEvent  extends Map<String,Object> {
      */
     @Deprecated
     @Override
-    Object put(String k, Object v);
+    default Object put(String k, Object v) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Guaranteed to throw an exception and leave the map unmodified.
@@ -129,7 +131,9 @@ public interface StreamlineEvent  extends Map<String,Object> {
      */
     @Deprecated
     @Override
-    Object remove(Object o);
+    default Object remove(Object o) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Guaranteed to throw an exception and leave the map unmodified.
@@ -139,7 +143,9 @@ public interface StreamlineEvent  extends Map<String,Object> {
      */
     @Deprecated
     @Override
-    void putAll(Map<? extends String, ? extends Object> map);
+    default void putAll(Map<? extends String, ? extends Object> map) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Guaranteed to throw an exception and leave the map unmodified.
@@ -149,6 +155,8 @@ public interface StreamlineEvent  extends Map<String,Object> {
      */
     @Deprecated
     @Override
-    void clear();
+    default void clear() {
+        throw new UnsupportedOperationException();
+    }
 
 }


### PR DESCRIPTION
Made StreamlineEvent immutable w.r.t fieldsAndValues and updated DruidEventMapper.

Headers and auxiliary key-values are still mutable. This can be done in a followup task.