### PR TITLE
STREAMLINE-728 Ambari cluster import should work when Ambari is on SS…

### DIFF
--- a/bin/import-certificate-into-truststore.sh
+++ b/bin/import-certificate-into-truststore.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2017 Hortonworks.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Read secret string
+read_secret()
+{
+  # Save the old setting
+  oldtty=`stty -g`
+
+  # Disable echo.
+  stty -echo
+
+  # Set up trap to ensure echo is enabled before exiting if the script
+  # is terminated while echo is disabled.
+  trap 'stty ${oldtty}' EXIT
+
+  # Read secret.
+  read "$@"
+
+  # Restore setting
+  stty ${oldtty}
+  trap - EXIT
+
+  # Print a newline because the newline entered by the user after
+  # entering the passcode is not echoed. This ensures that the
+  # next line of output begins at a new line.
+  echo
+}
+
+if [ $# -lt 3 ]; then
+  echo "Usage: [host] [port] [truststore path] (truststore password)"
+  exit 1
+fi
+
+HOST=$1
+PORT=$2
+TRUSTSTORE_FILE=$3
+
+if [ $# -lt 4 ]; then
+  printf "Password: "
+  read_secret TRUSTSTORE_PASS
+else
+  TRUSTSTORE_PASS=$4
+fi
+
+which openssl > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+  echo "openssl doesn't exist in PATH. Please install openssl and register to PATH."
+  exit 1
+fi
+
+# Which java to use
+if [ -z "${JAVA_HOME}" ]; then
+  KEYTOOL="keytool"
+else
+  KEYTOOL="${JAVA_HOME}/bin/keytool"
+fi
+
+CERT_FILE="${HOST}.cert"
+
+echo "Getting certificate for ${HOST}..."
+openssl s_client -connect ${HOST}:${PORT} </dev/null \
+    | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > ${CERT_FILE}
+
+grep "BEGIN CERTIFICATE" ${CERT_FILE} > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+  echo "Fail to get certificate for ${HOST}... Please check certification file ${CERT_FILE}"
+  exit 2
+fi
+
+echo "Importing certificate into truststore ${TRUSTSTORE_FILE} ..."
+${KEYTOOL} -import -noprompt -trustcacerts \
+    -alias ${HOST} -file ${CERT_FILE} \
+    -keystore ${TRUSTSTORE_FILE} -storepass ${TRUSTSTORE_PASS}
+
+echo "Verifying import..."
+${KEYTOOL} -list -v -keystore ${TRUSTSTORE_FILE} -storepass ${TRUSTSTORE_PASS} -alias ${HOST}
+
+echo "Deleting downloaded certificate file..."
+rm -f ${CERT_FILE}

--- a/conf/streamline-dev.yaml
+++ b/conf/streamline-dev.yaml
@@ -32,6 +32,13 @@ dashboardConfiguration:
 storageProviderConfiguration:
   providerClass: "com.hortonworks.streamline.storage.impl.memory.InMemoryStorageManager"
 
+# Truststore information which is needed for importing certificated Ambari cluster.
+# which default truststore doesn't cover the CA or self-certified.
+# When the options are not provided, JDK default truststore will be used.
+# It only supports single truststores, so admin needs to maintain single truststore and import certificates to that.
+#trustStorePath: ""
+#trustStorePassword: ""
+
 enableCors: true
 corsUrlPatterns:
   - "/api/v1/dashboards/*"

--- a/conf/streamline.mysql.yaml
+++ b/conf/streamline.mysql.yaml
@@ -45,6 +45,13 @@ storageProviderConfiguration:
     dataSource.user: "streamline_user"
     dataSource.password: "streamline_password"
 
+# Truststore information which is needed for importing certificated Ambari cluster.
+# which default truststore doesn't cover the CA or self-certified.
+# When the options are not provided, JDK default truststore will be used.
+# It only supports single truststores, so admin needs to maintain single truststore and import certificates to that.
+#trustStorePath: ""
+#trustStorePassword: ""
+
 enableCors: true
 corsUrlPatterns:
   - "/api/v1/dashboards/*"

--- a/conf/streamline.phoenix.yaml
+++ b/conf/streamline.phoenix.yaml
@@ -35,6 +35,12 @@ storageProviderConfiguration:
      jdbcDriverClass: "org.apache.phoenix.jdbc.PhoenixDriver"
      jdbcUrl: "jdbc:phoenix:localhost:2181:/hbase-unsecure"
 
+# Truststore information which is needed for importing certificated Ambari cluster.
+# which default truststore doesn't cover the CA or self-certified.
+# When the options are not provided, JDK default truststore will be used.
+# It only supports single truststores, so admin needs to maintain single truststore and import certificates to that.
+#trustStorePath: ""
+#trustStorePassword: ""
 
 enableCors: true
 corsUrlPatterns:

--- a/conf/streamline.postgre.yaml
+++ b/conf/streamline.postgre.yaml
@@ -45,6 +45,13 @@ storageProviderConfiguration:
      dataSource.user: "streamline_user"
      dataSource.password: "streamline_password"
 
+# Truststore information which is needed for importing certificated Ambari cluster.
+# which default truststore doesn't cover the CA or self-certified.
+# When the options are not provided, JDK default truststore will be used.
+# It only supports single truststores, so admin needs to maintain single truststore and import certificates to that.
+#trustStorePath: ""
+#trustStorePassword: ""
+
 enableCors: true
 corsUrlPatterns:
   - "/api/v1/dashboards/*"

--- a/conf/streamline.yaml
+++ b/conf/streamline.yaml
@@ -44,6 +44,12 @@ storageProviderConfiguration:
     dataSource.user: "streamline_user"
     dataSource.password: "streamline_password"
 
+# Truststore information which is needed for importing certificated Ambari cluster.
+# which default truststore doesn't cover the CA or self-certified.
+# When the options are not provided, JDK default truststore will be used.
+# It only supports single truststores, so admin needs to maintain single truststore and import certificates to that.
+#trustStorePath: ""
+#trustStorePassword: ""
 
 enableCors: true
 corsUrlPatterns:

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/ClusterCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/ClusterCatalogResource.java
@@ -190,8 +190,7 @@ public class ClusterCatalogResource {
             }
         } catch (Throwable e) {
             // other exceptions
-            response = Collections.singletonMap(RESPONSE_MESSAGE,
-                    RESPONSE_MESSAGE_BAD_INPUT_NOT_VALID_AMBARI_CLUSTER_REST_API_URL);
+            response = Collections.singletonMap(RESPONSE_MESSAGE, e.getMessage());
         }
 
         return WSUtils.respondEntity(response, OK);

--- a/webservice/src/main/java/com/hortonworks/streamline/webservice/StreamlineApplication.java
+++ b/webservice/src/main/java/com/hortonworks/streamline/webservice/StreamlineApplication.java
@@ -40,6 +40,7 @@ import io.dropwizard.server.AbstractServerFactory;
 import io.dropwizard.server.DefaultServerFactory;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.slf4j.Logger;
@@ -87,6 +88,17 @@ public class StreamlineApplication extends Application<StreamlineConfiguration> 
             List<String> urlPatterns = configuration.getCorsUrlPatterns();
             if (urlPatterns != null && !urlPatterns.isEmpty()) {
                 enableCORS(environment, urlPatterns);
+            }
+        }
+
+        setupCustomTrustStore(configuration);
+    }
+
+    private void setupCustomTrustStore(StreamlineConfiguration configuration) {
+        if (StringUtils.isNotEmpty(configuration.getTrustStorePath())) {
+            System.setProperty("javax.net.ssl.trustStore", configuration.getTrustStorePath());
+            if (StringUtils.isNotEmpty(configuration.getTrustStorePassword())) {
+                System.setProperty("javax.net.ssl.trustStorePassword", configuration.getTrustStorePassword());
             }
         }
     }

--- a/webservice/src/main/java/com/hortonworks/streamline/webservice/StreamlineConfiguration.java
+++ b/webservice/src/main/java/com/hortonworks/streamline/webservice/StreamlineConfiguration.java
@@ -57,7 +57,11 @@ public class StreamlineConfiguration extends Configuration {
     @JsonProperty
     private List<String> corsUrlPatterns;
 
+    @JsonProperty
+    private String trustStorePath;
 
+    @JsonProperty
+    private String trustStorePassword;
 
     public String getCatalogRootUrl () {
         return catalogRootUrl;
@@ -97,6 +101,22 @@ public class StreamlineConfiguration extends Configuration {
 
     public void setCorsUrlPatterns(List<String> corsUrlPatterns) {
         this.corsUrlPatterns = corsUrlPatterns;
+    }
+
+    public String getTrustStorePath() {
+        return trustStorePath;
+    }
+
+    public void setTrustStorePath(String trustStorePath) {
+        this.trustStorePath = trustStorePath;
+    }
+
+    public String getTrustStorePassword() {
+        return trustStorePassword;
+    }
+
+    public void setTrustStorePassword(String trustStorePassword) {
+        this.trustStorePassword = trustStorePassword;
     }
 
     public DashboardConfiguration getDashboardConfiguration () { return dashboardConfiguration; }


### PR DESCRIPTION
…L or Kerberos

* Add options to use custom Truststore
  * This enables importing self-certificated SSL Ambari cluster
  * Also CAs which default JDK truststore doesn't cover

REST APIs on Kerberized Ambari cluster still use basic authentication (user/pass) so it doesn't require change. 

This only covers using custom truststore. Given that this option is only needed for specific case and there're lots of documents describing how to create and maintain custom truststore, I'm not sure which thing is needed for making it easier to maintain single truststore. (Also left comment on origin issue.)

Please let me know if you have ideas for that.