### PR TITLE
STREAMLINE-679 Bug fixes on OpenTSDB sink

### DIFF
--- a/bootstrap/components/sinks/opentsdb-sink-topology-component.json
+++ b/bootstrap/components/sinks/opentsdb-sink-topology-component.json
@@ -9,6 +9,49 @@
   "topologyComponentUISpecification": {
     "fields": [
       {
+        "uiName": "REST API URL",
+        "fieldName": "url",
+        "isOptional": false,
+        "tooltip": "The URL of the REST API (ex: http://localhost:4242)",
+        "type": "string"
+      },
+      {
+        "uiName": "Metric Field Name",
+        "fieldName": "metricField",
+        "isOptional": false,
+        "tooltip": "Metric Field Name",
+        "type": "enumstring",
+        "options": [],
+        "hint": "inputFields"
+      },
+      {
+        "uiName": "Timestamp Field Name",
+        "fieldName": "timestampField",
+        "isOptional": false,
+        "tooltip": "Timestamp Field Name",
+        "type": "enumstring",
+        "options": [],
+        "hint": "inputFields"
+      },
+      {
+        "uiName": "Tags Field Name",
+        "fieldName": "tagsField",
+        "isOptional": false,
+        "tooltip": "Tags Field Name",
+        "type": "enumstring",
+        "options": [],
+        "hint": "inputFields"
+      },
+      {
+        "uiName": "Value Field Name",
+        "fieldName": "valueField",
+        "isOptional": false,
+        "tooltip": "Value Field Name",
+        "type": "enumstring",
+        "options": [],
+        "hint": "inputFields"
+      },
+      {
         "uiName": "Batch size",
         "fieldName": "withBatchSize",
         "isOptional": true,
@@ -39,6 +82,14 @@
         "tooltip": "Flag to indicate whether to sync",
         "type": "boolean",
         "defaultValue": true
+      },
+      {
+        "uiName": "Sync timeout (milliseconds)",
+        "fieldName": "syncTimeout",
+        "isOptional": false,
+        "tooltip": "Sync timeout in milliseconds, only effective when sync is true",
+        "type": "number",
+        "defaultValue": 500
       },
       {
         "uiName": "Return summary?",

--- a/streams/runners/storm/layout/pom.xml
+++ b/streams/runners/storm/layout/pom.xml
@@ -33,6 +33,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.storm</groupId>
+            <artifactId>storm-opentsdb</artifactId>
+            <version>${storm.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>io.druid</groupId>
             <artifactId>druid-server</artifactId>
             <version>0.9.1</version>

--- a/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/OpenTsdbTupleDatapointMapper.java
+++ b/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/OpenTsdbTupleDatapointMapper.java
@@ -1,0 +1,95 @@
+package com.hortonworks.streamline.streams.layout.storm;
+
+import com.hortonworks.streamline.streams.StreamlineEvent;
+import org.apache.storm.opentsdb.OpenTsdbMetricDatapoint;
+import org.apache.storm.opentsdb.bolt.ITupleOpenTsdbDatapointMapper;
+import org.apache.storm.tuple.ITuple;
+
+import java.util.Map;
+
+public class OpenTsdbTupleDatapointMapper implements ITupleOpenTsdbDatapointMapper {
+    private final String metricField;
+    private final String timestampField;
+    private final String valueField;
+    private final String tagsField;
+
+    public OpenTsdbTupleDatapointMapper(String metricField, String timestampField, String tagsField, String valueField) {
+        this.metricField = metricField;
+        this.timestampField = timestampField;
+        this.tagsField = tagsField;
+        this.valueField = valueField;
+    }
+
+    @Override
+    public OpenTsdbMetricDatapoint getMetricPoint(ITuple tuple) {
+        StreamlineEvent event = (StreamlineEvent) tuple.getValueByField(StreamlineEvent.STREAMLINE_EVENT);
+        return new OpenTsdbMetricDatapoint(
+                (String) event.get(metricField),
+                (Map<String, String>) event.get(tagsField),
+                (Long) event.get(timestampField),
+                (Number) event.get(valueField));
+    }
+
+    /**
+     * @return metric field name in the tuple.
+     */
+    public String getMetricField() {
+        return metricField;
+    }
+
+    /**
+     * @return timestamp field name in the tuple.
+     */
+    public String getTimestampField() {
+        return timestampField;
+    }
+
+    /**
+     * @return value field name in the tuple.
+     */
+    public String getValueField() {
+        return valueField;
+    }
+
+    /**
+     * @return tags field name in the tuple
+     */
+    public String getTagsField() {
+        return tagsField;
+    }
+
+    @Override
+    public String toString() {
+        return "OpenTsdbTupleDatapointMapper{" +
+                "metricField='" + metricField + '\'' +
+                ", timestampField='" + timestampField + '\'' +
+                ", valueField='" + valueField + '\'' +
+                ", tagsField='" + tagsField + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof OpenTsdbTupleDatapointMapper)) return false;
+
+        OpenTsdbTupleDatapointMapper that = (OpenTsdbTupleDatapointMapper) o;
+
+        if (getMetricField() != null ? !getMetricField().equals(that.getMetricField()) : that.getMetricField() != null)
+            return false;
+        if (getTimestampField() != null ? !getTimestampField().equals(that.getTimestampField()) : that.getTimestampField() != null)
+            return false;
+        if (getValueField() != null ? !getValueField().equals(that.getValueField()) : that.getValueField() != null)
+            return false;
+        return getTagsField() != null ? getTagsField().equals(that.getTagsField()) : that.getTagsField() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getMetricField() != null ? getMetricField().hashCode() : 0;
+        result = 31 * result + (getTimestampField() != null ? getTimestampField().hashCode() : 0);
+        result = 31 * result + (getValueField() != null ? getValueField().hashCode() : 0);
+        result = 31 * result + (getTagsField() != null ? getTagsField().hashCode() : 0);
+        return result;
+    }
+}


### PR DESCRIPTION
- withFlushInterval should be called with interval, not without argument
- sync in builder should be called with timeout value, not without argument
- bolt class should be "org.apache.storm.opentsdb.bolt.OpenTsdbBolt", not "org.apache.storm.hdfs.bolt.OpenTsdbBolt"
- builder class should be "org.apache.storm.opentsdb.client.OpenTsdbClient$Builder", not "org.apache.storm.opentsdb.client.OpenTsdbClient.Builder"

NOTE: https://github.com/apache/storm/pull/1880 is still needed for OpenTSDB Flux to be run.

https://github.com/apache/storm/pull/1880 resolves below issues:
- Flux doesn't support static factory method, but OpenTsdbClient.Builder only has protected constructor, and it should be initialized with OpenTsdbClient.newBuilder method.
  - easiest fix would be changing protected constructor to public constructor, and more valuable fix would be supporting builder method for Flux.
- Flux doesn't support list of references, but OpenTSDBBolt requires List<TupleOpenTsdbDatapointMapper>.
  - easiest fix would be adding overloaded constructor which takes TupleOpenTsdbDatapointMapper, and more valuable fix would be supporting list of references for Flux.
