### PR TITLE
STREAMLINE-686 Bug fixes on Cassandra sink

### DIFF
--- a/bootstrap/components/sinks/cassandra-sink-topology-component.json
+++ b/bootstrap/components/sinks/cassandra-sink-topology-component.json
@@ -5,7 +5,7 @@
   "builtin": true,
   "streamingEngine": "STORM",
   "transformationClass": "com.hortonworks.streamline.streams.layout.storm.CassandraBoltFluxComponent",
-  "mavenDeps": "org.apache.storm:storm-cassandra:STORM_VERSION,com.datastax.cassandra:cassandra-driver-core:2.1.7.1",
+  "mavenDeps": "org.apache.storm:storm-cassandra:STORM_VERSION,com.datastax.cassandra:cassandra-driver-core:3.1.2",
   "topologyComponentUISpecification": {
     "fields": [
       {
@@ -51,7 +51,7 @@
       },
       {
         "uiName": "Cassandra Configuration",
-        "fieldName": "cassandraConfig",
+        "fieldName": "cassandraEndpointConfig",
         "tooltip": "Cassandra cluster configuration",
         "isOptional": false,
         "type": "object",
@@ -111,8 +111,9 @@
             "fieldName": "cassandra.retryPolicy",
             "tooltip": "Retry policy classname",
             "isOptional": false,
-            "type": "string",
-            "defaultValue": "com.datastax.driver.core.policies.DefaultRetryPolicy"
+            "type": "enumstring",
+            "defaultValue": "DefaultRetryPolicy",
+            "options": ["DowngradingConsistencyRetryPolicy", "FallthroughRetryPolicy", "DefaultRetryPolicy"]
           },
           {
             "uiName": "Consistency Level",

--- a/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/StormTopologyLayoutConstants.java
+++ b/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/StormTopologyLayoutConstants.java
@@ -31,6 +31,7 @@ public final class StormTopologyLayoutConstants {
     public static final String YAML_KEY_PROPERTIES = "properties";
     public static final String YAML_KEY_CONSTRUCTOR_ARGS = "constructorArgs";
     public static final String YAML_KEY_REF = "ref";
+    public static final String YAML_KEY_REF_LIST = "reflist";
     public static final String YAML_KEY_ARGS = "args";
     public static final String YAML_KEY_CONFIG_METHODS = "configMethods";
     public static final String YAML_KEY_FROM = "from";

--- a/streams/runners/storm/layout/src/test/java/com/hortonworks/streamline/streams/layout/storm/CassandraBoltFluxComponentTest.java
+++ b/streams/runners/storm/layout/src/test/java/com/hortonworks/streamline/streams/layout/storm/CassandraBoltFluxComponentTest.java
@@ -78,8 +78,9 @@ public class CassandraBoltFluxComponentTest {
 
         // only one config method with name 'bind'
         Assert.assertEquals("bind", bindMethodConfig.get("name"));
-        List<Map<String, String>> args = (List<Map<String, String>>) bindMethodConfig.get("args");
-        List<String> bindArgRefs = args.stream().map(map -> map.get("ref")).collect(Collectors.toList());
+        List<Map<String, Object>> args = (List<Map<String, Object>>) bindMethodConfig.get("args");
+        Assert.assertEquals(1, args.size());
+        List<String> bindArgRefs = (List<String>) args.get(0).get("reflist");
 
         // bind method args should be same as field selectors that are configured
         Assert.assertEquals(selectorIds, bindArgRefs);

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/cassandra/StreamlineFieldSelector.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/cassandra/StreamlineFieldSelector.java
@@ -41,9 +41,7 @@ public class StreamlineFieldSelector extends FieldSelector {
 
     protected Object getFieldValue(ITuple tuple) {
         StreamlineEvent streamlineEvent = (StreamlineEvent) tuple.getValueByField(StreamlineEvent.STREAMLINE_EVENT);
-
-//        return streamlineEvent.get(field);
-        return null;
+        return streamlineEvent.get(field);
     }
 
 }


### PR DESCRIPTION
* this patch depends on [STORM-2300](https://issues.apache.org/jira/browse/STORM-2300) and [STORM-2301](https://issues.apache.org/jira/browse/STORM-2301)

Manually tested this patch with Cassandra 3.0.9.

Since it requires STORM-2300 (Flux) and STORM-2301 (storm-cassandra), to test this patch manually we should build custom Storm for Flux and storm-cassandra, and modify mavenDeps for Cassandra sink and set Flux version to custom build version in streams/runner/storm/runtime/pom.xml