### PR TITLE
STREAMLINE-664 Handle tick tuples in all storm components of a streamline topology

### DIFF
--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/AbstractProcessorBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/AbstractProcessorBolt.java
@@ -21,6 +21,7 @@ import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.base.BaseRichBolt;
 import org.apache.storm.tuple.Tuple;
+import org.apache.storm.utils.TupleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +30,7 @@ import java.util.Map;
 /**
  *
  */
-public abstract class AbstractProcessorBolt extends BaseRichBolt {
+public abstract class AbstractProcessorBolt extends BaseTickTupleAwareRichBolt {
     protected static final Logger LOG = LoggerFactory.getLogger(AbstractProcessorBolt.class);
 
     protected Map stormConf;
@@ -44,21 +45,21 @@ public abstract class AbstractProcessorBolt extends BaseRichBolt {
     }
 
     @Override
-    public void execute(Tuple inputTuple) {
+    protected void process(Tuple tuple) {
         try {
-            Object event = inputTuple.getValueByField(StreamlineEvent.STREAMLINE_EVENT);
-            LOG.debug("Executing StreamlineEvent: [{}] with tuple: [{}]", event, inputTuple);
+            Object event = tuple.getValueByField(StreamlineEvent.STREAMLINE_EVENT);
+            LOG.debug("Executing StreamlineEvent: [{}] with tuple: [{}]", event, tuple);
 
             if(event instanceof StreamlineEvent) {
-                process(inputTuple, (StreamlineEvent) event);
+                process(tuple, (StreamlineEvent) event);
             } else {
-                LOG.debug("Received invalid input tuple:[{}] with streamline event:[{}] and it is not processed.", inputTuple, event);
+                LOG.debug("Received invalid input tuple:[{}] with streamline event:[{}] and it is not processed.", tuple, event);
             }
 
-            collector.ack(inputTuple);
+            collector.ack(tuple);
         } catch(Exception e) {
             LOG.error("Error occurred while processing the tuple", e);
-            collector.fail(inputTuple);
+            collector.fail(tuple);
             collector.reportError(e);
         }
     }

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/BaseTickTupleAwareRichBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/BaseTickTupleAwareRichBolt.java
@@ -1,0 +1,43 @@
+package com.hortonworks.streamline.streams.runtime.storm.bolt;
+
+import org.apache.storm.topology.base.BaseRichBolt;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.utils.TupleUtils;
+
+/**
+ * This class is based on BaseRichBolt, but is aware of tick tuple.
+ */
+public abstract class BaseTickTupleAwareRichBolt extends BaseRichBolt {
+    /**
+     * {@inheritDoc}
+     *
+     * @param tuple the tuple to process.
+     */
+    @Override
+    public void execute(final Tuple tuple) {
+        if (TupleUtils.isTick(tuple)) {
+            onTickTuple(tuple);
+        } else {
+            process(tuple);
+        }
+    }
+
+    /**
+     * Process a single tick tuple of input. Tick tuple doesn't need to be acked.
+     * It provides default "DO NOTHING" implementation for convenient. Override this method if needed.
+     *
+     * More details on {@link org.apache.storm.task.IBolt#execute(Tuple)}.
+     *
+     * @param tuple The input tuple to be processed.
+     */
+    protected void onTickTuple(final Tuple tuple) {
+    }
+
+    /**
+     * Process a single non-tick tuple of input. Implementation needs to handle ack manually.
+     * More details on {@link org.apache.storm.task.IBolt#execute(Tuple)}.
+     *
+     * @param tuple The input tuple to be processed.
+     */
+    protected abstract void process(final Tuple tuple);
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/notification/NotificationBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/notification/NotificationBolt.java
@@ -18,11 +18,11 @@
 package com.hortonworks.streamline.streams.runtime.storm.bolt.notification;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hortonworks.streamline.streams.runtime.storm.bolt.BaseTickTupleAwareRichBolt;
 import org.apache.commons.lang.StringUtils;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
-import org.apache.storm.topology.base.BaseRichBolt;
 import org.apache.storm.tuple.Tuple;
 import com.hortonworks.streamline.streams.StreamlineEvent;
 import com.hortonworks.streamline.streams.layout.component.impl.NotificationSink;
@@ -47,7 +47,7 @@ import java.util.Properties;
  * This storm bolt receives tuples from rule engine
  * and uses notification service to send out notifications.
  */
-public class NotificationBolt extends BaseRichBolt {
+public class NotificationBolt extends BaseTickTupleAwareRichBolt {
     private static final Logger LOG = LoggerFactory.getLogger(NotificationBolt.class);
 
     private static final String CATALOG_ROOT_URL = "catalog.root.url";
@@ -138,7 +138,7 @@ public class NotificationBolt extends BaseRichBolt {
     }
 
     @Override
-    public void execute(Tuple tuple) {
+    protected void process(Tuple tuple) {
         Notification notification = new StreamlineEventAdapter((StreamlineEvent) tuple.getValueByField(StreamlineEvent.STREAMLINE_EVENT));
         notificationContext.track(notification.getId(), tuple);
         // send to notifier

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/NotificationsTestBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/NotificationsTestBolt.java
@@ -17,6 +17,7 @@ package com.hortonworks.streamline.streams.runtime.storm.testing;
 
 import com.hortonworks.streamline.streams.StreamlineEvent;
 import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
+import com.hortonworks.streamline.streams.runtime.storm.bolt.BaseTickTupleAwareRichBolt;
 import com.hortonworks.streamline.streams.runtime.transform.AddHeaderTransformRuntime;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
@@ -25,6 +26,7 @@ import org.apache.storm.topology.base.BaseRichBolt;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.TupleUtils;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -34,7 +36,7 @@ import java.util.Map;
 /**
  * This is a dummy bolt to just send some notifications for testing the Notifications.
  */
-public class NotificationsTestBolt extends BaseRichBolt {
+public class NotificationsTestBolt extends BaseTickTupleAwareRichBolt {
 
     public static final String STREAMLINE_NOTIFICATION = "streamline.notification";
     private static final int EMAIL_NOTIFICATION_INTERVAL = 500; // after every 500 notifications
@@ -61,7 +63,7 @@ public class NotificationsTestBolt extends BaseRichBolt {
     }
 
     @Override
-    public void execute(Tuple input) {
+    protected void process(Tuple input) {
         StreamlineEvent event = (StreamlineEvent) input.getValueByField(StreamlineEvent.STREAMLINE_EVENT);
         List<String> eventIds = Arrays.asList(event.getId());
         List<String> dataSourceIds = Arrays.asList(event.getDataSourceId());


### PR DESCRIPTION
* adds TupleUtils.isTick for each Bolt implementations

I've seen some Storm Bolt implementations also don't handle tick tuples. I'll make a patch for Storm side too.
If we want to wrap the Bolt in Streamline and fix in Streamline, please let me know.