### PR TITLE
STREAMLINE-723 JdbcStorageManager#add(Storable) should call insert in…

### DIFF
--- a/storage/core/src/main/java/com/hortonworks/streamline/storage/impl/jdbc/JdbcStorageManager.java
+++ b/storage/core/src/main/java/com/hortonworks/streamline/storage/impl/jdbc/JdbcStorageManager.java
@@ -36,8 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -63,18 +61,7 @@ public class JdbcStorageManager implements StorageManager {
     @Override
     public void add(Storable storable) throws AlreadyExistsException {
         log.debug("Adding storable [{}]", storable);
-
-        try {
-            queryExecutor.insert(storable);
-        } catch (StorageException ex) {
-            if (ex.getCause() instanceof SQLIntegrityConstraintViolationException) {
-                throw new AlreadyExistsException("Another instance with same id = " + storable.getPrimaryKey()
-                                                         + " exists with different value in namespace " + storable.getNameSpace()
-                                                         + ". Consider using addOrUpdate method if you always want to overwrite.");
-            }
-
-            throw ex;
-        }
+        queryExecutor.insert(storable);
     }
 
     @Override

--- a/storage/core/src/test/java/com/hortonworks/streamline/storage/AbstractStoreManagerTest.java
+++ b/storage/core/src/test/java/com/hortonworks/streamline/storage/AbstractStoreManagerTest.java
@@ -84,10 +84,8 @@ public abstract class AbstractStoreManagerTest {
     }
 
     // UnequalExistingStorable => Storable that has the same StorableKey but does NOT verify .equals()
-    // All DBs does not throw SQLIntegrityConstraintViolationException, some of them throw their own custom SQLException
-    // so, storage layer wraps that as StorageException
     //@Test(expected = StorageException.class)
-    public void testAdd_UnequalExistingStorable_AlreadyExistsException() {
+    public void testAdd_UnequalExistingStorable_Storage_Exception() {
         for (StorableTest test : storableTests) {
             Storable storable1 = test.getStorableList().get(0);
             Storable storable2 = test.getStorableList().get(1);

--- a/storage/core/src/test/java/com/hortonworks/streamline/storage/AbstractStoreManagerTest.java
+++ b/storage/core/src/test/java/com/hortonworks/streamline/storage/AbstractStoreManagerTest.java
@@ -84,7 +84,9 @@ public abstract class AbstractStoreManagerTest {
     }
 
     // UnequalExistingStorable => Storable that has the same StorableKey but does NOT verify .equals()
-    //@Test(expected = AlreadyExistsException.class)
+    // All DBs does not throw SQLIntegrityConstraintViolationException, some of them throw their own custom SQLException
+    // so, storage layer wraps that as StorageException
+    //@Test(expected = StorageException.class)
     public void testAdd_UnequalExistingStorable_AlreadyExistsException() {
         for (StorableTest test : storableTests) {
             Storable storable1 = test.getStorableList().get(0);
@@ -102,7 +104,7 @@ public abstract class AbstractStoreManagerTest {
         for (StorableTest test : storableTests) {
             Storable storable1 = test.getStorableList().get(0);
             getStorageManager().add(storable1);
-            getStorageManager().add(storable1);     // should throw exception
+            getStorageManager().addOrUpdate(storable1);
             Assert.assertEquals(storable1, getStorageManager().get(storable1.getStorableKey()));
         }
     }


### PR DESCRIPTION
JdbcStorageManager#add(Storable) should call insert instead of insertOrUpdate and it should throw AlreadyExistsException when it encounters any constraint validation exception.