### PR TITLE
STREAMLINE-675 : Added HdfsTextOutputFormat to replace IdentityHdfsRecordFormat

### DIFF
--- a/bootstrap/components/sinks/hdfs-sink-topology-component.json
+++ b/bootstrap/components/sinks/hdfs-sink-topology-component.json
@@ -20,7 +20,7 @@
         "uiName": "Path",
         "fieldName": "path",
         "isOptional": false,
-        "tooltip": "Path for default file name format",
+        "tooltip": "Directory to which the files will be written",
         "type": "string"
       },
       {
@@ -43,14 +43,14 @@
         "uiName": "Count policy value",
         "fieldName": "countPolicyValue",
         "isOptional": false,
-        "tooltip": "Count value for count sync policy",
+        "tooltip": "Number of records to wait for before flushing to Hdfs",
         "type": "number"
       },
       {
         "uiName": "Rotation Policy",
         "fieldName": "rotationPolicy",
         "isOptional": false,
-        "tooltip": "Strategy to rotate files in hdfs",
+        "tooltip": "Strategy to rotate files in Hdfs",
         "type": "enumobject",
         "defaultValue": "timeBasedRotation",
         "options": [
@@ -113,6 +113,15 @@
             ]
           }
         ]
+      },
+      {
+        "uiName": "Output Fields",
+        "fieldName": "outputFields",
+        "isOptional": false,
+        "tooltip": "Specify the output fields, in the desired order",
+        "type": "array.enumstring",
+        "options": [],
+        "hint": "inputFields"
       },
       {
         "uiName": "Parallelism",

--- a/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/HdfsBoltFluxComponent.java
+++ b/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/HdfsBoltFluxComponent.java
@@ -4,6 +4,8 @@ import com.hortonworks.streamline.streams.layout.TopologyLayoutConstants;
 import com.hortonworks.streamline.streams.layout.exception.ComponentConfigException;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -69,12 +71,27 @@ public class HdfsBoltFluxComponent extends AbstractFluxComponent {
     private String addRecordFormatComponent () {
         String recordFormatComponentId = "recordFormat" +
                 UUID_FOR_COMPONENTS;
-        // currently only IdentityHdfsRecordFormat is supported.
-        String recordFormatClassName = "com.hortonworks.streamline.streams.runtime.storm.hdfs" +
-                ".IdentityHdfsRecordFormat";
+        // currently only HdfsTextOutputFormat is supported.
+        String recordFormatClassName
+                = "com.hortonworks.streamline.streams.runtime.storm.hdfs.HdfsTextOutputFormat";
+
+        List<Map<String, Object>> configMethods = new ArrayList<>();
+
+        // setup the call to 'withFields()' config method
+        Map<String, Object> withFieldsMethod = new LinkedHashMap<>();
+        withFieldsMethod.put(StormTopologyLayoutConstants.YAML_KEY_NAME, "withFields");
+        String outputFields = getCommaSepList( (List<String>) conf.get("outputFields") ) ;
+        withFieldsMethod.put(StormTopologyLayoutConstants.YAML_KEY_ARGS, Arrays.asList(outputFields));
+        configMethods.add(withFieldsMethod);
+
         addToComponents(createComponent(recordFormatComponentId,
-                recordFormatClassName, null, null, null));
+                recordFormatClassName, null, null, configMethods));
         return recordFormatComponentId;
+    }
+
+    // returns a String with comma separated fields
+    private static String getCommaSepList(List<String> fields) {
+        return fields.stream().reduce( (a, b) -> a + "," + b ).get();
     }
 
     private String addSyncPolicyComponent () {

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/hdfs/HdfsTextOutputFormat.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/hdfs/HdfsTextOutputFormat.java
@@ -1,0 +1,78 @@
+package com.hortonworks.streamline.streams.runtime.storm.hdfs;
+
+
+import com.hortonworks.streamline.streams.StreamlineEvent;
+
+import org.apache.storm.hdfs.bolt.format.RecordFormat;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Tuple;
+
+
+public class HdfsTextOutputFormat implements RecordFormat {
+    public static final String DEFAULT_FIELD_DELIMITER = ",";
+    public static final String DEFAULT_RECORD_DELIMITER = "\n";
+    private String fieldDelimiter = DEFAULT_FIELD_DELIMITER;
+    private String recordDelimiter = DEFAULT_RECORD_DELIMITER;
+    private Fields fields = null;
+
+    /**
+     * Only output the specified fields.
+     *
+     * @param commaSeparatedFields  Names of output fields, in the order they should appear in file
+     * @return
+     */
+    public HdfsTextOutputFormat withFields(String commaSeparatedFields){
+        String[] rawFields = commaSeparatedFields.split(",");
+        String[] trimmedFields = new String[rawFields.length];
+        for (int i = 0; i < rawFields.length; i++)   {
+            trimmedFields[i] = rawFields[i].trim();
+        }
+
+        fields = new Fields(trimmedFields);
+        return this;
+    }
+
+    /**
+     * Overrides the default field delimiter.
+     *
+     * @param delimiter
+     * @return
+     */
+    public HdfsTextOutputFormat withFieldDelimiter(String delimiter){
+        this.fieldDelimiter = delimiter;
+        return this;
+    }
+
+    /**
+     * Overrides the default record delimiter.
+     *
+     * @param delimiter
+     * @return
+     */
+    public HdfsTextOutputFormat withRecordDelimiter(String delimiter){
+        this.recordDelimiter = delimiter;
+        return this;
+    }
+
+    @Override
+    public byte[] format(Tuple tuple) {
+        if (fields==null || fields.size()==0) {
+            throw new IllegalArgumentException("Output field names not specified. Set them using withFields().");
+        }
+
+        StreamlineEvent event = ((StreamlineEvent) tuple.getValueByField(StreamlineEvent.STREAMLINE_EVENT));
+        StringBuilder sb = new StringBuilder();
+
+        for(int i = 0; i < fields.size(); i++) {
+            Object value = event.get(fields.get(i));
+            if (value!=null) {
+                sb.append( value );
+            }
+            if ( i != fields.size()-1 ) {
+                sb.append(this.fieldDelimiter);
+            }
+        }
+        sb.append(this.recordDelimiter);
+        return sb.toString().getBytes();
+    }
+}


### PR DESCRIPTION
Also added 'outputFields' field to UI for HdfsBot... which allows the users to select which fields to write out and also determines the order.