### PR TITLE
STREAMLINE-673 Cluster: use 'ID' and 'name + url' as unique identifier

### DIFF
--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/Cluster.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/Cluster.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.hortonworks.streamline.common.Schema;
 import com.hortonworks.streamline.storage.PrimaryKey;
 import com.hortonworks.streamline.storage.catalog.AbstractStorable;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -75,6 +76,14 @@ public class Cluster extends AbstractStorable {
 
     public void setTimestamp(Long timestamp) {
         this.timestamp = timestamp;
+    }
+
+    @JsonIgnore
+    public String getNameWithImportUrl() {
+        if (StringUtils.isEmpty(ambariImportUrl)) {
+            return name + " []";
+        }
+        return name + " [" + ambariImportUrl + "]";
     }
 
     @JsonIgnore

--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/service/EnvironmentService.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/service/EnvironmentService.java
@@ -111,10 +111,11 @@ public class EnvironmentService {
         return this.dao.get(new StorableKey(CLUSTER_NAMESPACE, cluster.getPrimaryKey()));
     }
 
-    public Cluster getClusterByName(String clusterName) {
-        Collection<Cluster> clusters = listClusters(Lists.newArrayList(new QueryParam("name", clusterName)));
+    public Cluster getClusterByNameAndImportUrl(String clusterName, String ambariImportUrl) {
+        Collection<Cluster> clusters = listClusters(
+                Lists.newArrayList(new QueryParam("name", clusterName), new QueryParam("ambariImportUrl", ambariImportUrl)));
         if (clusters.size() > 1) {
-            LOG.warn("Multiple Clusters have same name: {} returning first match.", clusterName);
+            LOG.warn("Multiple Clusters have same name {} and import url {} : returning first match.", clusterName, ambariImportUrl);
             return clusters.iterator().next();
         } else if (clusters.size() == 1) {
             return clusters.iterator().next();
@@ -330,49 +331,6 @@ public class EnvironmentService {
         }
         this.dao.addOrUpdate(serviceConfiguration);
         return serviceConfiguration;
-    }
-
-    public Map<String, Object> getDeserializedConfiguration(String clusterName, String serviceName,
-                                                            String serviceConfiguraionName) throws IOException {
-        Cluster cluster = getClusterByName(clusterName);
-        if (cluster == null) {
-            return null;
-        }
-
-        Service service = getServiceByName(cluster.getId(), serviceName);
-        if (service == null) {
-            return null;
-        }
-
-        ServiceConfiguration serviceConfiguration = getServiceConfigurationByName(service.getId(), serviceConfiguraionName);
-        if (serviceConfiguration == null) {
-            return null;
-        }
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        return objectMapper.readValue(serviceConfiguration.getConfiguration(), Map.class);
-    }
-
-    public Object lookupConfiguration(String clusterName, String serviceName,
-                                      String serviceConfiguraionName, String configKey) throws IOException {
-        Cluster cluster = getClusterByName(clusterName);
-        if (cluster == null) {
-            return null;
-        }
-
-        Service service = getServiceByName(cluster.getId(), serviceName);
-        if (service == null) {
-            return null;
-        }
-
-        ServiceConfiguration serviceConfiguration = getServiceConfigurationByName(service.getId(), serviceConfiguraionName);
-        if (serviceConfiguration == null) {
-            return null;
-        }
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        Map<String, Object> conf = objectMapper.readValue(serviceConfiguration.getConfiguration(), Map.class);
-        return conf.get(configKey);
     }
 
     public Collection<Namespace> listNamespaces() {

--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/topology/component/bundle/AbstractBundleHintProvider.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/topology/component/bundle/AbstractBundleHintProvider.java
@@ -15,14 +15,15 @@ public abstract class AbstractBundleHintProvider implements ComponentBundleHintP
 
     protected EnvironmentService environmentService;
 
+
     @Override
     public void init(EnvironmentService environmentService) {
         this.environmentService = environmentService;
     }
 
     @Override
-    public Map<String, Map<String, Object>> provide(Namespace namespace) {
-        Map<String, Map<String, Object>> hintMap = new HashMap<>();
+    public Map<Long, BundleHintsResponse> provide(Namespace namespace) {
+        Map<Long, BundleHintsResponse> hintMap = new HashMap<>();
 
         Collection<NamespaceServiceClusterMapping> serviceMappings = environmentService.listServiceClusterMapping(
                 namespace.getId(), getServiceName());
@@ -33,7 +34,8 @@ public abstract class AbstractBundleHintProvider implements ComponentBundleHintP
                 throw new RuntimeException(new ClusterNotFoundException(clusterId));
             }
 
-            hintMap.put(cluster.getName(), getHintsOnCluster(cluster));
+            BundleHintsResponse response = new BundleHintsResponse(cluster, getHintsOnCluster(cluster));
+            hintMap.put(clusterId, response);
         }
 
         return hintMap;

--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/topology/component/bundle/ComponentBundleHintProvider.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/topology/component/bundle/ComponentBundleHintProvider.java
@@ -1,5 +1,6 @@
 package com.hortonworks.streamline.streams.catalog.topology.component.bundle;
 
+import com.hortonworks.streamline.streams.catalog.Cluster;
 import com.hortonworks.streamline.streams.catalog.Namespace;
 import com.hortonworks.streamline.streams.catalog.service.EnvironmentService;
 import com.hortonworks.streamline.streams.catalog.service.StreamCatalogService;
@@ -14,6 +15,24 @@ import java.util.Map;
  * mapped to namespace 'env1' and provide that values to be used as hint.
  */
 public interface ComponentBundleHintProvider {
+    class BundleHintsResponse {
+        private Cluster cluster;
+        private Map<String, Object> hints;
+
+        public BundleHintsResponse(Cluster cluster, Map<String, Object> hints) {
+            this.cluster = cluster;
+            this.hints = hints;
+        }
+
+        public Cluster getCluster() {
+            return cluster;
+        }
+
+        public Map<String, Object> getHints() {
+            return hints;
+        }
+    }
+
     /**
      * Initialize provider.
      *
@@ -25,7 +44,7 @@ public interface ComponentBundleHintProvider {
      * Provide hints on specific component bundle with selected namespace.
      *
      * @param namespace selected namespace
-     * @return Hint structures. The structure of map should be cluster name -> field name -> values.
+     * @return Hint structures. The structure of map should be cluster id -> (cluster, hints).
      */
-    Map<String, Map<String, Object>> provide(Namespace namespace);
+    Map<Long, BundleHintsResponse> provide(Namespace namespace);
 }

--- a/streams/catalog/src/test/java/com/hortonworks/streamline/streams/catalog/topology/component/bundle/AbstractBundleHintProviderTest.java
+++ b/streams/catalog/src/test/java/com/hortonworks/streamline/streams/catalog/topology/component/bundle/AbstractBundleHintProviderTest.java
@@ -73,11 +73,14 @@ public class AbstractBundleHintProviderTest {
         Namespace namespace = new Namespace();
         namespace.setId(TEST_NAMESPACE_ID);
 
-        Map<String, Map<String, Object>> hints = provider.provide(namespace);
+        Map<Long, ComponentBundleHintProvider.BundleHintsResponse> hints = provider.provide(namespace);
         Assert.assertEquals(3, hints.size());
-        Assert.assertEquals(TEST_HINTS, hints.get(cluster1.getName()));
-        Assert.assertEquals(TEST_HINTS, hints.get(cluster2.getName()));
-        Assert.assertEquals(TEST_HINTS, hints.get(cluster3.getName()));
+        Assert.assertEquals(cluster1, hints.get(cluster1.getId()).getCluster());
+        Assert.assertEquals(TEST_HINTS, hints.get(cluster1.getId()).getHints());
+        Assert.assertEquals(cluster2, hints.get(cluster2.getId()).getCluster());
+        Assert.assertEquals(TEST_HINTS, hints.get(cluster2.getId()).getHints());
+        Assert.assertEquals(cluster3, hints.get(cluster3.getId()).getCluster());
+        Assert.assertEquals(TEST_HINTS, hints.get(cluster3.getId()).getHints());
     }
 
     private Cluster createDummyCluster(long id, String clusterName) {

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/ClusterCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/ClusterCatalogResource.java
@@ -114,27 +114,15 @@ public class ClusterCatalogResource {
         throw EntityNotFoundException.byId(clusterId.toString());
     }
 
-    @GET
-    @Path("/clusters/name/{clusterName}")
-    @Timed
-    public Response getClusterByName(@PathParam("clusterName") String clusterName,
-                                     @javax.ws.rs.QueryParam("detail") Boolean detail) {
-        Cluster result = environmentService.getClusterByName(clusterName);
-        if (result != null) {
-            return buildClusterGetResponse(result, detail);
-        }
-
-        throw EntityNotFoundException.byName(clusterName);
-    }
-
     @Timed
     @POST
     @Path("/clusters")
     public Response addCluster(Cluster cluster) {
         String clusterName = cluster.getName();
-        Cluster result = environmentService.getClusterByName(clusterName);
+        String ambariImportUrl = cluster.getAmbariImportUrl();
+        Cluster result = environmentService.getClusterByNameAndImportUrl(clusterName, ambariImportUrl);
         if (result != null) {
-            throw EntityAlreadyExistsException.byName(clusterName);
+            throw EntityAlreadyExistsException.byName(cluster.getNameWithImportUrl());
         }
 
         Cluster createdCluster = environmentService.addCluster(cluster);

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/ComponentCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/ComponentCatalogResource.java
@@ -56,34 +56,6 @@ public class ComponentCatalogResource {
         throw EntityNotFoundException.byFilter(queryParams.toString());
     }
 
-    /**
-     * List ALL components or the ones matching specific query params.
-     */
-    @GET
-    @Path("/clusters/name/{clusterName}/services/name/{serviceName}/components")
-    @Timed
-    public Response listComponentsByName(@PathParam("clusterName") String clusterName,
-        @PathParam("serviceName") String serviceName, @Context UriInfo uriInfo) {
-        Cluster cluster = environmentService.getClusterByName(clusterName);
-        if (cluster == null) {
-            throw EntityNotFoundException.byName("cluster name " + clusterName);
-        }
-
-        Service service = environmentService.getServiceByName(cluster.getId(), serviceName);
-        if (service == null) {
-            throw EntityNotFoundException.byName("service name " + serviceName);
-        }
-
-        List<QueryParam> queryParams = buildServiceIdAwareQueryParams(service.getId(), uriInfo);
-
-        Collection<Component> components = environmentService.listComponents(queryParams);
-        if (components != null) {
-            return WSUtils.respondEntities(components, OK);
-        }
-
-        throw EntityNotFoundException.byFilter(queryParams.toString());
-    }
-
     @GET
     @Path("/services/{serviceId}/components/{id}")
     @Timed
@@ -97,30 +69,6 @@ public class ComponentCatalogResource {
         }
 
         throw EntityNotFoundException.byId(buildMessageForCompositeId(serviceId, componentId));
-    }
-
-    @GET
-    @Path("/clusters/name/{clusterName}/services/name/{serviceName}/components/name/{componentName}")
-    @Timed
-    public Response getComponentByName(@PathParam("clusterName") String clusterName,
-        @PathParam("serviceName") String serviceName, @PathParam("componentName") String componentName) {
-        Cluster cluster = environmentService.getClusterByName(clusterName);
-        if (cluster == null) {
-            throw EntityNotFoundException.byName("cluster name " + clusterName);
-        }
-
-        Service service = environmentService.getServiceByName(cluster.getId(), serviceName);
-        if (service == null) {
-            throw EntityNotFoundException.byName("service name " + serviceName);
-        }
-
-        Component component = environmentService.getComponentByName(service.getId(), componentName);
-        if (component != null) {
-            return WSUtils.respondEntity(component, OK);
-        }
-
-        throw EntityNotFoundException.byName(buildMessageForCompositeName(clusterName,
-            serviceName, componentName));
     }
 
     @POST
@@ -203,11 +151,4 @@ public class ComponentCatalogResource {
         return String.format("service id <%d>, component id <%d>",
                 serviceId, componentId);
     }
-
-    private String buildMessageForCompositeName(String clusterName, String serviceName,
-        String componentName) {
-        return String.format("cluster name <%s>, service name <%s>, component name <%s>",
-            clusterName, serviceName, componentName);
-    }
-
 }

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/ServiceCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/ServiceCatalogResource.java
@@ -58,28 +58,6 @@ public class ServiceCatalogResource {
         throw EntityNotFoundException.byFilter(queryParams.toString());
     }
 
-    /**
-     * List ALL services or the ones matching specific query params.
-     */
-    @GET
-    @Path("/clusters/name/{clusterName}/services")
-    @Timed
-    public Response listServicesByName(@PathParam("clusterName") String clusterName, @Context UriInfo uriInfo) {
-        Cluster cluster = environmentService.getClusterByName(clusterName);
-        if (cluster == null) {
-            throw EntityNotFoundException.byName("cluster name " + clusterName);
-        }
-
-        List<QueryParam> queryParams = buildClusterIdAwareQueryParams(cluster.getId(), uriInfo);
-        Collection<Service> services;
-        services = environmentService.listServices(queryParams);
-        if (services != null) {
-            return WSUtils.respondEntities(services, OK);
-        }
-
-        throw EntityNotFoundException.byFilter(queryParams.toString());
-    }
-
     @GET
     @Path("/clusters/{clusterId}/services/{id}")
     @Timed
@@ -93,24 +71,6 @@ public class ServiceCatalogResource {
         }
 
         throw EntityNotFoundException.byId(buildMessageForCompositeId(clusterId, serviceId));
-    }
-
-    @GET
-    @Path("/clusters/name/{clusterName}/services/name/{serviceName}")
-    @Timed
-    public Response getServiceByName(@PathParam("clusterName") String clusterName,
-        @PathParam("serviceName") String serviceName) {
-        Cluster cluster = environmentService.getClusterByName(clusterName);
-        if (cluster == null) {
-            throw EntityNotFoundException.byName("cluster name " + clusterName);
-        }
-
-        Service result = environmentService.getServiceByName(cluster.getId(), serviceName);
-        if (result != null) {
-            return WSUtils.respondEntity(result, OK);
-        }
-
-        throw EntityNotFoundException.byId(buildMessageForCompositeName(clusterName, serviceName));
     }
 
     @Timed
@@ -181,11 +141,6 @@ public class ServiceCatalogResource {
     private String buildMessageForCompositeId(Long clusterId, Long serviceId) {
         return String.format("cluster id <%d>, service id <%d>",
             clusterId, serviceId);
-    }
-
-    private String buildMessageForCompositeName(String clusterName, String serviceName) {
-        return String.format("cluster name <%s>, service name <%s>",
-            clusterName, serviceName);
     }
 
 }

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/ServiceConfigurationCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/ServiceConfigurationCatalogResource.java
@@ -55,34 +55,6 @@ public class ServiceConfigurationCatalogResource {
         throw EntityNotFoundException.byFilter(queryParams.toString());
     }
 
-    /**
-     * List ALL configurations or the ones matching specific query params.
-     */
-    @GET
-    @Path("/clusters/name/{clusterName}/services/name/{serviceName}/configurations")
-    @Timed
-    public Response listServiceConfigurationsByName(@PathParam("clusterName") String clusterName,
-        @PathParam("serviceName") String serviceName, @Context UriInfo uriInfo) {
-        Cluster cluster = environmentService.getClusterByName(clusterName);
-        if (cluster == null) {
-            throw EntityNotFoundException.byName("cluster name " + clusterName);
-        }
-
-        Service service = environmentService.getServiceByName(cluster.getId(), serviceName);
-        if (service == null) {
-            throw EntityNotFoundException.byName("service name " + serviceName);
-        }
-
-        List<QueryParam> queryParams = buildServiceIdAwareQueryParams(service.getId(), uriInfo);
-
-        Collection<ServiceConfiguration> configurations = environmentService.listServiceConfigurations(queryParams);
-        if (configurations != null) {
-            return WSUtils.respondEntities(configurations, OK);
-        }
-
-        throw EntityNotFoundException.byFilter(queryParams.toString());
-    }
-
     @GET
     @Path("/services/{serviceId}/configurations/{id}")
     @Timed
@@ -96,29 +68,6 @@ public class ServiceConfigurationCatalogResource {
         }
 
         throw EntityNotFoundException.byId(buildMessageForCompositeId(serviceId, configurationId));
-    }
-
-    @GET
-    @Path("/clusters/name/{clusterName}/services/name/{serviceName}/configurations/name/{configurationName}")
-    @Timed
-    public Response getConfigurationByName(@PathParam("clusterName") String clusterName,
-        @PathParam("serviceName") String serviceName, @PathParam("configurationName") String configurationName) {
-        Cluster cluster = environmentService.getClusterByName(clusterName);
-        if (cluster == null) {
-            throw EntityNotFoundException.byName("cluster name " + clusterName);
-        }
-
-        Service service = environmentService.getServiceByName(cluster.getId(), serviceName);
-        if (service == null) {
-            throw EntityNotFoundException.byName("service name " + serviceName);
-        }
-
-        ServiceConfiguration configuration = environmentService.getServiceConfigurationByName(service.getId(), configurationName);
-        if (configuration != null) {
-            return WSUtils.respondEntity(configuration, OK);
-        }
-
-        throw EntityNotFoundException.byName(buildMessageForCompositeName(clusterName, serviceName, configurationName));
     }
 
     @POST
@@ -203,12 +152,6 @@ public class ServiceConfigurationCatalogResource {
     private String buildMessageForCompositeId(Long serviceId, Long serviceConfigurationId) {
         return String.format("service id <%d>, configuration id <%d>",
                 serviceId, serviceConfigurationId);
-    }
-
-    private String buildMessageForCompositeName(String clusterName, String serviceName,
-        String serviceConfigurationName) {
-        return String.format("cluster name <%s>, service name <%s>, configuration name <%s>",
-            clusterName, serviceName, serviceConfigurationName);
     }
 
 }

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyComponentBundleResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyComponentBundleResource.java
@@ -418,7 +418,7 @@ public class TopologyComponentBundleResource {
                 throw EntityNotFoundException.byId("namespace id: " + namespaceId);
             }
 
-            Map<String, Map<String, Object>> hints = provider.provide(namespace);
+            Map<Long, ComponentBundleHintProvider.BundleHintsResponse> hints = provider.provide(namespace);
             return WSUtils.respondEntity(hints, OK);
         } else {
             return WSUtils.respondEntity(Collections.emptyMap(), OK);

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/metadata/HBaseMetadataResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/metadata/HBaseMetadataResource.java
@@ -30,18 +30,6 @@ public class HBaseMetadataResource {
     }
 
     @GET
-    @Path("/clusters/name/{clusterName}/services/hbase/namespaces")
-    @Timed
-    public Response getNamespacesByClusterName(@PathParam("clusterName") String clusterName)
-        throws Exception {
-        final Cluster cluster = environmentService.getClusterByName(clusterName);
-        if (cluster == null) {
-            throw com.hortonworks.streamline.common.exception.service.exception.request.EntityNotFoundException.byName("cluster name " + clusterName);
-        }
-        return getNamespacesByClusterId(cluster.getId());
-    }
-
-    @GET
     @Path("/clusters/{clusterId}/services/hbase/namespaces")
     @Timed
     public Response getNamespacesByClusterId(@PathParam("clusterId") Long clusterId)
@@ -56,18 +44,6 @@ public class HBaseMetadataResource {
     // ===
 
     @GET
-    @Path("/clusters/name/{clusterName}/services/hbase/tables")
-    @Timed
-    public Response getTablesByClusterName(@PathParam("clusterName") String clusterName)
-        throws Exception {
-        final Cluster cluster = environmentService.getClusterByName(clusterName);
-        if (cluster == null) {
-            throw com.hortonworks.streamline.common.exception.service.exception.request.EntityNotFoundException.byName(clusterName);
-        }
-        return getTablesByClusterId(cluster.getId());
-    }
-
-    @GET
     @Path("/clusters/{clusterId}/services/hbase/tables")
     @Timed
     public Response getTablesByClusterId(@PathParam("clusterId") Long clusterId) throws Exception {
@@ -79,18 +55,6 @@ public class HBaseMetadataResource {
     }
 
     // ===
-
-    @GET
-    @Path("/clusters/name/{clusterName}/services/hbase/namespaces/{namespace}/tables")
-    @Timed
-    public Response getNamespaceTablesByClusterName(@PathParam("clusterName") String clusterName, @PathParam("namespace") String namespace)
-        throws Exception {
-        final Cluster cluster = environmentService.getClusterByName(clusterName);
-        if (cluster == null) {
-            throw com.hortonworks.streamline.common.exception.service.exception.request.EntityNotFoundException.byName(clusterName);
-        }
-        return getNamespaceTablesByClusterId(cluster.getId(), namespace);
-    }
 
     @GET
     @Path("/clusters/{clusterId}/services/hbase/namespaces/{namespace}/tables")

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/metadata/HiveMetadataResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/metadata/HiveMetadataResource.java
@@ -28,18 +28,6 @@ public class HiveMetadataResource {
     }
 
     @GET
-    @Path("/clusters/name/{clusterName}/services/hive/databases")
-    @Timed
-    public Response getDatabasesByClusterName(@PathParam("clusterName") String clusterName)
-        throws Exception {
-        final Cluster cluster = environmentService.getClusterByName(clusterName);
-        if (cluster == null) {
-            throw com.hortonworks.streamline.common.exception.service.exception.request.EntityNotFoundException.byName("cluster name " + clusterName);
-        }
-        return getDatabasesByClusterId(cluster.getId());
-    }
-
-    @GET
     @Path("/clusters/{clusterId}/services/hive/databases")
     @Timed
     public Response getDatabasesByClusterId(@PathParam("clusterId") Long clusterId)
@@ -49,18 +37,6 @@ public class HiveMetadataResource {
         } catch (EntityNotFoundException ex) {
             throw com.hortonworks.streamline.common.exception.service.exception.request.EntityNotFoundException.byId(ex.getMessage());
         }
-    }
-
-    @GET
-    @Path("/clusters/name/{clusterName}/services/hive/databases/{dbName}/tables")
-    @Timed
-    public Response getDatabaseTablesByClusterName(@PathParam("clusterName") String clusterName, @PathParam("dbName") String dbName)
-        throws Exception {
-        final Cluster cluster = environmentService.getClusterByName(clusterName);
-        if (cluster == null) {
-            throw com.hortonworks.streamline.common.exception.service.exception.request.EntityNotFoundException.byName("cluster name " + clusterName);
-        }
-        return getDatabaseTablesByClusterId(cluster.getId(), dbName);
     }
 
     @GET

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/metadata/KafkaMetadataResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/metadata/KafkaMetadataResource.java
@@ -31,18 +31,6 @@ public class KafkaMetadataResource {
     }
 
     @GET
-    @Path("/clusters/name/{clusterName}/services/kafka/brokers")
-    @Timed
-    public Response getBrokersByClusterName(@PathParam("clusterName") String clusterName)
-        throws Exception {
-        final Cluster cluster = environmentService.getClusterByName(clusterName);
-        if (cluster == null) {
-            throw com.hortonworks.streamline.common.exception.service.exception.request.EntityNotFoundException.byName("cluster name " + clusterName);
-        }
-        return getBrokersByClusterId(cluster.getId());
-    }
-
-    @GET
     @Path("/clusters/{clusterId}/services/kafka/brokers")
     @Timed
     public Response getBrokersByClusterId(@PathParam("clusterId") Long clusterId) throws Exception {
@@ -51,18 +39,6 @@ public class KafkaMetadataResource {
         } catch (EntityNotFoundException ex) {
             throw com.hortonworks.streamline.common.exception.service.exception.request.EntityNotFoundException.byId(ex.getMessage());
         }
-    }
-
-    @GET
-    @Path("/clusters/name/{clusterName}/services/kafka/topics")
-    @Timed
-    public Response getTopicsByClusterName(@PathParam("clusterName") String clusterName)
-        throws Exception {
-        final Cluster cluster = environmentService.getClusterByName(clusterName);
-        if (cluster == null) {
-            throw com.hortonworks.streamline.common.exception.service.exception.request.EntityNotFoundException.byName("cluster name " + clusterName);
-        }
-        return getTopicsByClusterId(cluster.getId());
     }
 
     @GET

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/metadata/StormMetadataResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/metadata/StormMetadataResource.java
@@ -28,17 +28,6 @@ public class StormMetadataResource {
     }
 
     @GET
-    @Path("/clusters/name/{clusterName}/services/storm/topologies")
-    @Timed
-    public Response getTopologiesByClusterName(@PathParam("clusterName") String clusterName) {
-        final Cluster cluster = environmentService.getClusterByName(clusterName);
-        if (cluster == null) {
-            throw com.hortonworks.streamline.common.exception.service.exception.request.EntityNotFoundException.byName("cluster name " + clusterName);
-        }
-        return getTopologiesByClusterId(cluster.getId());
-    }
-
-    @GET
     @Path("/clusters/{clusterId}/services/storm/topologies")
     @Timed
     public Response getTopologiesByClusterId(@PathParam("clusterId") Long clusterId) {

--- a/webservice/Cluster.md
+++ b/webservice/Cluster.md
@@ -131,39 +131,6 @@ and show only sample for creating a service, service configuration, component.
 }
 ```
 
-`GET /api/v1/catalog/clusters/name/:clustername`
-
-**Success Response**
-
-    GET /api/v1/catalog/clusters/name/production
-    HTTP/1.1 200 OK
-    Content-Type: application/json
-
-```json
-{
-  "responseCode": 1000,
-  "responseMessage": "Success",
-  "entity": {
-    "id": 1,
-    "name": "production",
-    "description": "The production cluster that handles streaming events",
-    "timestamp": 1475657006739
-  }
-}
-```
-**Error Response**
-
-    GET /api/v1/catalog/clusters/name/production10
-    HTTP/1.1 404 Not Found
-    Content-Type: application/json
-    
-```json
-{
-  "responseCode": 1102,
-  "responseMessage": "Entity with name [production10] not found. Please check webservice/ErrorCodes.md for more details."
-}
-```
-
 ### List Clusters
 
 `GET /api/v1/catalog/clusters`
@@ -686,13 +653,9 @@ User should create a new Cluster entity or specify existing one. If user chooses
 
 `GET /api/v1/catalog/clusters/:clusterId/services`
 
-`GET /api/v1/catalog/clusters/name/:clusterName/services`
-
 ### Get Service
 
 `GET /api/v1/catalog/clusters/{clusterId}/services/{id}`
-
-`GET /api/v1/catalog/clusters/name/{clusterName}/services/name/{serviceName}`
 
 ### Update Service
 
@@ -750,8 +713,6 @@ User should create a new Cluster entity or specify existing one. If user chooses
 
 `GET /api/v1/catalog/services/:serviceId/configurations/:configurationId`
 
-`GET /api/v1/catalog/clusters/name/:clusterName/services/name/:serviceName/configurations/:configurationName`
-
 ### Update Service Configuration
 
 `PUT /api/v1/catalog/services/:serviceId/configurations/:configurationId`
@@ -805,13 +766,9 @@ User should create a new Cluster entity or specify existing one. If user chooses
 
 `GET /api/v1/catalog/clusters/:clusterId/services`
 
-`GET /api/v1/catalog/clusters/name/:clusterName/services`
-
 ### Get Component
 
 `GET /api/v1/catalog/clusters/{clusterId}/services/{id}`
-
-`GET /api/v1/catalog/clusters/name/{clusterName}/services/name/{serviceName}`
 
 ### Update Component
 


### PR DESCRIPTION
* remove all APIs and methods regarding utilizing 'name' as unique identifier for Cluster
* change unique identifier from 'name' to 'name + url' on adding Cluster

For field hint provider, I replaced `cluster name` to `cluster name [import url]` so that it can be classified and also be able to put the map separately. Please suggest if the pattern is not suitable for displaying.