### PR TITLE
STREAMLINE-709 Import Druid service during the Service pool creation

### DIFF
--- a/bootstrap/components/sinks/druid-sink-topology-component.json
+++ b/bootstrap/components/sinks/druid-sink-topology-component.json
@@ -4,6 +4,7 @@
   "subType": "DRUID",
   "builtin": true,
   "streamingEngine": "STORM",
+  "fieldHintProviderClass": "com.hortonworks.streamline.streams.cluster.bundle.impl.DruidSinkBundleHintProvider",
   "transformationClass": "com.hortonworks.streamline.streams.layout.storm.DruidBoltFluxComponent",
   "mavenDeps": "org.apache.storm:storm-druid:STORM_VERSION,org.scala-lang:scala-library:2.11.8",
   "topologyComponentUISpecification": {

--- a/bootstrap/services/druid-bundle.json
+++ b/bootstrap/services/druid-bundle.json
@@ -1,0 +1,15 @@
+{
+  "name": "DRUID",
+  "registerClass": "com.hortonworks.streamline.streams.cluster.register.impl.DruidServiceRegistrar",
+  "serviceUISpecification": {
+    "fields": [
+      {
+        "uiName": "Druid config file (common.runtime.properties)",
+        "fieldName": "common.runtime.properties",
+        "isOptional": false,
+        "tooltip": "Upload common.runtime.properties file used by Druid cluster",
+        "type": "file"
+      }
+    ]
+  }
+}

--- a/bootstrap/services/hbase-bundle.json
+++ b/bootstrap/services/hbase-bundle.json
@@ -4,7 +4,7 @@
   "serviceUISpecification": {
     "fields": [
       {
-        "uiName": "hbase-site.xml",
+        "uiName": "HBase config file (hbase-site.xml)",
         "fieldName": "hbase-site.xml",
         "isOptional": false,
         "tooltip": "Upload hbase-site.xml file used by HBase cluster",

--- a/bootstrap/services/hdfs-bundle.json
+++ b/bootstrap/services/hdfs-bundle.json
@@ -4,14 +4,14 @@
   "serviceUISpecification": {
     "fields": [
       {
-        "uiName": "core-site.xml",
+        "uiName": "HDFS config file (core-site.xml)",
         "fieldName": "core-site.xml",
         "isOptional": false,
         "tooltip": "Upload core-site.xml file used by Hadoop cluster",
         "type": "file"
       },
       {
-        "uiName": "hdfs-site.xml",
+        "uiName": "HDFS config file (hdfs-site.xml)",
         "fieldName": "hdfs-site.xml",
         "isOptional": false,
         "tooltip": "Upload hdfs-site.xml file used by Hadoop cluster",

--- a/bootstrap/services/hive-bundle.json
+++ b/bootstrap/services/hive-bundle.json
@@ -4,7 +4,7 @@
   "serviceUISpecification": {
     "fields": [
       {
-        "uiName": "hive-site.xml",
+        "uiName": "Hive config file (hive-site.xml)",
         "fieldName": "hive-site.xml",
         "isOptional": false,
         "tooltip": "Upload hive-site.xml file used by Hive cluster",

--- a/bootstrap/services/kafka-bundle.json
+++ b/bootstrap/services/kafka-bundle.json
@@ -11,7 +11,7 @@
         "type": "array.string"
       },
       {
-        "uiName": "server.properties",
+        "uiName": "Kafka config file (server.properties)",
         "fieldName": "server.properties",
         "isOptional": false,
         "tooltip": "Upload server.properties file used by Kafka cluster",

--- a/bootstrap/services/storm-bundle.json
+++ b/bootstrap/services/storm-bundle.json
@@ -18,7 +18,7 @@
         "type": "array.string"
       },
       {
-        "uiName": "storm.yaml",
+        "uiName": "Storm config file (storm.yaml)",
         "fieldName": "storm.yaml",
         "isOptional": false,
         "tooltip": "Upload storm.yaml file used by Storm cluster",

--- a/bootstrap/services/zookeeper-bundle.json
+++ b/bootstrap/services/zookeeper-bundle.json
@@ -11,7 +11,7 @@
         "type": "array.string"
       },
       {
-        "uiName": "zoo.cfg",
+        "uiName": "Zookeeper config file (zoo.cfg)",
         "fieldName": "zoo.cfg",
         "isOptional": false,
         "tooltip": "Upload zoo.cfg file used by Zookeeper cluster",

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/Constants.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/Constants.java
@@ -1,0 +1,46 @@
+package com.hortonworks.streamline.streams.cluster;
+
+public final class Constants {
+    private Constants() {
+    }
+
+    public static class Zookeeper {
+        public static final String SERVICE_NAME = "ZOOKEEPER";
+    }
+
+    public static class Storm {
+        public static final String SERVICE_NAME = "STORM";
+    }
+
+    public static class Kafka {
+        public static final String SERVICE_NAME = "KAFKA";
+        public static final String PROPERTY_KEY_ZOOKEEPER_CONNECT = "zookeeper.connect";
+    }
+
+    public static class HDFS {
+        public static final String SERVICE_NAME = "HDFS";
+        public static final String PROPERTY_KEY_DEFAULT_FS = "fs.defaultFS";
+    }
+
+    public static class HBase {
+        public static final String SERVICE_NAME = "HBASE";
+        public static final String PROPERTY_KEY_HBASE_ZOOKEEPER_QUORUM = "hbase.zookeeper.quorum";
+    }
+
+    public static class Hive {
+        public static final String SERVICE_NAME = "HIVE";
+        public static final String PROPERTY_KEY_HIVE_ZOOKEEPER_QUORUM = "hive.zookeeper.quorum";
+    }
+
+    public static class EventHubs {
+        public static final String SERVICE_NAME = "EVENTHUBS";
+    }
+
+    public static class Druid {
+        public static final String SERVICE_NAME = "DRUID";
+        public static final String CONF_TYPE_COMMON_RUNTIME = "common.runtime"; // common.runtime.properties
+        public static final String PROPERTY_KEY_ZK_SERVICE_HOSTS = "druid.zk.service.host";
+        public static final String PROPERTY_KEY_INDEXING_SERVICE_NAME = "druid.selectors.indexing.serviceName";
+        public static final String PROPERTY_KEY_DISCOVERY_CURATOR_PATH = "druid.discovery.curator.path";
+    }
+}

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/AbstractHDFSBundleHintProvider.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/AbstractHDFSBundleHintProvider.java
@@ -18,6 +18,7 @@ package com.hortonworks.streamline.streams.cluster.bundle.impl;
 import com.hortonworks.streamline.streams.catalog.Cluster;
 import com.hortonworks.streamline.streams.catalog.exception.ServiceConfigurationNotFoundException;
 import com.hortonworks.streamline.streams.catalog.exception.ServiceNotFoundException;
+import com.hortonworks.streamline.streams.cluster.Constants;
 import com.hortonworks.streamline.streams.cluster.service.metadata.HDFSMetadataService;
 import com.hortonworks.streamline.streams.cluster.bundle.AbstractBundleHintProvider;
 
@@ -25,8 +26,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 public abstract class AbstractHDFSBundleHintProvider extends AbstractBundleHintProvider {
-    public static final String SERVICE_NAME = "HDFS";
-
     @Override
     public Map<String, Object> getHintsOnCluster(Cluster cluster) {
         Map<String, Object> hintMap = new HashMap<>();
@@ -36,7 +35,7 @@ public abstract class AbstractHDFSBundleHintProvider extends AbstractBundleHintP
             hintMap.put(getFieldNameForFSUrl(), hdfsMetadataService.getDefaultFsUrl());
         } catch (ServiceNotFoundException e) {
             // we access it from mapping information so shouldn't be here
-            throw new IllegalStateException("Service " + SERVICE_NAME + " in cluster " + cluster.getName() +
+            throw new IllegalStateException("Service " + Constants.HDFS.SERVICE_NAME + " in cluster " + cluster.getName() +
                     " not found but mapping information exists.");
         } catch (ServiceConfigurationNotFoundException e) {
             // there's HBASE service but not enough configuration info.
@@ -48,7 +47,7 @@ public abstract class AbstractHDFSBundleHintProvider extends AbstractBundleHintP
 
     @Override
     public String getServiceName() {
-        return SERVICE_NAME;
+        return Constants.HDFS.SERVICE_NAME;
     }
 
     protected abstract String getFieldNameForFSUrl();

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/DruidSinkBundleHintProvider.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/DruidSinkBundleHintProvider.java
@@ -1,0 +1,62 @@
+package com.hortonworks.streamline.streams.cluster.bundle.impl;
+
+import com.hortonworks.streamline.streams.catalog.Cluster;
+import com.hortonworks.streamline.streams.catalog.Service;
+import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
+import com.hortonworks.streamline.streams.catalog.exception.ServiceConfigurationNotFoundException;
+import com.hortonworks.streamline.streams.catalog.exception.ServiceNotFoundException;
+import com.hortonworks.streamline.streams.cluster.Constants;
+import com.hortonworks.streamline.streams.cluster.bundle.AbstractBundleHintProvider;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DruidSinkBundleHintProvider extends AbstractBundleHintProvider {
+    public static final String FIELD_NAME_ZK_CONNECT = "tranquilityZKconnect";
+    public static final String FIELD_NAME_INDEX_SERVICE = "indexService";
+    public static final String FIELD_NAME_DISCOVERY_PATH = "discoveryPath";
+
+    @Override
+    public String getServiceName() {
+        return Constants.Druid.SERVICE_NAME;
+    }
+
+    @Override
+    public Map<String, Object> getHintsOnCluster(Cluster cluster) {
+        Map<String, Object> hintMap = new HashMap<>();
+
+        try {
+            Service druid = environmentService.getServiceByName(cluster.getId(), Constants.Druid.SERVICE_NAME);
+            if (druid == null) {
+                throw new ServiceNotFoundException(Constants.Druid.SERVICE_NAME);
+            }
+
+            ServiceConfiguration commonRuntime = environmentService.getServiceConfigurationByName(druid.getId(), Constants.Druid.CONF_TYPE_COMMON_RUNTIME);
+            if (commonRuntime == null) {
+                throw new ServiceConfigurationNotFoundException(Constants.Druid.CONF_TYPE_COMMON_RUNTIME);
+            }
+
+            Map<String, String> configurationMap = commonRuntime.getConfigurationMap();
+            putToHintMapIfAvailable(configurationMap, hintMap, Constants.Druid.PROPERTY_KEY_ZK_SERVICE_HOSTS, FIELD_NAME_ZK_CONNECT);
+            putToHintMapIfAvailable(configurationMap, hintMap, Constants.Druid.PROPERTY_KEY_INDEXING_SERVICE_NAME, FIELD_NAME_INDEX_SERVICE);
+            putToHintMapIfAvailable(configurationMap, hintMap, Constants.Druid.PROPERTY_KEY_DISCOVERY_CURATOR_PATH, FIELD_NAME_DISCOVERY_PATH);
+        } catch (ServiceNotFoundException e) {
+            // we access it from mapping information so shouldn't be here
+            throw new IllegalStateException("Service " + Constants.Druid.SERVICE_NAME + " in cluster " + cluster.getName() +
+                    " not found but mapping information exists.");
+        } catch (ServiceConfigurationNotFoundException e) {
+            // there's Druid service configuration but not having enough information
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        return hintMap;
+    }
+
+    private void putToHintMapIfAvailable(Map<String, String> configurationMap, Map<String, Object> hintMap,
+                                         String confKey, String fieldName) {
+        if (configurationMap.containsKey(confKey)) {
+            hintMap.put(fieldName, configurationMap.get(confKey));
+        }
+    }
+}

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/EventHubsSourceHintProvider.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/EventHubsSourceHintProvider.java
@@ -1,14 +1,13 @@
 package com.hortonworks.streamline.streams.cluster.bundle.impl;
 
 import com.hortonworks.streamline.streams.catalog.Cluster;
+import com.hortonworks.streamline.streams.cluster.Constants;
 import com.hortonworks.streamline.streams.cluster.bundle.AbstractBundleHintProvider;
 
 import java.util.Collections;
 import java.util.Map;
 
 public class EventHubsSourceHintProvider extends AbstractBundleHintProvider {
-    public static final String SERVICE_NAME = "EVENTHUBS";
-
     @Override
     public Map<String, Object> getHintsOnCluster(Cluster cluster) {
         return Collections.emptyMap();
@@ -16,6 +15,6 @@ public class EventHubsSourceHintProvider extends AbstractBundleHintProvider {
 
     @Override
     public String getServiceName() {
-        return SERVICE_NAME;
+        return Constants.EventHubs.SERVICE_NAME;
     }
 }

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/HBaseBundleHintProvider.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/HBaseBundleHintProvider.java
@@ -18,6 +18,7 @@ package com.hortonworks.streamline.streams.cluster.bundle.impl;
 import com.hortonworks.streamline.streams.catalog.Cluster;
 import com.hortonworks.streamline.streams.catalog.exception.ServiceConfigurationNotFoundException;
 import com.hortonworks.streamline.streams.catalog.exception.ServiceNotFoundException;
+import com.hortonworks.streamline.streams.cluster.Constants;
 import com.hortonworks.streamline.streams.cluster.bundle.AbstractBundleHintProvider;
 import com.hortonworks.streamline.streams.cluster.service.metadata.HBaseMetadataService;
 
@@ -25,7 +26,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class HBaseBundleHintProvider extends AbstractBundleHintProvider {
-    public static final String SERVICE_NAME = "HBASE";
     public static final String FIELD_NAME_TABLE = "table";
 
     @Override
@@ -35,7 +35,7 @@ public class HBaseBundleHintProvider extends AbstractBundleHintProvider {
             hintMap.put(FIELD_NAME_TABLE, hBaseMetadataService.getHBaseTables().getTables());
         } catch (ServiceNotFoundException e) {
             // we access it from mapping information so shouldn't be here
-            throw new IllegalStateException("Service " + SERVICE_NAME + " in cluster " + cluster.getName() +
+            throw new IllegalStateException("Service " + Constants.HBase.SERVICE_NAME + " in cluster " + cluster.getName() +
                     " not found but mapping information exists.");
         } catch (ServiceConfigurationNotFoundException e) {
             // there's HBASE service but not enough configuration info.
@@ -47,6 +47,6 @@ public class HBaseBundleHintProvider extends AbstractBundleHintProvider {
 
     @Override
     public String getServiceName() {
-        return SERVICE_NAME;
+        return Constants.HBase.SERVICE_NAME;
     }
 }

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/KafkaBundleHintProvider.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/KafkaBundleHintProvider.java
@@ -15,6 +15,7 @@
  **/
 package com.hortonworks.streamline.streams.cluster.bundle.impl;
 
+import com.hortonworks.streamline.streams.cluster.Constants;
 import org.apache.commons.lang3.StringUtils;
 import com.hortonworks.streamline.streams.catalog.Cluster;
 import com.hortonworks.streamline.streams.catalog.exception.ServiceConfigurationNotFoundException;
@@ -33,7 +34,6 @@ import static java.util.stream.Collectors.toList;
 public class KafkaBundleHintProvider extends AbstractBundleHintProvider {
     public static final String DEFAULT_BROKER_ZK_PATH = "/brokers";
 
-    public static final String SERVICE_NAME = "KAFKA";
     public static final String FIELD_NAME_ZK_URL = "zkUrl";
     public static final String FIELD_NAME_TOPIC = "topic";
     public static final String FIELD_NAME_BROKER_ZK_PATH = "zkPath";
@@ -65,7 +65,7 @@ public class KafkaBundleHintProvider extends AbstractBundleHintProvider {
             fillZookeeperHints(cluster, hintClusterMap);
         } catch (ServiceNotFoundException e) {
             // we access it from mapping information so shouldn't be here
-            throw new IllegalStateException("Service " + SERVICE_NAME + " in cluster " + cluster.getName() +
+            throw new IllegalStateException("Service " + Constants.Kafka.SERVICE_NAME + " in cluster " + cluster.getName() +
                     " not found but mapping information exists.");
         } catch (ServiceConfigurationNotFoundException e) {
             // there's KAFKA service but not enough configuration info.
@@ -91,6 +91,6 @@ public class KafkaBundleHintProvider extends AbstractBundleHintProvider {
 
     @Override
     public String getServiceName() {
-        return SERVICE_NAME;
+        return Constants.Kafka.SERVICE_NAME;
     }
 }

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/KafkaSinkBundleHintProvider.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/KafkaSinkBundleHintProvider.java
@@ -15,6 +15,7 @@
  **/
 package com.hortonworks.streamline.streams.cluster.bundle.impl;
 
+import com.hortonworks.streamline.streams.cluster.Constants;
 import org.apache.commons.lang.StringUtils;
 import com.hortonworks.streamline.streams.catalog.Cluster;
 import com.hortonworks.streamline.streams.catalog.exception.ServiceConfigurationNotFoundException;
@@ -30,7 +31,6 @@ import java.util.Map;
 import static java.util.stream.Collectors.toList;
 
 public class KafkaSinkBundleHintProvider extends AbstractBundleHintProvider {
-    public static final String SERVICE_NAME = "KAFKA";
     public static final String FIELD_NAME_TOPIC = "topic";
     public static final String FIELD_NAME_BOOTSTRAP_SERVERS = "bootstrapServers";
     public static final String FIELD_NAME_SECURITY_PROTOCOL = "securityProtocol";
@@ -57,7 +57,7 @@ public class KafkaSinkBundleHintProvider extends AbstractBundleHintProvider {
             }
         } catch (ServiceNotFoundException e) {
             // we access it from mapping information so shouldn't be here
-            throw new IllegalStateException("Service " + SERVICE_NAME + " in cluster " + cluster.getName() +
+            throw new IllegalStateException("Service " + Constants.Kafka.SERVICE_NAME + " in cluster " + cluster.getName() +
                     " not found but mapping information exists.");
         } catch (ServiceConfigurationNotFoundException e) {
             // there's KAFKA service but not enough configuration info.
@@ -69,6 +69,6 @@ public class KafkaSinkBundleHintProvider extends AbstractBundleHintProvider {
 
     @Override
     public String getServiceName() {
-        return SERVICE_NAME;
+        return Constants.Kafka.SERVICE_NAME;
     }
 }

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/AbstractServiceRegistrar.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/AbstractServiceRegistrar.java
@@ -35,8 +35,6 @@ import java.util.List;
 import java.util.Map;
 
 public abstract class AbstractServiceRegistrar implements ManualServiceRegistrar {
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-
     protected EnvironmentService environmentService;
 
     protected abstract String getServiceName();
@@ -69,7 +67,7 @@ public abstract class AbstractServiceRegistrar implements ManualServiceRegistrar
             String confType = getConfType(fileName);
             String actualFileName = ConfigFilePattern.getOriginFileName(confType);
 
-            ServiceConfiguration configuration = environmentService.initializeServiceConfiguration(objectMapper,
+            ServiceConfiguration configuration = environmentService.initializeServiceConfiguration(
                     service.getId(), confType, actualFileName, new HashMap<>(configMap));
             configurations.add(configuration);
             flattenConfigMap.putAll(configMap);

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/DruidServiceRegistrar.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/DruidServiceRegistrar.java
@@ -19,19 +19,15 @@ import com.hortonworks.streamline.common.Config;
 import com.hortonworks.streamline.streams.catalog.Component;
 import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
 import com.hortonworks.streamline.streams.cluster.Constants;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static com.hortonworks.streamline.streams.cluster.discovery.ambari.ConfigFilePattern.HBASE_SITE;
-
-public class HBaseServiceRegistrar extends AbstractServiceRegistrar {
-
+public class DruidServiceRegistrar extends AbstractServiceRegistrar {
     @Override
     protected String getServiceName() {
-        return Constants.HBase.SERVICE_NAME;
+        return Constants.Druid.SERVICE_NAME;
     }
 
     @Override
@@ -49,22 +45,15 @@ public class HBaseServiceRegistrar extends AbstractServiceRegistrar {
     @Override
     protected boolean validateServiceConfigurations(List<ServiceConfiguration> serviceConfigurations) {
         // requirements
-        // 1. hbase-site.xml should be provided
+        // 1. common.runtime.properties should be provided
 
-        long validConfigFileCount = serviceConfigurations.stream().filter(configuration -> {
-            if (configuration.getName().equals(HBASE_SITE.getConfType())) {
-                if (!StringUtils.isEmpty(configuration.getFilename())) {
-                    return true;
-                }
-            }
-            return false;
-        }).count();
-
-        return validConfigFileCount == 1;
+        return serviceConfigurations.stream()
+                .anyMatch(configuration -> configuration.getName().equals(Constants.Druid.CONF_TYPE_COMMON_RUNTIME));
     }
 
     @Override
     protected boolean validateServiceConfiguationsAsFlattenedMap(Map<String, String> configMap) {
-        return configMap.containsKey(Constants.HBase.PROPERTY_KEY_HBASE_ZOOKEEPER_QUORUM);
+        // only druid.zk.service.host is mandatory
+        return configMap.containsKey(Constants.Druid.PROPERTY_KEY_ZK_SERVICE_HOSTS);
     }
 }

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/HDFSServiceRegistrar.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/HDFSServiceRegistrar.java
@@ -18,6 +18,7 @@ package com.hortonworks.streamline.streams.cluster.register.impl;
 import com.hortonworks.streamline.common.Config;
 import com.hortonworks.streamline.streams.catalog.Component;
 import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
+import com.hortonworks.streamline.streams.cluster.Constants;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collections;
@@ -29,12 +30,9 @@ import static com.hortonworks.streamline.streams.cluster.discovery.ambari.Config
 
 public class HDFSServiceRegistrar extends AbstractServiceRegistrar {
 
-    public static final String SERVICE_NAME_HDFS = "HDFS";
-    public static final String PROPERTY_KEY_DEFAULT_FS = "fs.defaultFS";
-
     @Override
     protected String getServiceName() {
-        return SERVICE_NAME_HDFS;
+        return Constants.HDFS.SERVICE_NAME;
     }
 
     @Override
@@ -69,6 +67,6 @@ public class HDFSServiceRegistrar extends AbstractServiceRegistrar {
 
     @Override
     protected boolean validateServiceConfiguationsAsFlattenedMap(Map<String, String> configMap) {
-        return configMap.containsKey(PROPERTY_KEY_DEFAULT_FS);
+        return configMap.containsKey(Constants.HDFS.PROPERTY_KEY_DEFAULT_FS);
     }
 }

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/HiveServiceRegistrar.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/HiveServiceRegistrar.java
@@ -18,6 +18,7 @@ package com.hortonworks.streamline.streams.cluster.register.impl;
 import com.hortonworks.streamline.common.Config;
 import com.hortonworks.streamline.streams.catalog.Component;
 import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
+import com.hortonworks.streamline.streams.cluster.Constants;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collections;
@@ -28,12 +29,9 @@ import static com.hortonworks.streamline.streams.cluster.discovery.ambari.Config
 
 public class HiveServiceRegistrar extends AbstractServiceRegistrar {
 
-    public static final String SERVICE_NAME_HIVE = "HIVE";
-    public static final String PROPERTY_KEY_HIVE_ZOOKEEPER_QUORUM = "hive.zookeeper.quorum";
-
     @Override
     protected String getServiceName() {
-        return SERVICE_NAME_HIVE;
+        return Constants.Hive.SERVICE_NAME;
     }
 
     @Override
@@ -67,6 +65,6 @@ public class HiveServiceRegistrar extends AbstractServiceRegistrar {
 
     @Override
     protected boolean validateServiceConfiguationsAsFlattenedMap(Map<String, String> configMap) {
-        return configMap.containsKey(PROPERTY_KEY_HIVE_ZOOKEEPER_QUORUM);
+        return configMap.containsKey(Constants.Hive.PROPERTY_KEY_HIVE_ZOOKEEPER_QUORUM);
     }
 }

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/KafkaServiceRegistrar.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/KafkaServiceRegistrar.java
@@ -18,6 +18,7 @@ package com.hortonworks.streamline.streams.cluster.register.impl;
 import com.hortonworks.streamline.common.Config;
 import com.hortonworks.streamline.streams.catalog.Component;
 import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
+import com.hortonworks.streamline.streams.cluster.Constants;
 import com.hortonworks.streamline.streams.cluster.discovery.ambari.ComponentPropertyPattern;
 import com.hortonworks.streamline.streams.cluster.discovery.ambari.ServiceConfigurations;
 import org.apache.commons.lang3.StringUtils;
@@ -38,7 +39,7 @@ public class KafkaServiceRegistrar extends AbstractServiceRegistrar {
 
     @Override
     protected String getServiceName() {
-        return SERVICE_NAME_KAFKA;
+        return Constants.Kafka.SERVICE_NAME;
     }
 
     @Override
@@ -77,7 +78,7 @@ public class KafkaServiceRegistrar extends AbstractServiceRegistrar {
         // requirements
         // 1. zookeeper.connect should be available in kafka-broker
         // if it exists, it should be within kafka-broker since we are allowing only one 'kafka-broker'
-        return configMap.containsKey(KAFKA_PROPERTY_ZOOKEEPER_CONNECT);
+        return configMap.containsKey(Constants.Kafka.PROPERTY_KEY_ZOOKEEPER_CONNECT);
     }
 
     private Component createKafkaBrokerComponent(Config config, Map<String, String> flattenConfigMap) {

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/StormServiceRegistrar.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/StormServiceRegistrar.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import com.hortonworks.streamline.common.Config;
 import com.hortonworks.streamline.streams.catalog.Component;
 import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
+import com.hortonworks.streamline.streams.cluster.Constants;
 import com.hortonworks.streamline.streams.cluster.discovery.ambari.ComponentPropertyPattern;
 
 import java.util.Arrays;
@@ -31,13 +32,12 @@ import static java.util.stream.Collectors.toList;
 public class StormServiceRegistrar extends AbstractServiceRegistrar {
     public static final String COMPONENT_STORM_UI_SERVER = ComponentPropertyPattern.STORM_UI_SERVER.name();
     public static final String COMPONENT_NIMBUS = ComponentPropertyPattern.NIMBUS.name();
-    public static final String SERVICE_NAME_STORM = "STORM";
     public static final String PARAM_STORM_UI_SERVER_HOSTNAME = "uiServerHostname";
     public static final String PARAM_NIMBUS_HOSTNAMES = "nimbusesHostnames";
 
     @Override
     protected String getServiceName() {
-        return SERVICE_NAME_STORM;
+        return Constants.Storm.SERVICE_NAME;
     }
 
     @Override

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/ZookeeperServiceRegistrar.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/ZookeeperServiceRegistrar.java
@@ -18,6 +18,7 @@ package com.hortonworks.streamline.streams.cluster.register.impl;
 import com.hortonworks.streamline.common.Config;
 import com.hortonworks.streamline.streams.catalog.Component;
 import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
+import com.hortonworks.streamline.streams.cluster.Constants;
 import com.hortonworks.streamline.streams.cluster.discovery.ambari.ComponentPropertyPattern;
 
 import java.util.Arrays;
@@ -30,12 +31,11 @@ import static java.util.stream.Collectors.toList;
 
 public class ZookeeperServiceRegistrar extends AbstractServiceRegistrar {
     public static final String COMPONENT_ZOOKEEPER_SERVER = ComponentPropertyPattern.ZOOKEEPER_SERVER.name();
-    public static final String SERVICE_NAME_ZOOKEEPER = "ZOOKEEPER";
     public static final String PARAM_ZOOKEEPER_SERVER_HOSTNAMES = "zkServersHostnames";
 
     @Override
     protected String getServiceName() {
-        return SERVICE_NAME_ZOOKEEPER;
+        return Constants.Zookeeper.SERVICE_NAME;
     }
 
     @Override

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/service/EnvironmentService.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/service/EnvironmentService.java
@@ -61,11 +61,13 @@ public class EnvironmentService {
     private final StorageManager dao;
     private final ClusterImporter clusterImporter;
     private final List<ContainingNamespaceAwareContainer> containers;
+    private final ObjectMapper objectMapper;
 
     public EnvironmentService(StorageManager dao) {
         this.dao = dao;
         this.clusterImporter = new ClusterImporter(this);
         this.containers = new ArrayList<>();
+        this.objectMapper = new ObjectMapper();
     }
 
     public void addNamespaceAwareContainer(ContainingNamespaceAwareContainer container) {
@@ -95,8 +97,8 @@ public class EnvironmentService {
         return component;
     }
 
-    public ServiceConfiguration initializeServiceConfiguration(ObjectMapper objectMapper, Long serviceId,
-                                                               String confType, String actualFileName, Map<String, String> configuration) throws JsonProcessingException {
+    public ServiceConfiguration initializeServiceConfiguration(Long serviceId, String confType, String actualFileName,
+                                                               Map<String, String> configuration) throws JsonProcessingException {
         ServiceConfiguration conf = new ServiceConfiguration();
         conf.setId(this.dao.nextId(SERVICE_CONFIGURATION_NAMESPACE));
         conf.setName(confType);

--- a/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/bundle/impl/DruidSinkBundleHintProviderTest.java
+++ b/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/bundle/impl/DruidSinkBundleHintProviderTest.java
@@ -1,0 +1,65 @@
+package com.hortonworks.streamline.streams.cluster.bundle.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hortonworks.streamline.streams.catalog.Cluster;
+import com.hortonworks.streamline.streams.catalog.Service;
+import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
+import com.hortonworks.streamline.streams.cluster.Constants;
+import com.hortonworks.streamline.streams.cluster.service.EnvironmentService;
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(JMockit.class)
+public class DruidSinkBundleHintProviderTest {
+    private DruidSinkBundleHintProvider provider = new DruidSinkBundleHintProvider();
+
+    @Mocked
+    private EnvironmentService environmentService;
+
+    @Test
+    public void getHintsOnCluster() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        Cluster cluster = new Cluster();
+        cluster.setId(1L);
+        cluster.setName("cluster1");
+
+        Service service = new Service();
+        service.setId(1L);
+        service.setName(Constants.Druid.SERVICE_NAME);
+
+        Map<String, String> confMap = new HashMap<>();
+        confMap.put(Constants.Druid.PROPERTY_KEY_ZK_SERVICE_HOSTS, "svr1:2181,svr2:2181");
+        confMap.put(Constants.Druid.PROPERTY_KEY_INDEXING_SERVICE_NAME, "druid/overlord");
+        confMap.put(Constants.Druid.PROPERTY_KEY_DISCOVERY_CURATOR_PATH, "/discovery");
+
+        ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
+        serviceConfiguration.setId(1L);
+        serviceConfiguration.setName(Constants.Druid.CONF_TYPE_COMMON_RUNTIME);
+        serviceConfiguration.setConfiguration(objectMapper.writeValueAsString(confMap));
+
+        new Expectations() {{
+            environmentService.getServiceByName(cluster.getId(), Constants.Druid.SERVICE_NAME);
+            result = service;
+
+            environmentService.getServiceConfigurationByName(service.getId(), Constants.Druid.CONF_TYPE_COMMON_RUNTIME);
+            result = serviceConfiguration;
+        }};
+
+        provider.init(environmentService);
+
+        Map<String, Object> hints = provider.getHintsOnCluster(cluster);
+        Assert.assertNotNull(hints);
+        Assert.assertEquals("svr1:2181,svr2:2181", hints.get(DruidSinkBundleHintProvider.FIELD_NAME_ZK_CONNECT));
+        Assert.assertEquals("druid/overlord", hints.get(DruidSinkBundleHintProvider.FIELD_NAME_INDEX_SERVICE));
+        Assert.assertEquals("/discovery", hints.get(DruidSinkBundleHintProvider.FIELD_NAME_DISCOVERY_PATH));
+    }
+
+}

--- a/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/register/impl/DruidServiceRegistrarTest.java
+++ b/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/register/impl/DruidServiceRegistrarTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.cluster.register.impl;
+
+import com.google.common.collect.Lists;
+import com.hortonworks.streamline.common.Config;
+import com.hortonworks.streamline.streams.catalog.Cluster;
+import com.hortonworks.streamline.streams.catalog.Service;
+import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
+import com.hortonworks.streamline.streams.cluster.Constants;
+import com.hortonworks.streamline.streams.cluster.register.ManualServiceRegistrar;
+import mockit.integration.junit4.JMockit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.InputStream;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+@RunWith(JMockit.class)
+public class DruidServiceRegistrarTest extends AbstractServiceRegistrarTest<DruidServiceRegistrar> {
+    public static final String DRUID_COMMON_RUNTIME_PROPERTIES = "common.runtime.properties";
+    public static final String DRUID_COMMON_RUNTIME_PROPERTIES_FILE_PATH = REGISTER_RESOURCE_DIRECTORY + DRUID_COMMON_RUNTIME_PROPERTIES;
+    public static final String DRUID_COMMON_RUNTIME_PROPERTIES_BADCASE_FILE_PATH = REGISTER_BADCASE_RESOURCE_DIRECTORY + DRUID_COMMON_RUNTIME_PROPERTIES;
+    private static final String CONFIGURATION_NAME_COMMON_RUNTIME_PROPERTIES = "common.runtime";
+
+    public DruidServiceRegistrarTest() {
+        super(DruidServiceRegistrar.class);
+    }
+
+    @Before
+    public void setUp() {
+        resetEnvironmentService();
+    }
+
+    @Test
+    public void testRegister_happyCase() throws Exception {
+        Cluster cluster = getTestCluster(1L);
+
+        DruidServiceRegistrar registerer = initializeServiceRegistrar();
+
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream(DRUID_COMMON_RUNTIME_PROPERTIES_FILE_PATH)) {
+            ManualServiceRegistrar.ConfigFileInfo hiveSiteXml = new ManualServiceRegistrar.ConfigFileInfo(DRUID_COMMON_RUNTIME_PROPERTIES, is);
+            registerer.register(cluster, new Config(), Lists.newArrayList(hiveSiteXml));
+        }
+
+        Service druidService = environmentService.getServiceByName(cluster.getId(), Constants.Druid.SERVICE_NAME);
+        assertNotNull(druidService);
+        ServiceConfiguration commonRuntimePropertiesConf = environmentService.getServiceConfigurationByName(druidService.getId(), CONFIGURATION_NAME_COMMON_RUNTIME_PROPERTIES);
+        assertNotNull(commonRuntimePropertiesConf);
+    }
+
+    @Test
+    public void testRegister_requiredPropertyNotPresented() throws Exception {
+        Cluster cluster = getTestCluster(1L);
+
+        DruidServiceRegistrar registerer = initializeServiceRegistrar();
+
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream(DRUID_COMMON_RUNTIME_PROPERTIES_BADCASE_FILE_PATH)) {
+            ManualServiceRegistrar.ConfigFileInfo hiveSiteXml = new ManualServiceRegistrar.ConfigFileInfo(DRUID_COMMON_RUNTIME_PROPERTIES, is);
+            registerer.register(cluster, new Config(), Lists.newArrayList(hiveSiteXml));
+            fail("Should throw IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            // OK
+            Service druidService = environmentService.getServiceByName(cluster.getId(), Constants.Druid.SERVICE_NAME);
+            assertNull(druidService);
+        }
+    }
+
+    @Test
+    public void testRegister_common_runtime_properties_notPresent() throws Exception {
+        Cluster cluster = getTestCluster(1L);
+
+        DruidServiceRegistrar registerer = initializeServiceRegistrar();
+
+        try {
+            registerer.register(cluster, new Config(), Lists.newArrayList());
+            fail("Should throw IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            // OK
+            Service druidService = environmentService.getServiceByName(cluster.getId(), Constants.Druid.SERVICE_NAME);
+            assertNull(druidService);
+        }
+    }
+}

--- a/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/register/impl/HBaseServiceRegistrarTest.java
+++ b/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/register/impl/HBaseServiceRegistrarTest.java
@@ -20,6 +20,7 @@ import com.hortonworks.streamline.common.Config;
 import com.hortonworks.streamline.streams.catalog.Cluster;
 import com.hortonworks.streamline.streams.catalog.Service;
 import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
+import com.hortonworks.streamline.streams.cluster.Constants;
 import com.hortonworks.streamline.streams.cluster.register.ManualServiceRegistrar;
 import mockit.integration.junit4.JMockit;
 import org.junit.Before;
@@ -57,7 +58,7 @@ public class HBaseServiceRegistrarTest extends AbstractServiceRegistrarTest<HBas
             registrar.register(cluster, new Config(), Lists.newArrayList(hiveSiteXml));
         }
 
-        Service hbaseService = environmentService.getServiceByName(cluster.getId(), HBaseServiceRegistrar.SERVICE_NAME_HBASE);
+        Service hbaseService = environmentService.getServiceByName(cluster.getId(), Constants.HBase.SERVICE_NAME);
         assertNotNull(hbaseService);
         ServiceConfiguration hbaseSiteConf = environmentService.getServiceConfigurationByName(hbaseService.getId(), CONFIGURATION_NAME_HBASE_SITE);
         assertNotNull(hbaseSiteConf);
@@ -75,7 +76,7 @@ public class HBaseServiceRegistrarTest extends AbstractServiceRegistrarTest<HBas
             fail("Should throw IllegalArgumentException");
         } catch (IllegalArgumentException e) {
             // OK
-            Service hbaseService = environmentService.getServiceByName(cluster.getId(), HBaseServiceRegistrar.SERVICE_NAME_HBASE);
+            Service hbaseService = environmentService.getServiceByName(cluster.getId(), Constants.HBase.SERVICE_NAME);
             assertNull(hbaseService);
         }
     }
@@ -91,7 +92,7 @@ public class HBaseServiceRegistrarTest extends AbstractServiceRegistrarTest<HBas
             fail("Should throw IllegalArgumentException");
         } catch (IllegalArgumentException e) {
             // OK
-            Service hbaseService = environmentService.getServiceByName(cluster.getId(), HBaseServiceRegistrar.SERVICE_NAME_HBASE);
+            Service hbaseService = environmentService.getServiceByName(cluster.getId(), Constants.HBase.SERVICE_NAME);
             assertNull(hbaseService);
         }
     }

--- a/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/register/impl/HDFSServiceRegistrarTest.java
+++ b/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/register/impl/HDFSServiceRegistrarTest.java
@@ -20,6 +20,7 @@ import com.hortonworks.streamline.common.Config;
 import com.hortonworks.streamline.streams.catalog.Cluster;
 import com.hortonworks.streamline.streams.catalog.Service;
 import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
+import com.hortonworks.streamline.streams.cluster.Constants;
 import com.hortonworks.streamline.streams.cluster.register.ManualServiceRegistrar;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,7 +61,7 @@ public class HDFSServiceRegistrarTest extends AbstractServiceRegistrarTest<HDFSS
             registrar.register(cluster, new Config(), Lists.newArrayList(coreSiteXml, hdfsSiteXml));
         }
 
-        Service hdfsService = environmentService.getServiceByName(cluster.getId(), HDFSServiceRegistrar.SERVICE_NAME_HDFS);
+        Service hdfsService = environmentService.getServiceByName(cluster.getId(), Constants.HDFS.SERVICE_NAME);
         assertNotNull(hdfsService);
         ServiceConfiguration coreSiteConf = environmentService.getServiceConfigurationByName(hdfsService.getId(), CONFIGURATION_NAME_CORE_SITE);
         assertNotNull(coreSiteConf);
@@ -82,7 +83,7 @@ public class HDFSServiceRegistrarTest extends AbstractServiceRegistrarTest<HDFSS
             fail("Should throw IllegalArgumentException");
         } catch (IllegalArgumentException e) {
             // OK
-            Service hdfsService = environmentService.getServiceByName(cluster.getId(), HDFSServiceRegistrar.SERVICE_NAME_HDFS);
+            Service hdfsService = environmentService.getServiceByName(cluster.getId(), Constants.HDFS.SERVICE_NAME);
             assertNull(hdfsService);
         }
     }
@@ -99,7 +100,7 @@ public class HDFSServiceRegistrarTest extends AbstractServiceRegistrarTest<HDFSS
             fail("Should throw IllegalArgumentException");
         } catch (IllegalArgumentException e) {
             // OK
-            Service hdfsService = environmentService.getServiceByName(cluster.getId(), HDFSServiceRegistrar.SERVICE_NAME_HDFS);
+            Service hdfsService = environmentService.getServiceByName(cluster.getId(), Constants.HDFS.SERVICE_NAME);
             assertNull(hdfsService);
         }
     }
@@ -116,7 +117,7 @@ public class HDFSServiceRegistrarTest extends AbstractServiceRegistrarTest<HDFSS
             fail("Should throw IllegalArgumentException");
         } catch (IllegalArgumentException e) {
             // OK
-            Service hdfsService = environmentService.getServiceByName(cluster.getId(), HDFSServiceRegistrar.SERVICE_NAME_HDFS);
+            Service hdfsService = environmentService.getServiceByName(cluster.getId(), Constants.HDFS.SERVICE_NAME);
             assertNull(hdfsService);
         }
     }

--- a/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/register/impl/HiveServiceRegistrarTest.java
+++ b/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/register/impl/HiveServiceRegistrarTest.java
@@ -20,6 +20,7 @@ import com.hortonworks.streamline.common.Config;
 import com.hortonworks.streamline.streams.catalog.Cluster;
 import com.hortonworks.streamline.streams.catalog.Service;
 import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
+import com.hortonworks.streamline.streams.cluster.Constants;
 import com.hortonworks.streamline.streams.cluster.register.ManualServiceRegistrar;
 import mockit.integration.junit4.JMockit;
 import org.junit.Before;
@@ -59,7 +60,7 @@ public class HiveServiceRegistrarTest extends AbstractServiceRegistrarTest<HiveS
             registrar.register(cluster, new Config(), Lists.newArrayList(hiveSiteXml));
         }
 
-        Service hiveService = environmentService.getServiceByName(cluster.getId(), HiveServiceRegistrar.SERVICE_NAME_HIVE);
+        Service hiveService = environmentService.getServiceByName(cluster.getId(), Constants.Hive.SERVICE_NAME);
         assertNotNull(hiveService);
         ServiceConfiguration coreSiteConf = environmentService.getServiceConfigurationByName(hiveService.getId(), CONFIGURATION_NAME_HIVE_SITE);
         assertNotNull(coreSiteConf);
@@ -77,7 +78,7 @@ public class HiveServiceRegistrarTest extends AbstractServiceRegistrarTest<HiveS
             fail("Should throw IllegalArgumentException");
         } catch (IllegalArgumentException e) {
             // OK
-            Service hiveService = environmentService.getServiceByName(cluster.getId(), HiveServiceRegistrar.SERVICE_NAME_HIVE);
+            Service hiveService = environmentService.getServiceByName(cluster.getId(), Constants.Hive.SERVICE_NAME);
             assertNull(hiveService);
         }
     }
@@ -93,7 +94,7 @@ public class HiveServiceRegistrarTest extends AbstractServiceRegistrarTest<HiveS
             fail("Should throw IllegalArgumentException");
         } catch (IllegalArgumentException e) {
             // OK
-            Service hiveService = environmentService.getServiceByName(cluster.getId(), HiveServiceRegistrar.SERVICE_NAME_HIVE);
+            Service hiveService = environmentService.getServiceByName(cluster.getId(), Constants.Hive.SERVICE_NAME);
             assertNull(hiveService);
         }
     }

--- a/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/register/impl/KafkaServiceRegistrarTest.java
+++ b/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/register/impl/KafkaServiceRegistrarTest.java
@@ -20,6 +20,7 @@ import com.hortonworks.streamline.common.Config;
 import com.hortonworks.streamline.streams.catalog.Cluster;
 import com.hortonworks.streamline.streams.catalog.Service;
 import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
+import com.hortonworks.streamline.streams.cluster.Constants;
 import com.hortonworks.streamline.streams.cluster.register.ManualServiceRegistrar;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,7 +58,7 @@ public class KafkaServiceRegistrarTest extends AbstractServiceRegistrarTest<Kafk
             registrar.register(cluster, config, Lists.newArrayList(serverProperties));
         }
 
-        Service kafkaService = environmentService.getServiceByName(cluster.getId(), KafkaServiceRegistrar.SERVICE_NAME_KAFKA);
+        Service kafkaService = environmentService.getServiceByName(cluster.getId(), Constants.Kafka.SERVICE_NAME);
         assertNotNull(kafkaService);
         ServiceConfiguration serverPropertiesConf = environmentService.getServiceConfigurationByName(kafkaService.getId(), CONFIGURATION_NAME_SERVER_PROPERTIES);
         assertNotNull(serverPropertiesConf);
@@ -77,7 +78,7 @@ public class KafkaServiceRegistrarTest extends AbstractServiceRegistrarTest<Kafk
             fail("Should throw IllegalArgumentException");
         } catch (IllegalArgumentException e) {
             // OK
-            Service kafkaService = environmentService.getServiceByName(cluster.getId(), KafkaServiceRegistrar.SERVICE_NAME_KAFKA);
+            Service kafkaService = environmentService.getServiceByName(cluster.getId(), Constants.Kafka.SERVICE_NAME);
             assertNull(kafkaService);
         }
     }
@@ -94,7 +95,7 @@ public class KafkaServiceRegistrarTest extends AbstractServiceRegistrarTest<Kafk
             fail("Should throw IllegalArgumentException");
         } catch (IllegalArgumentException e) {
             // OK
-            Service kafkaService = environmentService.getServiceByName(cluster.getId(), KafkaServiceRegistrar.SERVICE_NAME_KAFKA);
+            Service kafkaService = environmentService.getServiceByName(cluster.getId(), Constants.Kafka.SERVICE_NAME);
             assertNull(kafkaService);
         }
     }
@@ -111,6 +112,8 @@ public class KafkaServiceRegistrarTest extends AbstractServiceRegistrarTest<Kafk
             registrar.register(cluster, config, Lists.newArrayList());
         } catch (IllegalArgumentException e) {
             // OK
+            Service kafkaService = environmentService.getServiceByName(cluster.getId(), Constants.Kafka.SERVICE_NAME);
+            assertNull(kafkaService);
         }
     }
 

--- a/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/register/impl/StormServiceRegistrarTest.java
+++ b/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/register/impl/StormServiceRegistrarTest.java
@@ -20,6 +20,7 @@ import com.hortonworks.streamline.common.Config;
 import com.hortonworks.streamline.streams.catalog.Cluster;
 import com.hortonworks.streamline.streams.catalog.Service;
 import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
+import com.hortonworks.streamline.streams.cluster.Constants;
 import com.hortonworks.streamline.streams.cluster.register.ManualServiceRegistrar;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,7 +60,7 @@ public class StormServiceRegistrarTest extends AbstractServiceRegistrarTest<Stor
             registrar.register(cluster, config, Lists.newArrayList(stormYaml));
         }
 
-        Service stormService = environmentService.getServiceByName(cluster.getId(), StormServiceRegistrar.SERVICE_NAME_STORM);
+        Service stormService = environmentService.getServiceByName(cluster.getId(), Constants.Storm.SERVICE_NAME);
         assertNotNull(stormService);
         ServiceConfiguration stormYamlConf = environmentService.getServiceConfigurationByName(stormService.getId(), CONFIGURATION_NAME_STORM_YAML);
         assertNotNull(stormYamlConf);
@@ -80,7 +81,7 @@ public class StormServiceRegistrarTest extends AbstractServiceRegistrarTest<Stor
             fail("Should throw IllegalArgumentException");
         } catch (IllegalArgumentException e) {
             // OK
-            Service stormService = environmentService.getServiceByName(cluster.getId(), StormServiceRegistrar.SERVICE_NAME_STORM);
+            Service stormService = environmentService.getServiceByName(cluster.getId(), Constants.Storm.SERVICE_NAME);
             assertNull(stormService);
         }
     }
@@ -99,7 +100,7 @@ public class StormServiceRegistrarTest extends AbstractServiceRegistrarTest<Stor
             fail("Should throw IllegalArgumentException");
         } catch (IllegalArgumentException e) {
             // OK
-            Service stormService = environmentService.getServiceByName(cluster.getId(), StormServiceRegistrar.SERVICE_NAME_STORM);
+            Service stormService = environmentService.getServiceByName(cluster.getId(), Constants.Storm.SERVICE_NAME);
             assertNull(stormService);
         }
     }
@@ -118,7 +119,7 @@ public class StormServiceRegistrarTest extends AbstractServiceRegistrarTest<Stor
             fail("Should throw IllegalArgumentException");
         } catch (IllegalArgumentException e) {
             // OK
-            Service stormService = environmentService.getServiceByName(cluster.getId(), StormServiceRegistrar.SERVICE_NAME_STORM);
+            Service stormService = environmentService.getServiceByName(cluster.getId(), Constants.Storm.SERVICE_NAME);
             assertNull(stormService);
         }
     }

--- a/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/register/impl/ZookeeperServiceRegistrarTest.java
+++ b/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/register/impl/ZookeeperServiceRegistrarTest.java
@@ -20,6 +20,7 @@ import com.hortonworks.streamline.common.Config;
 import com.hortonworks.streamline.streams.catalog.Cluster;
 import com.hortonworks.streamline.streams.catalog.Service;
 import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
+import com.hortonworks.streamline.streams.cluster.Constants;
 import com.hortonworks.streamline.streams.cluster.register.ManualServiceRegistrar;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,7 +57,7 @@ public class ZookeeperServiceRegistrarTest extends AbstractServiceRegistrarTest<
             registrar.register(cluster, config, Lists.newArrayList(zooCfg));
         }
 
-        Service zkService = environmentService.getServiceByName(cluster.getId(), ZookeeperServiceRegistrar.SERVICE_NAME_ZOOKEEPER);
+        Service zkService = environmentService.getServiceByName(cluster.getId(), Constants.Zookeeper.SERVICE_NAME);
         assertNotNull(zkService);
         ServiceConfiguration zooConf = environmentService.getServiceConfigurationByName(zkService.getId(), CONFIGURATION_NAME_ZOO_CFG);
         assertNotNull(zooConf);
@@ -76,7 +77,7 @@ public class ZookeeperServiceRegistrarTest extends AbstractServiceRegistrarTest<
             fail("Should throw IllegalArgumentException");
         } catch (IllegalArgumentException e) {
             // OK
-            Service zkService = environmentService.getServiceByName(cluster.getId(), ZookeeperServiceRegistrar.SERVICE_NAME_ZOOKEEPER);
+            Service zkService = environmentService.getServiceByName(cluster.getId(), Constants.Zookeeper.SERVICE_NAME);
             assertNull(zkService);
         }
     }
@@ -93,7 +94,7 @@ public class ZookeeperServiceRegistrarTest extends AbstractServiceRegistrarTest<
             fail("Should throw IllegalArgumentException");
         } catch (IllegalArgumentException e) {
             // OK
-            Service zkService = environmentService.getServiceByName(cluster.getId(), ZookeeperServiceRegistrar.SERVICE_NAME_ZOOKEEPER);
+            Service zkService = environmentService.getServiceByName(cluster.getId(), Constants.Zookeeper.SERVICE_NAME);
             assertNull(zkService);
         }
     }
@@ -111,7 +112,7 @@ public class ZookeeperServiceRegistrarTest extends AbstractServiceRegistrarTest<
             fail("Should throw IllegalArgumentException");
         } catch (IllegalArgumentException e) {
             // OK
-            Service zkService = environmentService.getServiceByName(cluster.getId(), ZookeeperServiceRegistrar.SERVICE_NAME_ZOOKEEPER);
+            Service zkService = environmentService.getServiceByName(cluster.getId(), Constants.Zookeeper.SERVICE_NAME);
             assertNull(zkService);
         }
     }

--- a/streams/cluster/src/test/resources/register/correct_config/common.runtime.properties
+++ b/streams/cluster/src/test/resources/register/correct_config/common.runtime.properties
@@ -1,0 +1,117 @@
+#
+# Licensed to Metamarkets Group Inc. (Metamarkets) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Metamarkets licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# Extensions
+#
+
+# This is not the full list of Druid extensions, but common ones that people often use. You may need to change this list
+# based on your particular setup.
+druid.extensions.loadList=["druid-kafka-eight", "druid-s3-extensions", "druid-histogram", "druid-datasketches", "druid-lookups-cached-global", "mysql-metadata-storage"]
+
+# If you have a different version of Hadoop, place your Hadoop client jar files in your hadoop-dependencies directory
+# and uncomment the line below to point to your directory.
+#druid.extensions.hadoopDependenciesDir=/my/dir/hadoop-dependencies
+
+#
+# Logging
+#
+
+# Log all runtime properties on startup. Disable to avoid logging properties on startup:
+druid.startup.logging.logProperties=true
+
+#
+# Zookeeper
+#
+
+druid.zk.service.host=zk.host.ip
+druid.zk.paths.base=/druid
+
+#
+# Metadata storage
+#
+
+# For Derby server on your Druid Coordinator (only viable in a cluster with a single Coordinator, no fail-over):
+druid.metadata.storage.type=derby
+druid.metadata.storage.connector.connectURI=jdbc:derby://metadata.store.ip:1527/var/druid/metadata.db;create=true
+druid.metadata.storage.connector.host=metadata.store.ip
+druid.metadata.storage.connector.port=1527
+
+# For MySQL:
+#druid.metadata.storage.type=mysql
+#druid.metadata.storage.connector.connectURI=jdbc:mysql://db.example.com:3306/druid
+#druid.metadata.storage.connector.user=...
+#druid.metadata.storage.connector.password=...
+
+# For PostgreSQL (make sure to additionally include the Postgres extension):
+#druid.metadata.storage.type=postgresql
+#druid.metadata.storage.connector.connectURI=jdbc:postgresql://db.example.com:5432/druid
+#druid.metadata.storage.connector.user=...
+#druid.metadata.storage.connector.password=...
+
+#
+# Deep storage
+#
+
+# For local disk (only viable in a cluster if this is a network mount):
+druid.storage.type=local
+druid.storage.storageDirectory=var/druid/segments
+
+# For HDFS (make sure to include the HDFS extension and that your Hadoop config files in the cp):
+#druid.storage.type=hdfs
+#druid.storage.storageDirectory=/druid/segments
+
+# For S3:
+#druid.storage.type=s3
+#druid.storage.bucket=your-bucket
+#druid.storage.baseKey=druid/segments
+#druid.s3.accessKey=...
+#druid.s3.secretKey=...
+
+#
+# Indexing service logs
+#
+
+# For local disk (only viable in a cluster if this is a network mount):
+druid.indexer.logs.type=file
+druid.indexer.logs.directory=var/druid/indexing-logs
+
+# For HDFS (make sure to include the HDFS extension and that your Hadoop config files in the cp):
+#druid.indexer.logs.type=hdfs
+#druid.indexer.logs.directory=/druid/indexing-logs
+
+# For S3:
+#druid.indexer.logs.type=s3
+#druid.indexer.logs.s3Bucket=your-bucket
+#druid.indexer.logs.s3Prefix=druid/indexing-logs
+
+#
+# Service discovery
+#
+
+druid.selectors.indexing.serviceName=druid/overlord
+druid.selectors.coordinator.serviceName=druid/coordinator
+
+#
+# Monitoring
+#
+
+druid.monitoring.monitors=["com.metamx.metrics.JvmMonitor"]
+druid.emitter=logging
+druid.emitter.logging.logLevel=info

--- a/streams/cluster/src/test/resources/register/invalid_config/common.runtime.properties
+++ b/streams/cluster/src/test/resources/register/invalid_config/common.runtime.properties
@@ -1,0 +1,116 @@
+#
+# Licensed to Metamarkets Group Inc. (Metamarkets) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Metamarkets licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# Extensions
+#
+
+# This is not the full list of Druid extensions, but common ones that people often use. You may need to change this list
+# based on your particular setup.
+druid.extensions.loadList=["druid-kafka-eight", "druid-s3-extensions", "druid-histogram", "druid-datasketches", "druid-lookups-cached-global", "mysql-metadata-storage"]
+
+# If you have a different version of Hadoop, place your Hadoop client jar files in your hadoop-dependencies directory
+# and uncomment the line below to point to your directory.
+#druid.extensions.hadoopDependenciesDir=/my/dir/hadoop-dependencies
+
+#
+# Logging
+#
+
+# Log all runtime properties on startup. Disable to avoid logging properties on startup:
+druid.startup.logging.logProperties=true
+
+#
+# Zookeeper
+#
+
+druid.zk.paths.base=/druid
+
+#
+# Metadata storage
+#
+
+# For Derby server on your Druid Coordinator (only viable in a cluster with a single Coordinator, no fail-over):
+druid.metadata.storage.type=derby
+druid.metadata.storage.connector.connectURI=jdbc:derby://metadata.store.ip:1527/var/druid/metadata.db;create=true
+druid.metadata.storage.connector.host=metadata.store.ip
+druid.metadata.storage.connector.port=1527
+
+# For MySQL:
+#druid.metadata.storage.type=mysql
+#druid.metadata.storage.connector.connectURI=jdbc:mysql://db.example.com:3306/druid
+#druid.metadata.storage.connector.user=...
+#druid.metadata.storage.connector.password=...
+
+# For PostgreSQL (make sure to additionally include the Postgres extension):
+#druid.metadata.storage.type=postgresql
+#druid.metadata.storage.connector.connectURI=jdbc:postgresql://db.example.com:5432/druid
+#druid.metadata.storage.connector.user=...
+#druid.metadata.storage.connector.password=...
+
+#
+# Deep storage
+#
+
+# For local disk (only viable in a cluster if this is a network mount):
+druid.storage.type=local
+druid.storage.storageDirectory=var/druid/segments
+
+# For HDFS (make sure to include the HDFS extension and that your Hadoop config files in the cp):
+#druid.storage.type=hdfs
+#druid.storage.storageDirectory=/druid/segments
+
+# For S3:
+#druid.storage.type=s3
+#druid.storage.bucket=your-bucket
+#druid.storage.baseKey=druid/segments
+#druid.s3.accessKey=...
+#druid.s3.secretKey=...
+
+#
+# Indexing service logs
+#
+
+# For local disk (only viable in a cluster if this is a network mount):
+druid.indexer.logs.type=file
+druid.indexer.logs.directory=var/druid/indexing-logs
+
+# For HDFS (make sure to include the HDFS extension and that your Hadoop config files in the cp):
+#druid.indexer.logs.type=hdfs
+#druid.indexer.logs.directory=/druid/indexing-logs
+
+# For S3:
+#druid.indexer.logs.type=s3
+#druid.indexer.logs.s3Bucket=your-bucket
+#druid.indexer.logs.s3Prefix=druid/indexing-logs
+
+#
+# Service discovery
+#
+
+druid.selectors.indexing.serviceName=druid/overlord
+druid.selectors.coordinator.serviceName=druid/coordinator
+
+#
+# Monitoring
+#
+
+druid.monitoring.monitors=["com.metamx.metrics.JvmMonitor"]
+druid.emitter=logging
+druid.emitter.logging.logLevel=info


### PR DESCRIPTION
This is on top of STREAMLINE-545 (#511). I'll rebase once #511 is merged.
Only commit 10faa71 is for STREAMLINE-709.

Registering Druid service by manual should be easy: just uploading `common.runtime.properties`.