### PR TITLE
Update Calcite and Calcite Avatica version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Compile Scope Dependencies -->
-        <calcite.version>1.11.0-SNAPSHOT</calcite.version>
-        <calcite-avatica.version>1.10.0-SNAPSHOT</calcite-avatica.version>
+        <calcite.version>1.11.0</calcite.version>
+        <calcite-avatica.version>1.9.0</calcite-avatica.version>
         <commons-cli.version>1.3.1</commons-cli.version>
         <commons-io.version>2.5</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
Calciate 1.11.0 is released so we no longer need to rely on SNAPSHOT.