### PR TITLE
(POC) STREAMLINE-381 Test Source, Test Sink components

### DIFF
--- a/conf/streamline-dev.yaml
+++ b/conf/streamline-dev.yaml
@@ -11,6 +11,8 @@ modules:
       #change the below to the path on your local machine
       streamlineStormJar: /tmp/streamline-runtime-storm-0.1.0-SNAPSHOT.jar
       stormHomeDir: /usr/local/Cellar/storm/0.10.0/
+      # directory to store the results of topology test run
+      topologyTestRunResultDir: /tmp
       # schema registry configuration
       schemaRegistryUrl: "http://localhost:9090/api/v1"
       mavenRepoUrl: "hwx-public^http://repo.hortonworks.com/content/groups/public/,hwx-private^http://nexus-private.hortonworks.com/nexus/content/groups/public/"

--- a/conf/streamline.mysql.yaml
+++ b/conf/streamline.mysql.yaml
@@ -11,6 +11,8 @@ modules:
       #change the below to the path on your local machine
       streamlineStormJar: /tmp/streamline-runtime-storm-0.1.0-SNAPSHOT.jar
       stormHomeDir: /usr/local/Cellar/storm/0.10.0/
+      # directory to store the results of topology test run
+      topologyTestRunResultDir: /tmp
       # schema registry configuration
       schemaRegistryUrl: "http://localhost:9090/api/v1"
       #Custom processor upload configuration

--- a/conf/streamline.phoenix.yaml
+++ b/conf/streamline.phoenix.yaml
@@ -11,6 +11,8 @@ modules:
       #change the below to the path on your local machine
       streamlineStormJar: /tmp/streamline-runtime-storm-0.1.0-SNAPSHOT.jar
       stormHomeDir: /usr/local/Cellar/storm/0.10.0/
+      # directory to store the results of topology test run
+      topologyTestRunResultDir: /tmp
       # schema registry configuration
       schemaRegistryUrl: "http://localhost:9090/api/v1"
       mavenRepoUrl: "hwx-public^http://repo.hortonworks.com/content/groups/public/,hwx-private^http://nexus-private.hortonworks.com/nexus/content/groups/public/"

--- a/conf/streamline.yaml
+++ b/conf/streamline.yaml
@@ -11,6 +11,8 @@ modules:
       #change the below to the path on your local machine
       streamlineStormJar: /tmp/streamline-runtime-storm-0.1.0-SNAPSHOT.jar
       stormHomeDir: /usr/local/Cellar/storm/0.10.0/
+      # directory to store the results of topology test run
+      topologyTestRunResultDir: /tmp
       # schema registry configuration
       schemaRegistryUrl: "http://localhost:9090/api/v1"
       #Custom processor upload configuration

--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/TopologyActions.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/TopologyActions.java
@@ -35,7 +35,8 @@ public interface TopologyActions {
     // engine
     void deploy(TopologyLayout topology, String mavenArtifacts) throws Exception;
 
-    // Compose test topology based on topology DAG using the underlying streaming engine
+    // Compose test topology based on current topology DAG using the underlying streaming engine
+    // It copies topology DAG, and replaces sources to test purpose one and also sinks to test purpose one
     void testRun(TopologyLayout topology, String mavenArtifacts,
                  Map<String, TestRunSource> testRunSourcesMap,
                  Map<String, TestRunSink> testRunSinksMap) throws Exception;

--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/TopologyActions.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/TopologyActions.java
@@ -35,11 +35,12 @@ public interface TopologyActions {
     // engine
     void deploy(TopologyLayout topology, String mavenArtifacts) throws Exception;
 
-    // Compose test topology based on current topology DAG using the underlying streaming engine
-    // It copies topology DAG, and replaces sources to test purpose one and also sinks to test purpose one
+    // Compose and run parameter topology as test mode using the underlying streaming engine.
+    // The parameter 'topology' should contain its own topology DAG.
+    // Please refer the javadoc of TestRunSource and also TestRunSink to see which information this method requires.
     void testRun(TopologyLayout topology, String mavenArtifacts,
-                 Map<String, TestRunSource> testRunSourcesMap,
-                 Map<String, TestRunSink> testRunSinksMap) throws Exception;
+                 Map<String, TestRunSource> testRunSourcesForEachSource,
+                 Map<String, TestRunSink> testRunSinksForEachSink) throws Exception;
 
     //Kill the artifact that was deployed using deploy
     void kill (TopologyLayout topology) throws Exception;

--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/TopologyActions.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/TopologyActions.java
@@ -16,8 +16,11 @@
 package com.hortonworks.streamline.streams.actions;
 
 import com.hortonworks.streamline.streams.layout.component.TopologyLayout;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSink;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSource;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -31,6 +34,11 @@ public interface TopologyActions {
     // Deploy the artifact generated using the underlying streaming
     // engine
     void deploy(TopologyLayout topology, String mavenArtifacts) throws Exception;
+
+    // Compose test topology based on topology DAG using the underlying streaming engine
+    void testRun(TopologyLayout topology, String mavenArtifacts,
+                 Map<String, TestRunSource> testRunSourcesMap,
+                 Map<String, TestRunSink> testRunSinksMap) throws Exception;
 
     //Kill the artifact that was deployed using deploy
     void kill (TopologyLayout topology) throws Exception;

--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyActionsService.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyActionsService.java
@@ -132,7 +132,7 @@ public class TopologyActionsService implements ContainingNamespaceAwareContainer
         String mavenArtifacts = setUpExtraJars(topology, topologyActions);
 
         ObjectMapper objectMapper = new ObjectMapper();
-        Map<String, Map<String, List<Map<String, Object>>>> testRecordsMap = objectMapper.readValue(configJson,
+        Map<String, Map<String, List<Map<String, Object>>>> testRecordsForEachSource = objectMapper.readValue(configJson,
                 new TypeReference<Map<String, Map<String, List<Map<String, Object>>>>>() {});
 
         List<StreamlineSource> sources = dag.getOutputComponents().stream()
@@ -146,7 +146,7 @@ public class TopologyActionsService implements ContainingNamespaceAwareContainer
                 .collect(toList());
 
         Map<String, TestRunSource> testRunSourceMap = sources.stream()
-                .collect(toMap(s -> s.getName(), s -> new TestRunSource(s.getOutputStreams(), testRecordsMap.get(s.getName()))));
+                .collect(toMap(s -> s.getName(), s -> new TestRunSource(s.getOutputStreams(), testRecordsForEachSource.get(s.getName()))));
 
         Map<String, TestRunSink> testRunSinkMap = sinks.stream()
                 .collect(toMap(s -> s.getName(), s -> {

--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyActionsService.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyActionsService.java
@@ -132,8 +132,8 @@ public class TopologyActionsService implements ContainingNamespaceAwareContainer
         String mavenArtifacts = setUpExtraJars(topology, topologyActions);
 
         ObjectMapper objectMapper = new ObjectMapper();
-        Map<String, List<Map<String, Object>>> testRecordsMap = objectMapper.readValue(configJson,
-                new TypeReference<Map<String, List<Map<String, Object>>>>() {});
+        Map<String, Map<String, List<Map<String, Object>>>> testRecordsMap = objectMapper.readValue(configJson,
+                new TypeReference<Map<String, Map<String, List<Map<String, Object>>>>>() {});
 
         List<StreamlineSource> sources = dag.getOutputComponents().stream()
                 .filter(c -> c instanceof StreamlineSource)

--- a/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/TopologyLayout.java
+++ b/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/TopologyLayout.java
@@ -43,6 +43,13 @@ public class TopologyLayout {
         this.topologyDag = topologyDag;
     }
 
+    public TopologyLayout(Long id, String name, Config config, TopologyDag topologyDag) {
+        this.id = id;
+        this.name = name;
+        this.config = config;
+        this.topologyDag = topologyDag;
+    }
+
     public Long getId() {
         return id;
     }

--- a/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/testing/TestRunSink.java
+++ b/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/testing/TestRunSink.java
@@ -1,0 +1,56 @@
+package com.hortonworks.streamline.streams.layout.component.impl.testing;
+
+import com.hortonworks.streamline.streams.layout.component.StreamlineSink;
+
+public class TestRunSink extends StreamlineSink {
+    private String outputFilePath;
+    private String outputFileUUID;
+
+    public TestRunSink() {
+        this.outputFileUUID = "";
+        this.outputFilePath = "";
+    }
+
+    public TestRunSink(String outputFileUUID, String outputFilePath) {
+        this.outputFileUUID = outputFileUUID;
+        this.outputFilePath = outputFilePath;
+    }
+
+    public String getOutputFileUUID() {
+        return outputFileUUID;
+    }
+
+    public String getOutputFilePath() {
+        return outputFilePath;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TestRunSink)) return false;
+        if (!super.equals(o)) return false;
+
+        TestRunSink that = (TestRunSink) o;
+
+        if (getOutputFilePath() != null ? !getOutputFilePath().equals(that.getOutputFilePath()) : that.getOutputFilePath() != null)
+            return false;
+        return getOutputFileUUID() != null ? getOutputFileUUID().equals(that.getOutputFileUUID()) : that.getOutputFileUUID() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (getOutputFilePath() != null ? getOutputFilePath().hashCode() : 0);
+        result = 31 * result + (getOutputFileUUID() != null ? getOutputFileUUID().hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "TestRunSink{" +
+                "outputFilePath='" + outputFilePath + '\'' +
+                ", outputFileUUID='" + outputFileUUID + '\'' +
+                '}' + super.toString();
+    }
+
+}

--- a/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/testing/TestRunSource.java
+++ b/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/testing/TestRunSource.java
@@ -8,19 +8,22 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Source for topology test run. This class contains test records which will be emitted from test run Spout.
+ */
 public class TestRunSource extends StreamlineSource {
-    private final List<Map<String, Object>> testRecords;
+    private final Map<String, List<Map<String, Object>>> testRecords;
 
     public TestRunSource() {
-        this(Collections.EMPTY_SET, Collections.EMPTY_LIST);
+        this(Collections.EMPTY_SET, Collections.EMPTY_MAP);
     }
 
-    public TestRunSource(Set<Stream> outputStreams, List<Map<String, Object>> testRecords) {
+    public TestRunSource(Set<Stream> outputStreams, Map<String, List<Map<String, Object>>> testRecords) {
         super(outputStreams);
         this.testRecords = testRecords;
     }
 
-    public List<Map<String, Object>> getTestRecords() {
+    public Map<String, List<Map<String, Object>>> getTestRecords() {
         return testRecords;
     }
 

--- a/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/testing/TestRunSource.java
+++ b/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/testing/TestRunSource.java
@@ -12,19 +12,25 @@ import java.util.Set;
  * Source for topology test run. This class contains test records which will be emitted from test run Spout.
  */
 public class TestRunSource extends StreamlineSource {
-    private final Map<String, List<Map<String, Object>>> testRecords;
+    private final Map<String, List<Map<String, Object>>> testRecordsForEachStream;
 
     public TestRunSource() {
         this(Collections.EMPTY_SET, Collections.EMPTY_MAP);
     }
 
-    public TestRunSource(Set<Stream> outputStreams, Map<String, List<Map<String, Object>>> testRecords) {
+    /**
+     * Constructor.
+     *
+     * @param outputStreams output streams.
+     * @param testRecordsForEachStream (output stream name) -> list of test record (each map represents a record)
+     */
+    public TestRunSource(Set<Stream> outputStreams, Map<String, List<Map<String, Object>>> testRecordsForEachStream) {
         super(outputStreams);
-        this.testRecords = testRecords;
+        this.testRecordsForEachStream = testRecordsForEachStream;
     }
 
-    public Map<String, List<Map<String, Object>>> getTestRecords() {
-        return testRecords;
+    public Map<String, List<Map<String, Object>>> getTestRecordsForEachStream() {
+        return testRecordsForEachStream;
     }
 
     @Override
@@ -35,20 +41,22 @@ public class TestRunSource extends StreamlineSource {
 
         TestRunSource that = (TestRunSource) o;
 
-        return getTestRecords() != null ? getTestRecords().equals(that.getTestRecords()) : that.getTestRecords() == null;
+        return getTestRecordsForEachStream() != null ?
+                getTestRecordsForEachStream().equals(that.getTestRecordsForEachStream()) :
+                that.getTestRecordsForEachStream() == null;
     }
 
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (getTestRecords() != null ? getTestRecords().hashCode() : 0);
+        result = 31 * result + (getTestRecordsForEachStream() != null ? getTestRecordsForEachStream().hashCode() : 0);
         return result;
     }
 
     @Override
     public String toString() {
         return "TestRunSource{" +
-                "testRecords=" + testRecords +
+                "testRecordsForEachStream=" + testRecordsForEachStream +
                 '}' + super.toString();
     }
 }

--- a/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/testing/TestRunSource.java
+++ b/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/testing/TestRunSource.java
@@ -1,0 +1,51 @@
+package com.hortonworks.streamline.streams.layout.component.impl.testing;
+
+import com.hortonworks.streamline.streams.layout.component.Stream;
+import com.hortonworks.streamline.streams.layout.component.StreamlineSource;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class TestRunSource extends StreamlineSource {
+    private final List<Map<String, Object>> testRecords;
+
+    public TestRunSource() {
+        this(Collections.EMPTY_SET, Collections.EMPTY_LIST);
+    }
+
+    public TestRunSource(Set<Stream> outputStreams, List<Map<String, Object>> testRecords) {
+        super(outputStreams);
+        this.testRecords = testRecords;
+    }
+
+    public List<Map<String, Object>> getTestRecords() {
+        return testRecords;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TestRunSource)) return false;
+        if (!super.equals(o)) return false;
+
+        TestRunSource that = (TestRunSource) o;
+
+        return getTestRecords() != null ? getTestRecords().equals(that.getTestRecords()) : that.getTestRecords() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (getTestRecords() != null ? getTestRecords().hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "TestRunSource{" +
+                "testRecords=" + testRecords +
+                '}' + super.toString();
+    }
+}

--- a/streams/runners/storm/actions/pom.xml
+++ b/streams/runners/storm/actions/pom.xml
@@ -24,6 +24,11 @@
             <groupId>com.hortonworks.streamline</groupId>
             <artifactId>streamline-layout-storm</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/StormTopologyActionsImpl.java
+++ b/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/StormTopologyActionsImpl.java
@@ -150,12 +150,12 @@ public class StormTopologyActionsImpl implements TopologyActions {
 
     @Override
     public void testRun(TopologyLayout topology, String mavenArtifacts,
-                        Map<String, TestRunSource> testRunSourcesMap,
-                        Map<String, TestRunSink> testRunSinksMap) throws Exception {
+                        Map<String, TestRunSource> testRunSourcesForEachSource,
+                        Map<String, TestRunSink> testRunSinksForEachSink) throws Exception {
         TopologyDag originalTopologyDag = topology.getTopologyDag();
 
         TestTopologyDagCreatingVisitor visitor = new TestTopologyDagCreatingVisitor(originalTopologyDag,
-                testRunSourcesMap, testRunSinksMap);
+                testRunSourcesForEachSource, testRunSinksForEachSink);
         originalTopologyDag.traverse(visitor);
         TopologyDag testTopologyDag = visitor.getTestTopologyDag();
 

--- a/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/StormTopologyActionsImpl.java
+++ b/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/StormTopologyActionsImpl.java
@@ -16,6 +16,10 @@
 package com.hortonworks.streamline.streams.actions.storm.topology;
 
 import com.google.common.base.Joiner;
+import com.hortonworks.streamline.streams.layout.component.StreamlineSink;
+import com.hortonworks.streamline.streams.layout.component.StreamlineSource;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSink;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSource;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -48,6 +52,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,6 +65,7 @@ import static java.util.stream.Collectors.toList;
 public class StormTopologyActionsImpl implements TopologyActions {
     private static final Logger LOG = LoggerFactory.getLogger(StormTopologyActionsImpl.class);
     public static final int DEFAULT_WAIT_TIME_SEC = 30;
+    public static final int TEST_RUN_TOPOLOGY_WAIT_MILLIS_FOR_SHUTDOWN = 30_000;
 
     private static final String NIMBUS_SEEDS = "nimbus.seeds";
     private static final String NIMBUS_PORT = "nimbus.port";
@@ -142,87 +148,41 @@ public class StormTopologyActionsImpl implements TopologyActions {
         }
     }
 
-    private List<String> getMavenArtifactsRelatedArgs (String mavenArtifacts) {
-        List<String> args = new ArrayList<>();
-        if (mavenArtifacts != null && !mavenArtifacts.isEmpty()) {
-            args.add("--artifacts");
-            args.add(mavenArtifacts);
-            args.add("--artifactRepositories");
-            args.add(conf.get("mavenRepoUrl"));
+    @Override
+    public void testRun(TopologyLayout topology, String mavenArtifacts,
+                        Map<String, TestRunSource> testRunSourcesMap,
+                        Map<String, TestRunSink> testRunSinksMap) throws Exception {
+        TopologyDag originalTopologyDag = topology.getTopologyDag();
+
+        TestTopologyDagCreatingVisitor visitor = new TestTopologyDagCreatingVisitor(originalTopologyDag,
+                testRunSourcesMap, testRunSinksMap);
+        originalTopologyDag.traverse(visitor);
+        TopologyDag testTopologyDag = visitor.getTestTopologyDag();
+
+        TopologyLayout testTopology = copyTopologyLayout(topology, testTopologyDag);
+
+        Path jarToDeploy = addArtifactsToJar(getArtifactsLocation(testTopology));
+        String fileName = createYamlFile(testTopology);
+        List<String> commands = new ArrayList<String>();
+        commands.add(stormCliPath);
+        commands.add("jar");
+        commands.add(jarToDeploy.toString());
+        commands.addAll(getExtraJarsArg(testTopology));
+        commands.addAll(getMavenArtifactsRelatedArgs(mavenArtifacts));
+        commands.addAll(getNimbusConf());
+        commands.add("org.apache.storm.flux.Flux");
+        commands.add("--local");
+        commands.add("-s");
+        commands.add(String.valueOf(TEST_RUN_TOPOLOGY_WAIT_MILLIS_FOR_SHUTDOWN));
+        commands.add(fileName);
+
+        ShellProcessResult shellProcessResult = executeShellProcess(commands);
+        int exitValue = shellProcessResult.exitValue;
+        if (exitValue != 0) {
+            LOG.error("Topology deploy command as test mode failed - exit code: {} / output: {}", exitValue, shellProcessResult.stdout);
+            throw new Exception("Topology could not be run " +
+                    "successfully as test mode: storm deploy command failed");
         }
-        return args;
-    }
-
-    private List<String> getExtraJarsArg(TopologyLayout topology) {
-        List<String> args = new ArrayList<>();
-        List<String> jars = new ArrayList<>();
-        Path extraJarsPath = getExtraJarsLocation(topology);
-        if (extraJarsPath.toFile().isDirectory()) {
-            File[] jarFiles = extraJarsPath.toFile().listFiles();
-            if (jarFiles != null && jarFiles.length > 0) {
-                for (File jarFile : jarFiles) {
-                    jars.add(jarFile.getAbsolutePath());
-                }
-            }
-        } else {
-            LOG.debug("Extra jars directory {} does not exist, not adding any extra jars", extraJarsPath);
-        }
-        if (!jars.isEmpty()) {
-            args.add("--jars");
-            args.add(Joiner.on(",").join(jars));
-        }
-        return args;
-    }
-
-    private List<String> getNimbusConf() {
-        List<String> args = new ArrayList<>();
-
-        // FIXME: Can't find how to pass list to nimbus.seeds for Storm CLI
-        // Maybe we need to fix Storm to parse string when expected parameter type is list
-        args.add("-c");
-        args.add("nimbus.host=" + nimbusSeeds.split(",")[0]);
-
-        args.add("-c");
-        args.add("nimbus.port=" + String.valueOf(nimbusPort));
-
-        return args;
-    }
-
-    private Path addArtifactsToJar(Path artifactsLocation) throws Exception {
-        Path jarFile = Paths.get(stormJarLocation);
-        if (artifactsLocation.toFile().isDirectory()) {
-            File[] artifacts = artifactsLocation.toFile().listFiles();
-            if (artifacts != null && artifacts.length > 0) {
-                Path newJar = Files.copy(jarFile, artifactsLocation.resolve(jarFile.getFileName()));
-
-                List<String> artifactFileNames = Arrays.stream(artifacts).filter(File::isFile)
-                        .map(File::getName).collect(toList());
-                List<String> commands = new ArrayList<>();
-
-                commands.add(javaJarCommand);
-                commands.add("uf");
-                commands.add(newJar.toString());
-
-                artifactFileNames.stream().forEachOrdered(name -> {
-                    commands.add("-C");
-                    commands.add(artifactsLocation.toString());
-                    commands.add(name);
-                });
-
-                ShellProcessResult shellProcessResult = executeShellProcess(commands);
-                if (shellProcessResult.exitValue != 0) {
-                    LOG.error("Adding artifacts to jar command failed - exit code: {} / output: {}",
-                            shellProcessResult.exitValue, shellProcessResult.stdout);
-                    throw new RuntimeException("Topology could not be deployed " +
-                            "successfully: fail to add artifacts to jar");
-                }
-                LOG.debug("Added files {} to jar {}", artifactFileNames, jarFile);
-                return newJar;
-            }
-        } else {
-            LOG.debug("Artifacts directory {} does not exist, not adding any artifacts to jar", artifactsLocation);
-        }
-        return jarFile;
     }
 
     @Override
@@ -309,6 +269,93 @@ public class StormTopologyActionsImpl implements TopologyActions {
             throw new TopologyNotAliveException("Topology not found in Storm Cluster - topology id: " + topology.getId());
         }
         return stormTopologyId;
+    }
+
+    private TopologyLayout copyTopologyLayout(TopologyLayout topology, TopologyDag replacedTopologyDag) {
+        return new TopologyLayout(topology.getId(), topology.getName(), topology.getConfig(), replacedTopologyDag);
+    }
+
+    private List<String> getMavenArtifactsRelatedArgs (String mavenArtifacts) {
+        List<String> args = new ArrayList<>();
+        if (mavenArtifacts != null && !mavenArtifacts.isEmpty()) {
+            args.add("--artifacts");
+            args.add(mavenArtifacts);
+            args.add("--artifactRepositories");
+            args.add(conf.get("mavenRepoUrl"));
+        }
+        return args;
+    }
+
+    private List<String> getExtraJarsArg(TopologyLayout topology) {
+        List<String> args = new ArrayList<>();
+        List<String> jars = new ArrayList<>();
+        Path extraJarsPath = getExtraJarsLocation(topology);
+        if (extraJarsPath.toFile().isDirectory()) {
+            File[] jarFiles = extraJarsPath.toFile().listFiles();
+            if (jarFiles != null && jarFiles.length > 0) {
+                for (File jarFile : jarFiles) {
+                    jars.add(jarFile.getAbsolutePath());
+                }
+            }
+        } else {
+            LOG.debug("Extra jars directory {} does not exist, not adding any extra jars", extraJarsPath);
+        }
+        if (!jars.isEmpty()) {
+            args.add("--jars");
+            args.add(Joiner.on(",").join(jars));
+        }
+        return args;
+    }
+
+    private List<String> getNimbusConf() {
+        List<String> args = new ArrayList<>();
+
+        // FIXME: Can't find how to pass list to nimbus.seeds for Storm CLI
+        // Maybe we need to fix Storm to parse string when expected parameter type is list
+        args.add("-c");
+        args.add("nimbus.host=" + nimbusSeeds.split(",")[0]);
+
+        args.add("-c");
+        args.add("nimbus.port=" + String.valueOf(nimbusPort));
+
+        return args;
+    }
+
+    private Path addArtifactsToJar(Path artifactsLocation) throws Exception {
+        Path jarFile = Paths.get(stormJarLocation);
+        if (artifactsLocation.toFile().isDirectory()) {
+            File[] artifacts = artifactsLocation.toFile().listFiles();
+            if (artifacts != null && artifacts.length > 0) {
+                Path newJar = Files.copy(jarFile, artifactsLocation.resolve(jarFile.getFileName()));
+
+                List<String> artifactFileNames = Arrays.stream(artifacts).filter(File::isFile)
+                        .map(File::getName).collect(toList());
+                List<String> commands = new ArrayList<>();
+
+                commands.add(javaJarCommand);
+                commands.add("uf");
+                commands.add(newJar.toString());
+
+                artifactFileNames.stream().forEachOrdered(name -> {
+                    commands.add("-C");
+                    commands.add(artifactsLocation.toString());
+                    commands.add(name);
+                });
+
+                ShellProcessResult shellProcessResult = executeShellProcess(commands);
+                if (shellProcessResult.exitValue != 0) {
+                    LOG.error("Adding artifacts to jar command failed - exit code: {} / output: {}",
+                            shellProcessResult.exitValue, shellProcessResult.stdout);
+                    throw new RuntimeException("Topology could not be deployed " +
+                            "successfully: fail to add artifacts to jar");
+                }
+                LOG.debug("Added files {} to jar {}", artifactFileNames, jarFile);
+                return newJar;
+            }
+        } else {
+            LOG.debug("Artifacts directory {} does not exist, not adding any artifacts to jar", artifactsLocation);
+        }
+        return jarFile;
     }
 
     private String createYamlFile (TopologyLayout topology) throws Exception {
@@ -405,4 +452,5 @@ public class StormTopologyActionsImpl implements TopologyActions {
             this.stdout = stdout;
         }
     }
+
 }

--- a/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/TestTopologyDagCreatingVisitor.java
+++ b/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/TestTopologyDagCreatingVisitor.java
@@ -1,0 +1,132 @@
+package com.hortonworks.streamline.streams.actions.storm.topology;
+
+import com.hortonworks.streamline.common.Config;
+import com.hortonworks.streamline.streams.layout.component.Edge;
+import com.hortonworks.streamline.streams.layout.component.InputComponent;
+import com.hortonworks.streamline.streams.layout.component.OutputComponent;
+import com.hortonworks.streamline.streams.layout.component.StreamlineProcessor;
+import com.hortonworks.streamline.streams.layout.component.StreamlineSink;
+import com.hortonworks.streamline.streams.layout.component.StreamlineSource;
+import com.hortonworks.streamline.streams.layout.component.TopologyDag;
+import com.hortonworks.streamline.streams.layout.component.TopologyDagVisitor;
+import com.hortonworks.streamline.streams.layout.component.impl.RulesProcessor;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSink;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSource;
+import com.hortonworks.streamline.streams.layout.storm.TestRunSinkBoltFluxComponent;
+import com.hortonworks.streamline.streams.layout.storm.TestRunSourceSpoutFluxComponent;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TestTopologyDagCreatingVisitor extends TopologyDagVisitor {
+
+    private final Map<String, StreamlineSource> sourceToReplacedTestSourceMap;
+    private final Map<String, StreamlineSink> sinkToReplacedTestSinkMap;
+    private final Map<String, TestRunSource> testRunSourcesMap;
+    private final Map<String, TestRunSink> testRunSinksMap;
+    private final TopologyDag originTopologyDag;
+
+    private TopologyDag testTopologyDag;
+
+    public TestTopologyDagCreatingVisitor(TopologyDag originTopologyDag,
+                                          Map<String, TestRunSource> testRunSourcesMap,
+                                          Map<String, TestRunSink> testRunSinksMap) {
+        this.originTopologyDag = originTopologyDag;
+        this.testRunSourcesMap = testRunSourcesMap;
+        this.testRunSinksMap = testRunSinksMap;
+
+        this.testTopologyDag = new TopologyDag();
+        this.sourceToReplacedTestSourceMap = new HashMap<>();
+        this.sinkToReplacedTestSinkMap = new HashMap<>();
+    }
+
+    @Override
+    public void visit(RulesProcessor rulesProcessor) {
+        visit((StreamlineProcessor) rulesProcessor);
+    }
+
+    @Override
+    public void visit(StreamlineSource source) {
+        String id = source.getId();
+        String sourceName = source.getName();
+
+        if (!testRunSourcesMap.containsKey(sourceName)) {
+            throw new IllegalStateException("Not all sources have corresponding TestRunSource instance. source name: " + sourceName);
+        }
+
+        Config config = new Config(source.getConfig());
+
+        TestRunSource testRunSource = testRunSourcesMap.get(sourceName);
+
+        testRunSource.setId(id);
+        testRunSource.setName(sourceName);
+        testRunSource.setConfig(config);
+        testRunSource.setTransformationClass(TestRunSourceSpoutFluxComponent.class.getName());
+
+        testTopologyDag.add(testRunSource);
+        sourceToReplacedTestSourceMap.put(sourceName, testRunSource);
+    }
+
+    @Override
+    public void visit(StreamlineSink sink) {
+        String id = sink.getId();
+        String sinkName = sink.getName();
+
+        if (!testRunSinksMap.containsKey(sinkName)) {
+            throw new IllegalStateException("Not all sinks have corresponding TestRunSink instance. sink name: " + sinkName);
+        }
+
+        Config config = new Config(sink.getConfig());
+
+        TestRunSink testRunSink = testRunSinksMap.get(sinkName);
+
+        testRunSink.setId(id);
+        testRunSink.setName(sinkName);
+        testRunSink.setConfig(config);
+        testRunSink.setTransformationClass(TestRunSinkBoltFluxComponent.class.getName());
+
+        testTopologyDag.add(testRunSink);
+        sinkToReplacedTestSinkMap.put(sinkName, testRunSink);
+
+        copyEdges(sink);
+    }
+
+    @Override
+    public void visit(StreamlineProcessor processor) {
+        testTopologyDag.add(processor);
+
+        copyEdges(processor);
+    }
+
+    private void copyEdges(InputComponent inputComponent) {
+        List<Edge> edgesTo = originTopologyDag.getEdgesTo(inputComponent);
+        edgesTo.forEach(e -> {
+            OutputComponent from = e.getFrom();
+            InputComponent to = e.getTo();
+            Edge newEdge = new Edge(e.getId(), e.getFrom(), e.getTo(), e.getStreamGroupings());
+
+            StreamlineSource replacedSource = sourceToReplacedTestSourceMap.get(from.getName());
+            StreamlineSink replacedSink = sinkToReplacedTestSinkMap.get(to.getName());
+
+            if (replacedSource != null) {
+                newEdge.setFrom(replacedSource);
+            }
+
+            if (replacedSink != null) {
+                newEdge.setTo(replacedSink);
+            }
+
+            testTopologyDag.addEdge(newEdge);
+        });
+    }
+
+    @Override
+    public void visit(Edge edge) {
+        // no-op
+    }
+
+    public TopologyDag getTestTopologyDag() {
+        return testTopologyDag;
+    }
+}

--- a/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/TestTopologyDagCreatingVisitor.java
+++ b/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/TestTopologyDagCreatingVisitor.java
@@ -23,18 +23,18 @@ public class TestTopologyDagCreatingVisitor extends TopologyDagVisitor {
 
     private final Map<String, StreamlineSource> sourceToReplacedTestSourceMap;
     private final Map<String, StreamlineSink> sinkToReplacedTestSinkMap;
-    private final Map<String, TestRunSource> testRunSourcesMap;
-    private final Map<String, TestRunSink> testRunSinksMap;
+    private final Map<String, TestRunSource> testRunSourcesForEachSource;
+    private final Map<String, TestRunSink> testRunSinksForEachSink;
     private final TopologyDag originTopologyDag;
 
     private TopologyDag testTopologyDag;
 
     public TestTopologyDagCreatingVisitor(TopologyDag originTopologyDag,
-                                          Map<String, TestRunSource> testRunSourcesMap,
-                                          Map<String, TestRunSink> testRunSinksMap) {
+                                          Map<String, TestRunSource> testRunSourcesForEachSource,
+                                          Map<String, TestRunSink> testRunSinksForEachSink) {
         this.originTopologyDag = originTopologyDag;
-        this.testRunSourcesMap = testRunSourcesMap;
-        this.testRunSinksMap = testRunSinksMap;
+        this.testRunSourcesForEachSource = testRunSourcesForEachSource;
+        this.testRunSinksForEachSink = testRunSinksForEachSink;
 
         this.testTopologyDag = new TopologyDag();
         this.sourceToReplacedTestSourceMap = new HashMap<>();
@@ -51,13 +51,13 @@ public class TestTopologyDagCreatingVisitor extends TopologyDagVisitor {
         String id = source.getId();
         String sourceName = source.getName();
 
-        if (!testRunSourcesMap.containsKey(sourceName)) {
+        if (!testRunSourcesForEachSource.containsKey(sourceName)) {
             throw new IllegalStateException("Not all sources have corresponding TestRunSource instance. source name: " + sourceName);
         }
 
         Config config = new Config(source.getConfig());
 
-        TestRunSource testRunSource = testRunSourcesMap.get(sourceName);
+        TestRunSource testRunSource = testRunSourcesForEachSource.get(sourceName);
 
         testRunSource.setId(id);
         testRunSource.setName(sourceName);
@@ -73,13 +73,13 @@ public class TestTopologyDagCreatingVisitor extends TopologyDagVisitor {
         String id = sink.getId();
         String sinkName = sink.getName();
 
-        if (!testRunSinksMap.containsKey(sinkName)) {
+        if (!testRunSinksForEachSink.containsKey(sinkName)) {
             throw new IllegalStateException("Not all sinks have corresponding TestRunSink instance. sink name: " + sinkName);
         }
 
         Config config = new Config(sink.getConfig());
 
-        TestRunSink testRunSink = testRunSinksMap.get(sinkName);
+        TestRunSink testRunSink = testRunSinksForEachSink.get(sinkName);
 
         testRunSink.setId(id);
         testRunSink.setName(sinkName);

--- a/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/storm/topology/TestTopologyDagCreatingVisitorTest.java
+++ b/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/storm/topology/TestTopologyDagCreatingVisitorTest.java
@@ -55,7 +55,7 @@ public class TestTopologyDagCreatingVisitorTest {
 
         TestRunSource testRunSource = (TestRunSource) testSources.get(0);
         assertEquals(originSource.getId(), testRunSource.getId());
-        assertEquals(testSource.getTestRecords(), testRunSource.getTestRecords());
+        assertEquals(testSource.getTestRecordsForEachStream(), testRunSource.getTestRecordsForEachStream());
     }
 
     @Test

--- a/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/storm/topology/TestTopologyDagCreatingVisitorTest.java
+++ b/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/storm/topology/TestTopologyDagCreatingVisitorTest.java
@@ -1,0 +1,374 @@
+package com.hortonworks.streamline.streams.actions.storm.topology;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.hortonworks.streamline.common.Config;
+import com.hortonworks.streamline.common.Schema;
+import com.hortonworks.streamline.streams.layout.component.Edge;
+import com.hortonworks.streamline.streams.layout.component.InputComponent;
+import com.hortonworks.streamline.streams.layout.component.OutputComponent;
+import com.hortonworks.streamline.streams.layout.component.Stream;
+import com.hortonworks.streamline.streams.layout.component.StreamlineProcessor;
+import com.hortonworks.streamline.streams.layout.component.StreamlineSink;
+import com.hortonworks.streamline.streams.layout.component.StreamlineSource;
+import com.hortonworks.streamline.streams.layout.component.TopologyDag;
+import com.hortonworks.streamline.streams.layout.component.impl.RulesProcessor;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSink;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSource;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class TestTopologyDagCreatingVisitorTest {
+    @Test
+    public void visitSource() throws Exception {
+        StreamlineSource originSource = createStreamlineSource("1");
+
+        TopologyDag originTopologyDag = new TopologyDag();
+        originTopologyDag.add(originSource);
+
+        TestRunSource testSource = createTestRunSource(originSource);
+
+        TestTopologyDagCreatingVisitor visitor =
+                new TestTopologyDagCreatingVisitor(originTopologyDag,
+                        Collections.singletonMap(originSource.getName(), testSource),
+                        Collections.emptyMap());
+        visitor.visit(originSource);
+
+        TopologyDag testTopologyDag = visitor.getTestTopologyDag();
+
+        List<OutputComponent> testSources = testTopologyDag.getOutputComponents().stream()
+                .filter(o -> (o instanceof TestRunSource && o.getName().equals(originSource.getName())))
+                .collect(toList());
+
+        assertEquals(1, testSources.size());
+
+        TestRunSource testRunSource = (TestRunSource) testSources.get(0);
+        assertEquals(originSource.getId(), testRunSource.getId());
+        assertEquals(testSource.getTestRecords(), testRunSource.getTestRecords());
+    }
+
+    @Test
+    public void visitSource_noMatchingTestRunSource() throws Exception {
+        StreamlineSource originSource = createStreamlineSource("1");
+
+        TopologyDag originTopologyDag = new TopologyDag();
+        originTopologyDag.add(originSource);
+
+        TestTopologyDagCreatingVisitor visitor =
+                new TestTopologyDagCreatingVisitor(originTopologyDag, Collections.emptyMap(), Collections.emptyMap());
+
+        try {
+            visitor.visit(originSource);
+            fail("IllegalStateException should be thrown.");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains(originSource.getName()));
+        }
+    }
+
+    @Test
+    public void visitSink_connectedFromSource() throws Exception {
+        StreamlineSource originSource = createStreamlineSource("1");
+        StreamlineSink originSink = createStreamlineSink("2");
+
+        TopologyDag originTopologyDag = new TopologyDag();
+        originTopologyDag.add(originSource);
+        originTopologyDag.add(originSink);
+        originTopologyDag.addEdge(new Edge("e1", originSource, originSink, "default", Stream.Grouping.SHUFFLE));
+
+        TestRunSource testSource = createTestRunSource(originSource);
+        TestRunSink testSink = createTestRunSink();
+
+        TestTopologyDagCreatingVisitor visitor =
+                new TestTopologyDagCreatingVisitor(originTopologyDag,
+                        Collections.singletonMap(originSource.getName(), testSource),
+                        Collections.singletonMap(originSink.getName(), testSink));
+
+        visitor.visit(originSource);
+        visitor.visit(originSink);
+
+        TopologyDag testTopologyDag = visitor.getTestTopologyDag();
+
+        List<OutputComponent> testSources = testTopologyDag.getOutputComponents().stream()
+                .filter(o -> (o instanceof TestRunSource && o.getName().equals(originSource.getName())))
+                .collect(toList());
+
+        List<InputComponent> testSinks = testTopologyDag.getInputComponents().stream()
+                .filter(o -> (o instanceof TestRunSink && o.getName().equals(originSink.getName())))
+                .collect(toList());
+
+        assertEquals(1, testSinks.size());
+
+        TestRunSource testRunSource = (TestRunSource) testSources.get(0);
+        TestRunSink testRunSink = (TestRunSink) testSinks.get(0);
+        assertEquals(originSink.getId(), testRunSink.getId());
+        assertEquals(testSink.getOutputFileUUID(), testRunSink.getOutputFileUUID());
+        assertEquals(testSink.getOutputFilePath(), testRunSink.getOutputFilePath());
+
+        assertEquals(1, testTopologyDag.getEdgesFrom(testRunSource).size());
+        assertEquals(1, testTopologyDag.getEdgesTo(testRunSink).size());
+
+        assertTrue(testTopologyDag.getEdgesFrom(testRunSource).get(0) == testTopologyDag.getEdgesTo(testRunSink).get(0));
+    }
+
+    @Test
+    public void visitSink_connectedFromProcessor() throws Exception {
+        StreamlineProcessor originProcessor = createStreamlineProcessor("1");
+        StreamlineSink originSink = createStreamlineSink("2");
+
+        TopologyDag originTopologyDag = new TopologyDag();
+        originTopologyDag.add(originProcessor);
+        originTopologyDag.add(originSink);
+        originTopologyDag.addEdge(new Edge("e1", originProcessor, originSink, "default", Stream.Grouping.SHUFFLE));
+
+        TestRunSink testSink = createTestRunSink();
+
+        TestTopologyDagCreatingVisitor visitor =
+                new TestTopologyDagCreatingVisitor(originTopologyDag,
+                        Collections.emptyMap(),
+                        Collections.singletonMap(originSink.getName(), testSink));
+
+        visitor.visit(originProcessor);
+        visitor.visit(originSink);
+
+        TopologyDag testTopologyDag = visitor.getTestTopologyDag();
+
+        List<InputComponent> testSinks = testTopologyDag.getInputComponents().stream()
+                .filter(o -> (o instanceof TestRunSink && o.getName().equals(originSink.getName())))
+                .collect(toList());
+
+        assertEquals(1, testSinks.size());
+
+        TestRunSink testRunSink = (TestRunSink) testSinks.get(0);
+        assertEquals(originSink.getId(), testRunSink.getId());
+        assertEquals(testSink.getOutputFileUUID(), testRunSink.getOutputFileUUID());
+        assertEquals(testSink.getOutputFilePath(), testRunSink.getOutputFilePath());
+
+        assertEquals(1, testTopologyDag.getEdgesFrom(originProcessor).size());
+        assertEquals(1, testTopologyDag.getEdgesTo(testRunSink).size());
+
+        assertTrue(testTopologyDag.getEdgesFrom(originProcessor).get(0) == testTopologyDag.getEdgesTo(testRunSink).get(0));
+    }
+
+    @Test
+    public void visitSink_noMatchingTestRunSink() throws Exception {
+        TopologyDag originTopologyDag = new TopologyDag();
+        StreamlineSink originSink = createStreamlineSink("1");
+        originTopologyDag.add(originSink);
+
+        TestTopologyDagCreatingVisitor visitor =
+                new TestTopologyDagCreatingVisitor(originTopologyDag, Collections.emptyMap(), Collections.emptyMap());
+
+        try {
+            visitor.visit(originSink);
+            fail("IllegalStateException should be thrown.");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains(originSink.getName()));
+        }
+    }
+
+    @Test
+    public void visitProcessor_connectedFromSource() throws Exception {
+        StreamlineSource originSource = createStreamlineSource("1");
+        StreamlineProcessor originProcessor = createStreamlineProcessor("2");
+
+        TopologyDag originTopologyDag = new TopologyDag();
+        originTopologyDag.add(originSource);
+        originTopologyDag.add(originProcessor);
+        originTopologyDag.addEdge(new Edge("e1", originSource, originProcessor, "default", Stream.Grouping.SHUFFLE));
+
+        TestRunSource testSource = createTestRunSource(originSource);
+
+        TestTopologyDagCreatingVisitor visitor =
+                new TestTopologyDagCreatingVisitor(originTopologyDag,
+                        Collections.singletonMap(originSource.getName(), testSource),
+                        Collections.emptyMap());
+
+        visitor.visit(originSource);
+        visitor.visit(originProcessor);
+
+        TopologyDag testTopologyDag = visitor.getTestTopologyDag();
+
+        List<OutputComponent> testSources = testTopologyDag.getOutputComponents().stream()
+                .filter(o -> (o instanceof TestRunSource && o.getName().equals(originSource.getName())))
+                .collect(toList());
+
+        TestRunSource testRunSource = (TestRunSource) testSources.get(0);
+
+        assertEquals(1, testTopologyDag.getEdgesFrom(testRunSource).size());
+        assertEquals(1, testTopologyDag.getEdgesTo(originProcessor).size());
+
+        assertTrue(testTopologyDag.getEdgesFrom(testRunSource).get(0) == testTopologyDag.getEdgesTo(originProcessor).get(0));
+    }
+
+    @Test
+    public void visitProcessor_connectedFromProcessor() throws Exception {
+        StreamlineProcessor originProcessor = createStreamlineProcessor("1");
+        StreamlineProcessor originProcessor2 = createStreamlineProcessor("2");
+
+        TopologyDag originTopologyDag = new TopologyDag();
+        originTopologyDag.add(originProcessor);
+        originTopologyDag.add(originProcessor2);
+        originTopologyDag.addEdge(new Edge("e1", originProcessor, originProcessor2, "default", Stream.Grouping.SHUFFLE));
+
+        TestTopologyDagCreatingVisitor visitor =
+                new TestTopologyDagCreatingVisitor(originTopologyDag,
+                        Collections.emptyMap(),
+                        Collections.emptyMap());
+
+        visitor.visit(originProcessor);
+        visitor.visit(originProcessor2);
+
+        TopologyDag testTopologyDag = visitor.getTestTopologyDag();
+
+        assertEquals(1, testTopologyDag.getEdgesFrom(originProcessor).size());
+        assertEquals(1, testTopologyDag.getEdgesTo(originProcessor2).size());
+
+        assertTrue(testTopologyDag.getEdgesFrom(originProcessor).get(0) == testTopologyDag.getEdgesTo(originProcessor2).get(0));
+    }
+
+    @Test
+    public void visitRulesProcessor_connectedFromSource() throws Exception {
+        StreamlineSource originSource = createStreamlineSource("1");
+        RulesProcessor rulesProcessor = createRulesProcessor("2");
+
+        TopologyDag originTopologyDag = new TopologyDag();
+        originTopologyDag.add(originSource);
+        originTopologyDag.add(rulesProcessor);
+        originTopologyDag.addEdge(new Edge("e1", originSource, rulesProcessor, "default", Stream.Grouping.SHUFFLE));
+
+        TestRunSource testSource = createTestRunSource(originSource);
+
+        TestTopologyDagCreatingVisitor visitor =
+                new TestTopologyDagCreatingVisitor(originTopologyDag,
+                        Collections.singletonMap(originSource.getName(), testSource),
+                        Collections.emptyMap());
+
+        visitor.visit(originSource);
+        visitor.visit(rulesProcessor);
+
+        TopologyDag testTopologyDag = visitor.getTestTopologyDag();
+
+        List<OutputComponent> testSources = testTopologyDag.getOutputComponents().stream()
+                .filter(o -> (o instanceof TestRunSource && o.getName().equals(originSource.getName())))
+                .collect(toList());
+
+        TestRunSource testRunSource = (TestRunSource) testSources.get(0);
+
+        assertEquals(1, testTopologyDag.getEdgesFrom(testRunSource).size());
+        assertEquals(1, testTopologyDag.getEdgesTo(rulesProcessor).size());
+
+        assertTrue(testTopologyDag.getEdgesFrom(testRunSource).get(0) == testTopologyDag.getEdgesTo(rulesProcessor).get(0));
+    }
+
+    @Test
+    public void visitRulesProcessor_connectedFromProcessor() throws Exception {
+        StreamlineProcessor originProcessor = createStreamlineProcessor("1");
+        RulesProcessor rulesProcessor = createRulesProcessor("2");
+
+        TopologyDag originTopologyDag = new TopologyDag();
+        originTopologyDag.add(originProcessor);
+        originTopologyDag.add(rulesProcessor);
+        originTopologyDag.addEdge(new Edge("e1", originProcessor, rulesProcessor, "default", Stream.Grouping.SHUFFLE));
+
+        TestTopologyDagCreatingVisitor visitor =
+                new TestTopologyDagCreatingVisitor(originTopologyDag,
+                        Collections.emptyMap(),
+                        Collections.emptyMap());
+
+        visitor.visit(originProcessor);
+        visitor.visit(rulesProcessor);
+
+        TopologyDag testTopologyDag = visitor.getTestTopologyDag();
+
+        assertEquals(1, testTopologyDag.getEdgesFrom(originProcessor).size());
+        assertEquals(1, testTopologyDag.getEdgesTo(rulesProcessor).size());
+
+        assertTrue(testTopologyDag.getEdgesFrom(originProcessor).get(0) == testTopologyDag.getEdgesTo(rulesProcessor).get(0));
+    }
+
+    private StreamlineSource createStreamlineSource(String id) {
+        Stream stream = createDefaultStream();
+        StreamlineSource source = new StreamlineSource(Sets.newHashSet(stream));
+        source.setId(id);
+        source.setName("testSource_" + id);
+        source.setConfig(new Config());
+        source.setTransformationClass("dummyTransformation");
+        return source;
+    }
+
+    private StreamlineProcessor createStreamlineProcessor(String id) {
+        Stream stream = createDefaultStream();
+        StreamlineProcessor processor = new StreamlineProcessor(Sets.newHashSet(stream));
+        processor.setId(id);
+        processor.setName("testProcessor_" + id);
+        processor.setConfig(new Config());
+        processor.setTransformationClass("dummyTransformation");
+        return processor;
+    }
+
+    private RulesProcessor createRulesProcessor(String id) {
+        RulesProcessor processor = new RulesProcessor();
+        processor.setId(id);
+        processor.setName("testRuleProcessor_" + id);
+        processor.setConfig(new Config());
+        processor.setTransformationClass("dummyTransformation");
+        processor.setProcessAll(true);
+        processor.setRules(Collections.emptyList());
+        return processor;
+    }
+
+    private StreamlineSink createStreamlineSink(String id) {
+        StreamlineSink sink = new StreamlineSink();
+        sink.setId(id);
+        sink.setName("testSink_" + id);
+        sink.setConfig(new Config());
+        sink.setTransformationClass("dummyTransformation");
+        return sink;
+    }
+
+    private TestRunSource createTestRunSource(StreamlineSource originSource) {
+        Map<String, List<Map<String, Object>>> testRecordsMap = new HashMap<>();
+        for (Stream stream : originSource.getOutputStreams()) {
+            testRecordsMap.put(stream.getId(), createTestRecords());
+        }
+        return new TestRunSource(originSource.getOutputStreams(), testRecordsMap);
+    }
+
+    private List<Map<String, Object>> createTestRecords() {
+        List<Map<String, Object>> testRecords = new ArrayList<>();
+
+        Map<String, Object> testRecord1 = new HashMap<>();
+        testRecord1.put("A", 1);
+        testRecord1.put("B", 2);
+
+        Map<String, Object> testRecord2 = new HashMap<>();
+        testRecord2.put("A", 1);
+        testRecord2.put("B", 2);
+
+        testRecords.add(testRecord1);
+        testRecords.add(testRecord2);
+
+        return testRecords;
+    }
+
+    private TestRunSink createTestRunSink() {
+        return new TestRunSink(UUID.randomUUID().toString(), "dummyFilePath");
+    }
+
+    private Stream createDefaultStream() {
+        Schema.Field field = Schema.Field.of("A", Schema.Type.INTEGER);
+        Schema.Field field2 = Schema.Field.of("B", Schema.Type.INTEGER);
+        return new Stream("default", Lists.newArrayList(field, field2));
+    }
+}

--- a/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/TestRunSinkBoltFluxComponent.java
+++ b/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/TestRunSinkBoltFluxComponent.java
@@ -1,0 +1,51 @@
+/**
+  * Copyright 2017 Hortonworks.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+
+  *   http://www.apache.org/licenses/LICENSE-2.0
+
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.layout.storm;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSink;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestRunSinkBoltFluxComponent extends AbstractFluxComponent {
+    private final Logger log = LoggerFactory.getLogger(TestRunSinkBoltFluxComponent.class);
+
+    protected TestRunSink testRunSink;
+
+    @Override
+    protected void generateComponent() {
+        testRunSink = (TestRunSink) conf.get(StormTopologyLayoutConstants.STREAMLINE_COMPONENT_CONF_KEY);
+        String spoutId = "testRunSinkBolt" + UUID_FOR_COMPONENTS;
+        String spoutClassName = "com.hortonworks.streamline.streams.runtime.storm.testing.TestRunSinkBolt";
+        List<Object> constructorArgs = new ArrayList<>();
+        ObjectMapper mapper = new ObjectMapper();
+        String testRunSourceJson = null;
+        try {
+            testRunSourceJson = mapper.writeValueAsString(testRunSink);
+        } catch (JsonProcessingException e) {
+            log.error("Error creating json config string for TestRunSink", e);
+        }
+        constructorArgs.add(testRunSourceJson);
+        component = createComponent(spoutId, spoutClassName, null, constructorArgs, null);
+        addParallelismToComponent();
+    }
+
+}

--- a/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/TestRunSourceSpoutFluxComponent.java
+++ b/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/TestRunSourceSpoutFluxComponent.java
@@ -1,0 +1,50 @@
+/**
+  * Copyright 2017 Hortonworks.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+
+  *   http://www.apache.org/licenses/LICENSE-2.0
+
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.layout.storm;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestRunSourceSpoutFluxComponent extends AbstractFluxComponent {
+    private final Logger log = LoggerFactory.getLogger(TestRunSourceSpoutFluxComponent.class);
+
+    protected TestRunSource testRunSource;
+
+    @Override
+    protected void generateComponent() {
+        testRunSource = (TestRunSource) conf.get(StormTopologyLayoutConstants.STREAMLINE_COMPONENT_CONF_KEY);
+        String spoutId = "testRunSourceSpout" + UUID_FOR_COMPONENTS;
+        String spoutClassName = "com.hortonworks.streamline.streams.runtime.storm.testing.TestRunSourceSpout";
+        List<Object> constructorArgs = new ArrayList<>();
+        ObjectMapper mapper = new ObjectMapper();
+        String testRunSourceJson = null;
+        try {
+            testRunSourceJson = mapper.writeValueAsString(testRunSource);
+        } catch (JsonProcessingException e) {
+            log.error("Error creating json config string for TestRunSource", e);
+        }
+        constructorArgs.add(testRunSourceJson);
+        component = createComponent(spoutId, spoutClassName, null, constructorArgs, null);
+        addParallelismToComponent();
+    }
+
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunSinkBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunSinkBolt.java
@@ -1,0 +1,81 @@
+package com.hortonworks.streamline.streams.runtime.storm.testing;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hortonworks.streamline.common.util.Utils;
+import com.hortonworks.streamline.streams.StreamlineEvent;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSink;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.topology.base.BaseRichBolt;
+import org.apache.storm.tuple.Tuple;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Map;
+
+public class TestRunSinkBolt extends BaseRichBolt {
+    private static final Logger LOG = LoggerFactory.getLogger(TestRunSinkBolt.class);
+
+    private transient OutputCollector collector;
+    private transient ObjectMapper objectMapper;
+
+    private final TestRunSink testRunSink;
+
+    public TestRunSinkBolt(String testRunSinkJson) {
+        this(Utils.createObjectFromJson(testRunSinkJson, TestRunSink.class));
+    }
+
+    public TestRunSinkBolt(TestRunSink testRunSink) {
+        this.testRunSink = testRunSink;
+    }
+
+    @Override
+    public void prepare(Map stormConf, TopologyContext context, OutputCollector collector) {
+        if (this.testRunSink == null) {
+            throw new RuntimeException("testRunSink cannot be null");
+        }
+        if (StringUtils.isEmpty(this.testRunSink.getOutputFilePath())) {
+            throw new RuntimeException("output file path cannot be null or empty");
+        }
+
+        this.collector = collector;
+        this.objectMapper = new ObjectMapper();
+
+        String outputFilePath = testRunSink.getOutputFilePath();
+        try (FileWriter fw = new FileWriter(outputFilePath, true)) {
+            // no op
+        } catch (IOException e) {
+            LOG.error("Can't open file for preparing to write: " + outputFilePath);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void execute(Tuple input) {
+        String outputFilePath = testRunSink.getOutputFilePath();
+        try (FileWriter fw = new FileWriter(outputFilePath, true)) {
+            LOG.info("writing event to file " + outputFilePath);
+            Object value = input.getValueByField(StreamlineEvent.STREAMLINE_EVENT);
+            StreamlineEvent event = (StreamlineEvent) value;
+            fw.write(objectMapper.writeValueAsString(event) + "\n");
+            fw.flush();
+            collector.ack(input);
+        } catch (FileNotFoundException e) {
+            LOG.error("Can't open file for write: " + outputFilePath);
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            LOG.error("Fail to write event to output file " + outputFilePath + " : exception occurred.", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        // nothing to emit
+    }
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunSourceSpout.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunSourceSpout.java
@@ -1,0 +1,80 @@
+package com.hortonworks.streamline.streams.runtime.storm.testing;
+
+import com.hortonworks.streamline.common.util.Utils;
+import com.hortonworks.streamline.streams.StreamlineEvent;
+import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSource;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.topology.base.BaseRichSpout;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Values;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Queue;
+
+public class TestRunSourceSpout extends BaseRichSpout {
+    private static final Logger LOG = LoggerFactory.getLogger(TestRunSourceSpout.class);
+    private SpoutOutputCollector _collector;
+
+    private final TestRunSource testRunSource;
+    private final Queue<Map<String, Object>> testRecordsQueue;
+
+    public TestRunSourceSpout(String testRunSourceJson) {
+        this(Utils.createObjectFromJson(testRunSourceJson, TestRunSource.class));
+    }
+
+    public TestRunSourceSpout(TestRunSource testRunSource) {
+        this.testRunSource = testRunSource;
+        if (testRunSource != null) {
+            testRecordsQueue = new LinkedList<>(testRunSource.getTestRecords());
+        } else {
+            testRecordsQueue = new LinkedList<>();
+        }
+    }
+
+    @Override
+    public void open(Map conf, TopologyContext context, SpoutOutputCollector collector) {
+        if (this.testRunSource == null) {
+            throw new RuntimeException("testRunSource cannot be null");
+        }
+        _collector = collector;
+    }
+
+    @Override
+    public void nextTuple() {
+        Map<String, Object> record = testRecordsQueue.poll();
+        if (record == null) {
+            LOG.info("No more records, sleeping...");
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                // no-op
+            }
+            return;
+        }
+
+        testRunSource.getOutputStreams().forEach(stream -> {
+            StreamlineEventImpl streamlineEvent = new StreamlineEventImpl(record, testRunSource.getId());
+            LOG.info("Emitting event {} to stream {}", streamlineEvent, stream.getId());
+            _collector.emit(stream.getId(), new Values(streamlineEvent), streamlineEvent.getId());
+        });
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        if (testRunSource == null) {
+            throw new RuntimeException("testRunSource cannot be null");
+        }
+        Fields outputFields = getOutputFields();
+        testRunSource.getOutputStreams().forEach(s -> declarer.declareStream(s.getId(), outputFields));
+    }
+
+    public Fields getOutputFields() {
+        return new Fields(StreamlineEvent.STREAMLINE_EVENT);
+    }
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunSourceSpout.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunSourceSpout.java
@@ -34,7 +34,7 @@ public class TestRunSourceSpout extends BaseRichSpout {
         this.testRunSource = testRunSource;
         testRecordsQueueMap = new HashMap<>();
         if (testRunSource != null) {
-            Map<String, List<Map<String, Object>>> testRecords = testRunSource.getTestRecords();
+            Map<String, List<Map<String, Object>>> testRecords = testRunSource.getTestRecordsForEachStream();
             for (Map.Entry<String, List<Map<String, Object>>> entry : testRecords.entrySet()) {
                 testRecordsQueueMap.put(entry.getKey(), new LinkedList<>(entry.getValue()));
             }

--- a/webservice/src/test/resources/streamline-test.yaml
+++ b/webservice/src/test/resources/streamline-test.yaml
@@ -9,6 +9,8 @@ modules:
       #change the below to the path on your local machine
       streamlineStormJar: /tmp/streamline-runtime-storm-0.1.0-SNAPSHOT.jar
       stormHomeDir: /usr/local/Cellar/storm/0.10.0/
+      # directory to store the results of topology test run
+      topologyTestRunResultDir: /tmp
       # schema registry configuration
       schemaRegistryUrl: "http://localhost:9090/api/v1"
       #Custom processor upload configuration


### PR DESCRIPTION
TODO
----
- [x] : add unit tests

Summary
----
* Introduce 'test run' for topology actions
  * replace sources with test sources and sinks with test sinks from topology DAG
    * test source just emits test records (user input) to the downstream
    * test sink just writes received events to local file (generated uuid)
  * run topology via local mode, with 30s shutdown
  * create API endpoints for requesting test run and providing results

API endpoint
----
1. Run topology on test mode

- path: `/topologies/:topologyId/actions/testrun`
- method: POST
- input param: JSON (application/json)

```
{
  "<source name>": {
    "<stream name>": [
      <json format of record 1>,
      <json format of record 2>,
      ...
      <json format of record N>
    ],
    ...
    "<stream name>": [
      ...
    ]
  },
  ...
}
```

The JSON input should contain all sources in topology.

- Response

```
{
  "<sink name>": {
    "uuid": "<generated uuid value>",
    "eventDumpLink": "<full url path for retrieving result events for that sink>"
  },
  ...
}
```

The JSON response will contain all sinks in topology.

2. Retrieve result events of specific sink on topology test run

- path: `/topologies/actions/testrun/result/:uuid`
- method: GET

Full URI will be provided from API response of 1.

- Response

```
{
  "entities": [
    <json format of event 1>,
    <json format of event 1>,
    ...
    <json format of event N>,
  ]
}
```

Note
----
This is a patch for first iteration of [STREAMLINE-381](https://hwxiot.atlassian.net/browse/STREAMLINE-381). I'll file issues for each iterations soon.

There're something to consider and discuss:

1.
Since we're running test topology as local mode, run command doesn't return unless local cluster shutdown is complete. Same thing applies to the API endpoint, so that API will take about 1 minute (or more) to respond, and even hang if Storm has a bug on local cluster shutdown (e.g. non-daemon threads alive).

I'm thinking about asynchronous run, but then we need to have state of running status (maybe need to store to a new table), and UI needs to check the status periodically (or even users need to check it periodically)

2.
Ideally process should start shut down when all test records get processed, but Flux runner doesn't have the feature, and even we implement our own, specific signal should be made for accomplish this.
This patch just sets 30 seconds to shutdown local cluster (Flux provides this feature) which is enough for many cases, but still wondering whether we need to expose this so that users can change waiting seconds.