### PR TITLE
STREAMLINE-420: Change topology component definition for Eventhub to use yaml spec file

### DIFF
--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -119,6 +119,7 @@ function add_all_bundles {
     # === Source ===
     add_bundle /streams/componentbundles/SOURCE $component_dir/sources/kafka-source-topology-component.json
     add_bundle /streams/componentbundles/SOURCE $component_dir/sources/hdfs-source-topology-component.json
+    add_bundle /streams/componentbundles/SOURCE $component_dir/sources/eventhubs-source-topology-component.json
     # === Processor ===
     add_bundle /streams/componentbundles/PROCESSOR $component_dir/processors/rule-topology-component.json
     add_bundle /streams/componentbundles/PROCESSOR $component_dir/processors/window-topology-component.json

--- a/bootstrap/components/sources/eventhubs-source-topology-component.json
+++ b/bootstrap/components/sources/eventhubs-source-topology-component.json
@@ -1,0 +1,93 @@
+{
+  "type": "SOURCE",
+  "name": "Event Hubs",
+  "subType": "EVENTHUBS",
+  "streamingEngine": "STORM",
+  "builtin": true,
+  "transformationClass": "com.hortonworks.streamline.streams.layout.storm.EventHubSpoutFluxComponent",
+  "fieldHintProviderClass": "com.hortonworks.streamline.streams.catalog.topology.component.bundle.impl.EventHubsSourceHintProvider",
+  "mavenDeps": "org.apache.storm:storm-eventhubs:STORM_VERSION^org.slf4j:slf4j-log4j12",
+  "topologyComponentUISpecification": {
+    "fields": [
+      {
+        "uiName": "Username",
+        "fieldName": "username",
+        "isOptional": false,
+        "tooltip": "The Event Hubs user name (policy name in Event Hubs Portal)",
+        "type": "string"
+      },
+      {
+        "uiName": "Password",
+        "fieldName": "password",
+        "isOptional": false,
+        "tooltip": "The Event Hubs password (shared access key in Event Hubs Portal)",
+        "type": "string",
+        "hint": "password"
+      },
+      {
+        "uiName": "Namespace",
+        "fieldName": "namespace",
+        "isOptional": false,
+        "tooltip": "The Event Hubs namespace",
+        "type": "string"
+      },
+      {
+        "uiName": "Entity path",
+        "fieldName": "entityPath",
+        "isOptional": false,
+        "tooltip": "The Event Hubs entity path",
+        "type": "string",
+        "hint": "schema"
+      },
+      {
+        "uiName": "Partition count",
+        "fieldName": "partitionCount",
+        "isOptional": false,
+        "tooltip": "The number of partitions in the Event Hubs",
+        "type": "number"
+      },
+      {
+        "uiName": "Zookeeper Connection String",
+        "fieldName": "zkConnectionString",
+        "isOptional": true,
+        "tooltip": "The Zookeeper connection string",
+        "type": "string"
+      },
+      {
+        "uiName": "Checkpoint Interval (secs)",
+        "fieldName": "checkpointIntervalInSeconds",
+        "isOptional": true,
+        "tooltip": "The frequency at which offsets are checkpointed",
+        "type": "number"
+      },
+      {
+        "uiName": "Receiver credits",
+        "fieldName": "receiverCredits",
+        "isOptional": true,
+        "tooltip": "Receiver credits",
+        "type": "number"
+      },
+      {
+        "uiName": "Max pending messages per partition",
+        "fieldName": "maxPendingMsgsPerPartition",
+        "isOptional": true,
+        "tooltip": "The max pending messages per partition",
+        "type": "number"
+      },
+      {
+        "uiName": "Enqueue Time Filter",
+        "fieldName": "enqueueTimeFilter",
+        "isOptional": true,
+        "tooltip": "The enqueue time filter",
+        "type": "number"
+      },
+      {
+        "uiName": "Consumer Group Name",
+        "fieldName": "consumerGroupName",
+        "isOptional": true,
+        "tooltip": "The consumer group name",
+        "type": "string"
+      }
+    ]
+  }
+}

--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/topology/component/bundle/impl/EventHubsSourceHintProvider.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/topology/component/bundle/impl/EventHubsSourceHintProvider.java
@@ -1,0 +1,21 @@
+package com.hortonworks.streamline.streams.catalog.topology.component.bundle.impl;
+
+import com.hortonworks.streamline.streams.catalog.Cluster;
+import com.hortonworks.streamline.streams.catalog.topology.component.bundle.AbstractBundleHintProvider;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class EventHubsSourceHintProvider extends AbstractBundleHintProvider {
+    public static final String SERVICE_NAME = "EVENTHUBS";
+
+    @Override
+    public Map<String, Object> getHintsOnCluster(Cluster cluster) {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public String getServiceName() {
+        return SERVICE_NAME;
+    }
+}

--- a/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/EventHubSpoutFluxComponent.java
+++ b/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/EventHubSpoutFluxComponent.java
@@ -15,10 +15,18 @@
  **/
 package com.hortonworks.streamline.streams.layout.storm;
 
+import com.hortonworks.streamline.streams.layout.TopologyLayoutConstants;
+import com.hortonworks.streamline.streams.layout.component.StreamlineSource;
+import com.hortonworks.streamline.streams.layout.component.impl.KafkaSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.List;
 
 public class EventHubSpoutFluxComponent extends AbstractFluxComponent {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaSpoutFluxComponent.class);
+
     private static final String KEY_USENAME = "username";
     private static final String KEY_PASSWORD = "password";
     private static final String KEY_NAMESPACE = "namespace";
@@ -31,9 +39,13 @@ public class EventHubSpoutFluxComponent extends AbstractFluxComponent {
     private static final String KEY_MAX_PENDING_MSGS_PER_PARTITION = "maxPendingMsgsPerPartition";
     private static final String KEY_ENQUEUE_TIME_FILTER = "enqueueTimeFilter";
     private static final String KEY_CONSUMER_GROUP_NAME = "consumerGroupName";
+    private static final String KEY_OUTPUT_STREAM_ID = "outputStreamId";
+
+    private StreamlineSource streamlineSource;
 
     @Override
     protected void generateComponent() {
+        streamlineSource = (StreamlineSource) conf.get(StormTopologyLayoutConstants.STREAMLINE_COMPONENT_CONF_KEY);
         String spoutId = "eventhubSpout" + UUID_FOR_COMPONENTS;
         String spoutClassName = "org.apache.storm.eventhubs.spout.EventHubSpout";
         List<Object> constructorArgs = new ArrayList<>();
@@ -52,11 +64,25 @@ public class EventHubSpoutFluxComponent extends AbstractFluxComponent {
                         KEY_NAMESPACE,
                         KEY_ENTITYPATH,
                         KEY_PARTITIONCOUNT);
-        List<Object> properties = getPropertiesYaml(new String[]{
-                KEY_ZK_CONNECTION_STRING, KEY_CHECKPOINT_INTERVAL_SECS, KEY_RECEIVER_CREDITS,
-                KEY_MAX_PENDING_MSGS_PER_PARTITION, KEY_ENQUEUE_TIME_FILTER, KEY_CONSUMER_GROUP_NAME
-        });
-        addToComponents(createComponent(componentId, className, properties, constructorArgs, null));
+        String[] propertyKeys = new String[]{
+                KEY_ZK_CONNECTION_STRING,
+                KEY_CHECKPOINT_INTERVAL_SECS,
+                KEY_RECEIVER_CREDITS,
+                KEY_MAX_PENDING_MSGS_PER_PARTITION,
+                KEY_ENQUEUE_TIME_FILTER,
+                KEY_CONSUMER_GROUP_NAME,
+                KEY_OUTPUT_STREAM_ID
+        };
+        // add the output stream to conf so that the spout declares output stream properly
+        if (streamlineSource != null && streamlineSource.getOutputStreams().size() == 1) {
+            conf.put(TopologyLayoutConstants.JSON_KEY_OUTPUT_STREAM_ID,
+                    streamlineSource.getOutputStreams().iterator().next().getId());
+        } else {
+            String msg = "Eventhub source component [" + streamlineSource + "] should define exactly one output stream for Storm";
+            LOG.error(msg, streamlineSource);
+            throw new IllegalArgumentException(msg);
+        }
+        addToComponents(createComponent(componentId, className, getPropertiesYaml(propertyKeys), constructorArgs, null));
         return componentId;
     }
 


### PR DESCRIPTION
Added topology component definition for Event Hubs.


@harshach @shahsank3t 
When I drag and drop the component and try to edit the details, the "Cluster" field is coming out as empty since the Ambari cluster does not have a service named "EVENTHUB". Is the cluster a mandatory parameter for sources ? I am not sure how to test the eventhub component.