### PR TITLE
STREAMLINE-631 Pick runtime jar in libs dir to the default streamlineStormJar config

### DIFF
--- a/bin/streamline-server-start.sh
+++ b/bin/streamline-server-start.sh
@@ -19,7 +19,22 @@ then
         echo "USAGE: $0 [-daemon] streamline.yaml"
         exit 1
 fi
-base_dir=$(dirname $0)/..
+
+# Resolve links - $0 may be a softlink
+PRG="${0}"
+
+while [ -h "${PRG}" ]; do
+  ls=`ls -ld "${PRG}"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "${PRG}"`/"$link"
+  fi
+done
+
+bin_dir=`dirname ${PRG}`
+base_dir=`cd ${bin_dir}/..;pwd`
 
 if [ "x$STREAMLINE_HEAP_OPTS" = "x" ]; then
     export STREAMLINE_HEAP_OPTS="-Xmx1G -Xms1G"
@@ -81,6 +96,9 @@ if [ -z "$JAVA_HOME" ]; then
 else
   JAVA="$JAVA_HOME/bin/java"
 fi
+
+# add streamline base directory
+STREAMLINE_OPTS="-Dstreamline.home=${base_dir} "
 
 # JVM performance options
 if [ -z "$STREAMLINE_JVM_PERFORMANCE_OPTS" ]; then

--- a/conf/streamline.mysql.yaml
+++ b/conf/streamline.mysql.yaml
@@ -8,8 +8,6 @@ modules:
   - name: streams
     className: com.hortonworks.streamline.streams.service.StreamsModule
     config:
-      #change the below to the path on your local machine
-      streamlineStormJar: /tmp/streamline-runtime-storm-0.1.0-SNAPSHOT.jar
       stormHomeDir: /usr/local/Cellar/storm/0.10.0/
       # schema registry configuration
       schemaRegistryUrl: "http://localhost:9090/api/v1"

--- a/conf/streamline.phoenix.yaml
+++ b/conf/streamline.phoenix.yaml
@@ -8,8 +8,6 @@ modules:
   - name: streams
     className: com.hortonworks.streamline.streams.service.StreamsModule
     config:
-      #change the below to the path on your local machine
-      streamlineStormJar: /tmp/streamline-runtime-storm-0.1.0-SNAPSHOT.jar
       stormHomeDir: /usr/local/Cellar/storm/0.10.0/
       # schema registry configuration
       schemaRegistryUrl: "http://localhost:9090/api/v1"

--- a/conf/streamline.yaml
+++ b/conf/streamline.yaml
@@ -8,8 +8,6 @@ modules:
   - name: streams
     className: com.hortonworks.streamline.streams.service.StreamsModule
     config:
-      #change the below to the path on your local machine
-      streamlineStormJar: /tmp/streamline-runtime-storm-0.1.0-SNAPSHOT.jar
       stormHomeDir: /usr/local/Cellar/storm/0.10.0/
       # schema registry configuration
       schemaRegistryUrl: "http://localhost:9090/api/v1"

--- a/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/StormTopologyActionsImpl.java
+++ b/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/StormTopologyActionsImpl.java
@@ -76,7 +76,8 @@ public class StormTopologyActionsImpl implements TopologyActions {
                 }
                 stormCliPath = stormHomeDir + "bin" + File.separator + "storm";
             }
-            stormJarLocation = conf.get(StormTopologyLayoutConstants.STORM_JAR_LOCATION_KEY);
+            this.stormJarLocation = conf.get(StormTopologyLayoutConstants.STORM_JAR_LOCATION_KEY);
+
             catalogRootUrl = conf.get(StormTopologyLayoutConstants.YAML_KEY_CATALOG_ROOT_URL);
 
             Map<String, String> env = System.getenv();
@@ -102,7 +103,6 @@ public class StormTopologyActionsImpl implements TopologyActions {
         File f = new File (stormArtifactsLocation);
         f.mkdirs();
     }
-
 
     @Override
     public void deploy(TopologyLayout topology, String mavenArtifacts) throws Exception {


### PR DESCRIPTION
* Replace ${STREAMLINE_HOME} in streamlineStormJar to the streamline home directory
  * streamline-server-start.sh finds home directory and pass via Java system property
* when streamlineStormJar is not present, it will take default path

@harshach This is updated PR of #491. Please review.