### PR TITLE
STREAMLINE-727 bootstrap-stroage script should allow create only and …

### DIFF
--- a/storage/tool/src/main/java/com/hortonworks/streamline/storage/tool/MySqlDriverHelper.java
+++ b/storage/tool/src/main/java/com/hortonworks/streamline/storage/tool/MySqlDriverHelper.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.storage.tool;
+
+import com.google.common.collect.Lists;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Files;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+public class MySqlDriverHelper {
+    public static final String MYSQL_JAR_FILE_PATTERN = "mysql-connector-java-.*?-bin.jar";
+
+    public static void downloadMySQLJarIfNeeded(StorageProviderConfiguration storageProperties, String bootstrapDirPath, String mysqlJarUrl) throws Exception {
+        /* Due to license issues we will not be able to ship mysql driver.
+               If the dbtype is mysql we will prompt user to download the jar and place
+               it under bootstrap/lib and libs folder. This runs only one-time and for
+               next time onwards we will check if the mysql jar exists in the path.
+             */
+        File bootstrapLibDir = new File (bootstrapDirPath + File.separator + "lib/");
+        File libDir = new File (bootstrapDirPath + File.separator +  "../libs/");
+
+        if (storageProperties.getDbType().equals("mysql")
+                && (!isMySQLJarFileAvailableOnAnyOfDirectories(Lists.newArrayList(bootstrapLibDir, libDir)))) {
+            downloadMySQLJar(mysqlJarUrl, bootstrapLibDir);
+        }
+    }
+
+    private static boolean isMySQLJarFileAvailableOnAnyOfDirectories(List<File> directories) {
+        return directories.stream().anyMatch(dir -> MySqlDriverHelper.fileExists(dir, MYSQL_JAR_FILE_PATTERN));
+    }
+
+    private static void downloadMySQLJar(String mysqlJarUrl, File bootstrapLibDir) throws Exception {
+        if (mysqlJarUrl == null || mysqlJarUrl.equals(""))
+            throw new IllegalArgumentException("Missing mysql client jar url. " +
+                    "Please pass mysql client jar url using -m option.");
+        String mysqlJarFileName = MySqlDriverHelper.downloadMysqlJarAndCopyToLibDir(bootstrapLibDir, mysqlJarUrl, MYSQL_JAR_FILE_PATTERN);
+        if (mysqlJarFileName != null) {
+            File mysqlJarFile = new File(bootstrapLibDir+ File.separator + mysqlJarFileName);
+            System.out.println("mysqlJarFile " + mysqlJarFile);
+            Utils.loadJarIntoClasspath(mysqlJarFile);
+        }
+    }
+
+    /*
+      This method is solely for the use of downloading the mysql java driver jar.
+      It will download the zip file from the provided url.
+      Unzips the file and copies the jar into bootstrap/lib and libs.
+
+      @params url mysql zip file URL
+      @returns the mysql jar file name.
+     */
+    public static String downloadMysqlJarAndCopyToLibDir(File bootstrapLibDir, String url, String fileNamePattern) throws IOException {
+        System.out.println("Downloading mysql jar from url: " + url);
+        String tmpFileName;
+        try {
+            URL downloadUrl = new URL(url);
+            String[] pathSegments = downloadUrl.getPath().split("/");
+            String fileName = pathSegments[pathSegments.length - 1];
+            String tmpDir = System.getProperty("java.io.tmpdir");
+            tmpFileName = tmpDir + File.separator + fileName;
+            System.out.println("Downloading file " + fileName + " into " + tmpDir);
+            ReadableByteChannel rbc = Channels.newChannel(downloadUrl.openStream());
+            FileOutputStream fos = new FileOutputStream(tmpFileName);
+            fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+        } catch(IOException ie) {
+            System.out.println("Failed to download the mysql driver from " + url);
+            throw new IOException(ie);
+        }
+
+        System.out.println("Copying mysql libraries into lib dir...");
+        String libDir = bootstrapLibDir.getAbsolutePath() + File.separator + "../../libs/";
+        System.out.println("Unzipping downloaded mysql driver and copying");
+        try {
+            String mysqlJarFileName = MySqlDriverHelper.copyFileFromZipToDir(tmpFileName, fileNamePattern, bootstrapLibDir);
+            File bootstrapLibFile = new File(bootstrapLibDir + File.separator + mysqlJarFileName);
+            File libFile = new File(libDir + File.separator + mysqlJarFileName);
+            System.out.println("Copying file to libs " + libFile);
+            MySqlDriverHelper.copyFile(bootstrapLibFile, libFile);
+            return mysqlJarFileName;
+        } catch (IOException ie) {
+            System.out.println("Failed to copy mysql driver into " + bootstrapLibDir + " and " + libDir);
+        } catch (Exception e ) {
+            e.printStackTrace();
+            System.out.println("Failed to copy mysql driver into " + bootstrapLibDir + " and " + libDir);
+        }
+        return null;
+    }
+
+    public static String copyFileFromZipToDir(String zipFile, String fileNamePattern, File dir) throws IOException{
+        ZipFile zip = new ZipFile(zipFile);
+        Enumeration zipFileEntries = zip.entries();
+        int BUFFER = 2048;
+        while (zipFileEntries.hasMoreElements()) {
+            ZipEntry entry = (ZipEntry) zipFileEntries.nextElement();
+            String currentEntry = entry.getName();
+            if (currentEntry.matches(fileNamePattern)) {
+                String[] currentEntrySegments = currentEntry.split(File.separator);
+                String matchedFileName = currentEntrySegments[currentEntrySegments.length - 1];
+                File file = new File(dir, matchedFileName);
+                FileOutputStream fos = new FileOutputStream(file);
+                BufferedOutputStream dest = new BufferedOutputStream(fos, BUFFER);
+                byte data[] = new byte[BUFFER];
+                BufferedInputStream is = new BufferedInputStream(zip.getInputStream(entry));
+                int currentByte;
+                while ((currentByte = is.read(data, 0, BUFFER)) != -1) {
+                    dest.write(data, 0, currentByte);
+                }
+                dest.flush();
+                dest.close();
+                is.close();
+                return matchedFileName;
+            }
+        }
+        return null;
+    }
+
+    public static void copyFile(File sourceFile, File destFile) throws IOException {
+        if (!sourceFile.exists()) {
+            throw new IllegalArgumentException("Source File doesn't exists");
+        }
+
+        Files.copy(sourceFile.toPath(), destFile.toPath());
+    }
+
+    public static boolean fileExists(File dir, String regex) {
+        File[] files = dir.listFiles(new FileFilter() {
+            public boolean accept(File pathname) {
+                return pathname.getName().matches(regex);
+            }
+        });
+        return files != null && files.length == 1;
+    }
+
+}

--- a/storage/tool/src/main/java/com/hortonworks/streamline/storage/tool/TablesInitializer.java
+++ b/storage/tool/src/main/java/com/hortonworks/streamline/storage/tool/TablesInitializer.java
@@ -1,0 +1,203 @@
+package com.hortonworks.streamline.storage.tool;
+
+import org.apache.commons.cli.BasicParser;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.OptionBuilder;
+import org.apache.commons.cli.Options;
+import org.apache.commons.lang.BooleanUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Scanner;
+
+public class TablesInitializer {
+    private static final String OPTION_SCRIPT_ROOT_PATH = "script-root";
+    private static final String OPTION_CONFIG_FILE_PATH = "config";
+    private static final String OPTION_MYSQL_JAR_URL_PATH = "mysql-jar-url";
+    private static final String OPTION_EXECUTE_CREATE_TABLE = "create";
+    private static final String OPTION_EXECUTE_DROP_TABLE = "drop";
+    private static final String OPTION_EXECUTE_CHECK_CONNECTION = "check-connection";
+
+    private static final String CREATE_SCRIPT_FILE_NAME = "create_tables.sql";
+    private static final String DROP_SCRIPT_FILE_NAME = "drop_tables.sql";
+
+    public static void main(String[] args) throws Exception {
+        Options options = new Options();
+
+        options.addOption(
+                Option.builder("s")
+                        .numberOfArgs(1)
+                        .longOpt(OPTION_SCRIPT_ROOT_PATH)
+                        .desc("Root directory of script path")
+                        .build()
+        );
+
+        options.addOption(
+                Option.builder("c")
+                        .numberOfArgs(1)
+                        .longOpt(OPTION_CONFIG_FILE_PATH)
+                        .desc("Config file path")
+                        .build()
+        );
+
+        options.addOption(
+                Option.builder("m")
+                        .numberOfArgs(1)
+                        .longOpt(OPTION_MYSQL_JAR_URL_PATH)
+                        .desc("Mysql client jar url to download")
+                        .build()
+        );
+
+        options.addOption(
+                Option.builder()
+                        .hasArg(false)
+                        .longOpt(OPTION_EXECUTE_CREATE_TABLE)
+                        .desc("Execute 'create table' script")
+                        .build()
+        );
+
+        options.addOption(
+                Option.builder()
+                        .hasArg(false)
+                        .longOpt(OPTION_EXECUTE_DROP_TABLE)
+                        .desc("Execute 'drop table' script")
+                        .build()
+        );
+
+        options.addOption(
+                Option.builder()
+                        .hasArg(false)
+                        .longOpt(OPTION_EXECUTE_CHECK_CONNECTION)
+                        .desc("Check the connection for configured data source")
+                        .build()
+        );
+
+        CommandLineParser parser = new BasicParser();
+        CommandLine commandLine = parser.parse(options, args);
+
+        if (!commandLine.hasOption(OPTION_CONFIG_FILE_PATH) || !commandLine.hasOption(OPTION_SCRIPT_ROOT_PATH)) {
+            usage(options);
+            System.exit(1);
+        }
+
+        // either create or drop should be specified, not both
+        boolean executeCreate = commandLine.hasOption(OPTION_EXECUTE_CREATE_TABLE);
+        boolean executeDrop = commandLine.hasOption(OPTION_EXECUTE_DROP_TABLE);
+        boolean checkConnection = commandLine.hasOption(OPTION_EXECUTE_CHECK_CONNECTION);
+
+        boolean moreThanOneOperationIsSpecified = executeCreate == executeDrop ? executeCreate : checkConnection;
+        boolean noOperationSpecified = !(executeCreate || executeDrop || checkConnection);
+
+        if (moreThanOneOperationIsSpecified) {
+            System.out.println("Only one operation can be execute at once, please select 'create' or 'drop', or 'check-connection'.");
+            System.exit(1);
+        } else if (noOperationSpecified) {
+            System.out.println("One of 'create', 'drop', 'check-connection' operation should be specified to execute.");
+            System.exit(1);
+        }
+
+        String confFilePath = commandLine.getOptionValue(OPTION_CONFIG_FILE_PATH);
+        String scriptRootPath = commandLine.getOptionValue(OPTION_SCRIPT_ROOT_PATH);
+        String mysqlJarUrl = commandLine.getOptionValue(OPTION_MYSQL_JAR_URL_PATH);
+
+        StorageProviderConfiguration storageProperties;
+        try {
+            Map<String, Object> conf = Utils.readStreamlineConfig(confFilePath);
+
+            StorageProviderConfigurationReader confReader = new StorageProviderConfigurationReader();
+            storageProperties = confReader.readStorageConfig(conf);
+        } catch (IOException e) {
+            System.err.println("Error occurred while reading config file: " + confFilePath);
+            System.exit(1);
+            throw new IllegalStateException("Shouldn't reach here");
+        }
+
+        String bootstrapDirPath = null;
+        try {
+            bootstrapDirPath = System.getProperty("bootstrap.dir");
+            MySqlDriverHelper.downloadMySQLJarIfNeeded(storageProperties, bootstrapDirPath, mysqlJarUrl);
+        } catch (Exception e) {
+            System.err.println("Error occurred while downloading MySQL jar. bootstrap dir: " + bootstrapDirPath);
+            System.exit(1);
+            throw new IllegalStateException("Shouldn't reach here");
+        }
+
+        try {
+            SQLScriptRunner sqlScriptRunner = new SQLScriptRunner(storageProperties);
+
+            try {
+                sqlScriptRunner.initializeDriver();
+            } catch (ClassNotFoundException e) {
+                System.err.println("Driver class is not found in classpath. Please ensure that driver is in classpath.");
+                System.exit(1);
+            }
+
+            if (checkConnection) {
+                if (!sqlScriptRunner.checkConnection()) {
+                    System.exit(1);
+                }
+            } else if (executeDrop) {
+                doExecuteDrop(sqlScriptRunner, storageProperties, scriptRootPath);
+            } else {
+                // executeCreate
+                doExecuteCreate(sqlScriptRunner, storageProperties, scriptRootPath);
+            }
+        } catch (IOException e) {
+            System.err.println("Error occurred while reading script file. Script root path: " + scriptRootPath);
+            System.exit(1);
+        }
+    }
+
+    private static void doExecuteCreate(SQLScriptRunner sqlScriptRunner, StorageProviderConfiguration storageProperties,
+                                        String scriptRootPath) throws Exception {
+        String scriptPath = scriptRootPath + File.separator + storageProperties.getDbType() +
+                File.separator + CREATE_SCRIPT_FILE_NAME;
+
+        doExecute(sqlScriptRunner, scriptPath);
+    }
+
+    private static void doExecuteDrop(SQLScriptRunner sqlScriptRunner, StorageProviderConfiguration storageProperties,
+                                      String scriptRootPath) throws Exception {
+        System.out.println("The operation will drop any existing tables.");
+        System.out.print("Are you sure you want to proceed. (y/n)?");
+        Scanner scan = new Scanner(System.in);
+        String line = scan.nextLine();
+        System.out.println();
+
+        Boolean proceed = BooleanUtils.toBooleanObject(line);
+        if (!BooleanUtils.toBoolean(proceed)) {
+            System.exit(0);
+        }
+
+        String scriptPath = scriptRootPath + File.separator + storageProperties.getDbType() +
+                File.separator + DROP_SCRIPT_FILE_NAME;
+
+        doExecute(sqlScriptRunner, scriptPath);
+    }
+
+    private static void doExecute(SQLScriptRunner sqlScriptRunner, String scriptPath) throws Exception {
+        sqlScriptRunner.runScript(scriptPath);
+    }
+
+    private static Option option(int argCount, String shortName, String longName, String description){
+        return option(argCount, shortName, longName, longName, description);
+    }
+
+    private static Option option(int argCount, String shortName, String longName, String argName, String description){
+        return OptionBuilder.hasArgs(argCount)
+                .withArgName(argName)
+                .withLongOpt(longName)
+                .withDescription(description)
+                .create(shortName);
+    }
+
+    private static void usage(Options options) {
+        HelpFormatter formatter = new HelpFormatter();
+        formatter.printHelp("StreamlineTableInitializer [options]", options);
+    }
+
+}

--- a/storage/tool/src/main/java/com/hortonworks/streamline/storage/tool/Utils.java
+++ b/storage/tool/src/main/java/com/hortonworks/streamline/storage/tool/Utils.java
@@ -17,6 +17,7 @@ package com.hortonworks.streamline.storage.tool;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.google.common.collect.Lists;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -33,6 +34,7 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Map;
 
 import java.util.zip.ZipEntry;
@@ -45,97 +47,6 @@ public class Utils {
         return objectMapper.readValue(new File(configFilePath), Map.class);
     }
 
-    /*
-      This method is solely for the use of downloading the mysql java driver jar. 
-      It will download the zip file from the provided url.
-      Unzips the file and copies the jar into $STREAMLINE_HOME/bootstrap/lib and $STREAMLINE/libs.
-
-      @params url mysql zip file URL
-      @returns the mysql jar file name.
-     */
-    public static String downloadMysqlJarAndCopyToLibDir(String url, String fileNamePattern) throws IOException {
-        System.out.println("Downloading mysql jar from url: " + url);
-        String tmpFileName;
-        try {
-            URL downloadUrl = new URL(url);
-            String[] pathSegments = downloadUrl.getPath().split("/");
-            String fileName = pathSegments[pathSegments.length - 1];
-            String tmpDir = System.getProperty("java.io.tmpdir");
-            tmpFileName = tmpDir + File.separator + fileName;
-            System.out.println("Downloading file " + fileName + " into " + tmpDir);
-            ReadableByteChannel rbc = Channels.newChannel(downloadUrl.openStream());
-            FileOutputStream fos = new FileOutputStream(tmpFileName);
-            fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
-        } catch(IOException ie) {
-            System.out.println("Failed to download the mysql driver from " + url);
-            throw new IOException(ie);
-        }
-
-        System.out.println("Copying mysql libraries into StreamLine");
-        String bootstrapDir = System.getProperty("streamline.bootstrap.dir");
-        String bootstrapLibDir = bootstrapDir+ File.separator + "lib";
-        String streamlineLibDir = bootstrapDir + File.separator + "../libs/";
-        System.out.println("Unzipping downloaded mysql driver and copying into bootstrap lib dir");
-        try {
-            String mysqlJarFileName = Utils.copyFileFromZipToDir(tmpFileName, fileNamePattern, bootstrapLibDir);
-            File bootstrapLibFile = new File(bootstrapLibDir + File.separator + mysqlJarFileName);
-            File streamLineLibFile = new File(streamlineLibDir + File.separator + mysqlJarFileName);
-            System.out.println("Copying file to StreamLine libs" + streamLineLibFile);
-            Utils.copyFile(bootstrapLibFile, streamLineLibFile);
-            return mysqlJarFileName;
-        } catch (IOException ie) {
-            System.out.println("Failed to copy mysql driver into " + bootstrapLibDir + " and " + streamlineLibDir);
-        } catch (Exception e ) {
-            e.printStackTrace();
-            System.out.println("Failed to copy mysql driver into " + bootstrapLibDir + " and " + streamlineLibDir);
-        }
-        return null;
-    }
-
-    public static String copyFileFromZipToDir(String zipFile, String fileNamePattern, String dir) throws IOException{
-        ZipFile zip = new ZipFile(zipFile);
-        Enumeration zipFileEntries = zip.entries();
-        int BUFFER = 2048;
-        while (zipFileEntries.hasMoreElements()) {
-            ZipEntry entry = (ZipEntry) zipFileEntries.nextElement();
-            String currentEntry = entry.getName();
-            if (currentEntry.matches(fileNamePattern)) {
-                String[] currentEntrySegments = currentEntry.split(File.separator);
-                String matchedFileName = currentEntrySegments[currentEntrySegments.length - 1];
-                File file = new File(dir + File.separator + matchedFileName);
-                FileOutputStream fos = new FileOutputStream(file);
-                BufferedOutputStream dest = new BufferedOutputStream(fos, BUFFER);
-                byte data[] = new byte[BUFFER];
-                BufferedInputStream is = new BufferedInputStream(zip.getInputStream(entry));
-                int currentByte;
-                while ((currentByte = is.read(data, 0, BUFFER)) != -1) {
-                    dest.write(data, 0, currentByte);
-                }
-                dest.flush();
-                dest.close();
-                is.close();
-                return matchedFileName;
-            }
-        }
-        return null;
-    }
-
-    public static void copyFile(File sourceFile, File destFile) throws IOException {
-        if (!sourceFile.exists()) {
-            throw new IllegalArgumentException("Source File doesn't exists");
-        }
-
-        Files.copy(sourceFile.toPath(), destFile.toPath());
-    }
-
-    public static boolean fileExists(File dir, String regex) {
-        File[] files = dir.listFiles(new FileFilter() {
-                public boolean accept(File pathname) {
-                    return pathname.getName().matches(regex);
-                }
-            });
-        return files.length == 1;
-    }
 
     public static void loadJarIntoClasspath(File jarFile) throws Exception {
         try {


### PR DESCRIPTION
…keep deletion as an option

* bootstrap-storage.sh receives one optional argument
  * default value is "create"
  * "create": create tables
  * "drop": drop tables
  * "drop-create": drop then create tables
  * "check-connection": only check connection
* create new class StreamlineTableInitializer to keep SQLScriptRunner usable for general case
  * new class will handle only the case what bootstrap-storage provides
  * refactor SQLScriptRunner to let new class uses features

Regarding concurrent execution, since we're using `IF NOT EXISTS` for creating table and `IF EXISTS` for dropping table so it should be safe.