### PR TITLE
STREAMLINE-754 Need for another API to get test run results via polling

### DIFF
--- a/bootstrap/sql/mysql/create_tables.sql
+++ b/bootstrap/sql/mysql/create_tables.sql
@@ -438,7 +438,8 @@ CREATE TABLE IF NOT EXISTS topology_test_run_case_source (
   timestamp BIGINT,
   PRIMARY KEY (id),
   FOREIGN KEY (testCaseId) REFERENCES topology_test_run_case(id),
-  FOREIGN KEY (sourceId) REFERENCES topology_source(id)
+  FOREIGN KEY (sourceId) REFERENCES topology_source(id),
+  UNIQUE KEY `testcase_source` (testCaseId, sourceId)
 );
 
 CREATE TABLE IF NOT EXISTS topology_test_run_case_sink (
@@ -449,7 +450,8 @@ CREATE TABLE IF NOT EXISTS topology_test_run_case_sink (
   timestamp BIGINT,
   PRIMARY KEY (id),
   FOREIGN KEY (testCaseId) REFERENCES topology_test_run_case(id),
-  FOREIGN KEY (sinkId) REFERENCES topology_sink(id)
+  FOREIGN KEY (sinkId) REFERENCES topology_sink(id),
+  UNIQUE KEY `testcase_sink` (testCaseId, sinkId)
 );
 
 CREATE TABLE IF NOT EXISTS topology_test_run_histories (

--- a/bootstrap/sql/mysql/create_tables.sql
+++ b/bootstrap/sql/mysql/create_tables.sql
@@ -365,7 +365,7 @@ CREATE TABLE IF NOT EXISTS service_bundle (
   name VARCHAR(256) NOT NULL,
   serviceUISpecification TEXT NOT NULL,
   registerClass TEXT,
-  timestamp  BIGINT,
+  timestamp BIGINT,
   PRIMARY KEY (id)
 );
 
@@ -419,4 +419,53 @@ CREATE TABLE IF NOT EXISTS topology_editor_toolbar (
   timestamp BIGINT,
   PRIMARY KEY (userId),
   FOREIGN KEY (userId) REFERENCES user_entry(id)
+);
+
+CREATE TABLE IF NOT EXISTS topology_test_run_case (
+  id BIGINT AUTO_INCREMENT NOT NULL,
+  name VARCHAR(256) NOT NULL,
+  topologyId BIGINT NOT NULL,
+  timestamp BIGINT,
+  PRIMARY KEY (id),
+  FOREIGN KEY (topologyId) REFERENCES topology(id)
+);
+
+CREATE TABLE IF NOT EXISTS topology_test_run_case_source (
+  id BIGINT AUTO_INCREMENT NOT NULL,
+  testCaseId BIGINT NOT NULL,
+  sourceId BIGINT NOT NULL,
+  records TEXT NOT NULL,
+  timestamp BIGINT,
+  PRIMARY KEY (id),
+  FOREIGN KEY (testCaseId) REFERENCES topology_test_run_case(id),
+  FOREIGN KEY (sourceId) REFERENCES topology_source(id)
+);
+
+CREATE TABLE IF NOT EXISTS topology_test_run_case_sink (
+  id BIGINT AUTO_INCREMENT NOT NULL,
+  testCaseId BIGINT NOT NULL,
+  sinkId BIGINT NOT NULL,
+  records TEXT NOT NULL,
+  timestamp BIGINT,
+  PRIMARY KEY (id),
+  FOREIGN KEY (testCaseId) REFERENCES topology_test_run_case(id),
+  FOREIGN KEY (sinkId) REFERENCES topology_sink(id)
+);
+
+CREATE TABLE IF NOT EXISTS topology_test_run_histories (
+  id BIGINT AUTO_INCREMENT NOT NULL,
+  topologyId BIGINT NOT NULL,
+  versionId BIGINT,
+  testRecords TEXT NOT NULL,
+  finished CHAR(5) NOT NULL,
+  success CHAR(5) NOT NULL,
+  expectedOutputRecords TEXT,
+  actualOutputRecords TEXT,
+  matched CHAR(5),
+  startTime BIGINT,
+  finishTime BIGINT,
+  timestamp BIGINT,
+  PRIMARY KEY (id),
+  FOREIGN KEY (topologyId) REFERENCES topology(id),
+  FOREIGN KEY (versionId) REFERENCES topology_version(id)
 );

--- a/bootstrap/sql/mysql/drop_tables.sql
+++ b/bootstrap/sql/mysql/drop_tables.sql
@@ -5,6 +5,8 @@ DROP TABLE IF EXISTS tag;
 DROP TABLE IF EXISTS tag_storable_mapping;
 DROP TABLE IF EXISTS topology_component_bundle;
 DROP TABLE IF EXISTS notifier;
+DROP TABLE IF EXISTS topology_test_run_histories;
+DROP TABLE IF EXISTS topology_test_run_case;
 DROP TABLE IF EXISTS topology_component;
 DROP TABLE IF EXISTS topology_source_stream_mapping;
 DROP TABLE IF EXISTS topology_source;
@@ -39,5 +41,9 @@ DROP TABLE IF EXISTS role_hierarchy;
 DROP TABLE IF EXISTS user_role;
 DROP TABLE IF EXISTS role;
 DROP TABLE IF EXISTS user_entry;
+DROP TABLE IF EXISTS topology_test_run_case;
+DROP TABLE IF EXISTS topology_test_run_case_source;
+DROP TABLE IF EXISTS topology_test_run_case_sink;
+DROP TABLE IF EXISTS topology_test_run_histories;
 
 SET FOREIGN_KEY_CHECKS=1;

--- a/bootstrap/sql/phoenix/create_tables.sql
+++ b/bootstrap/sql/phoenix/create_tables.sql
@@ -37,7 +37,11 @@ CREATE TABLE IF NOT EXISTS role ("id" BIGINT NOT NULL, "name" VARCHAR(256) NOT N
 CREATE TABLE IF NOT EXISTS role_hierarchy ("parentId" BIGINT NOT NULL, "childId" BIGINT NOT NULL, CONSTRAINT pk PRIMARY KEY ("parentId", "childId"))
 CREATE TABLE IF NOT EXISTS user_entry ("id" BIGINT NOT NULL, "name" VARCHAR(256) NOT NULL, "email" VARCHAR(256) NOT NULL, "timestamp" BIGINT, CONSTRAINT pk PRIMARY KEY ("id"))
 CREATE TABLE IF NOT EXISTS user_role ("userId" BIGINT NOT NULL, "roleId" BIGINT NOT NULL, CONSTRAINT pk PRIMARY KEY ("userId", "roleId"))
-CREATE TABLE IF NOT EXISTS sequence_table ("id" VARCHAR, "file" BIGINT, "topology_version" BIGINT, "topology" BIGINT, "topology_component_bundle" BIGINT,"topology_component" BIGINT, "tag" BIGINT,  "topology_stream" BIGINT, "notifier" BIGINT, "topology_source" BIGINT, "topology_sink" BIGINT, "topology_processor" BIGINT, "topology_edge" BIGINT,"topology_rule" BIGINT, "topology_window" BIGINT, "udf" BIGINT, "cluster" BIGINT, "service" BIGINT, "service_configuration" BIGINT,"topology_branchrule" BIGINT, "component" BIGINT, "dashboard" BIGINT, "widget" BIGINT, "datasource" BIGINT, "namespace" BIGINT, "ml_model" BIGINT, "topology_state" BIGINT, "service_bundle" BIGINT, "acl_entry" BIGINT, "role" BIGINT, "role_hierarchy" BIGINT, "user_entry" BIGINT, "user_role" BIGINT, "topology_editor_toolbar" BIGINT, CONSTRAINT pk PRIMARY KEY ("id"))
+CREATE TABLE IF NOT EXISTS topology_test_run_case ("id" BIGINT NOT NULL, "name" VARCHAR(256) NOT NULL, "topologyId" BIGINT NOT NULL, "timestamp" BIGINT, CONSTRAINT pk PRIMARY KEY ("id"))
+CREATE TABLE IF NOT EXISTS topology_test_run_case_source ("id" BIGINT NOT NULL, "testCaseId" BIGINT NOT NULL, "sourceId" BIGINT NOT NULL, "records" VARCHAR NOT NULL, "timestamp" BIGINT, CONSTRAINT pk PRIMARY KEY ("id"))
+CREATE TABLE IF NOT EXISTS topology_test_run_case_sink ("id" BIGINT NOT NULL, "testCaseId" BIGINT NOT NULL, "sinkId" BIGINT NOT NULL, "records" VARCHAR NOT NULL, "timestamp" BIGINT, CONSTRAINT pk PRIMARY KEY ("id"))
+CREATE TABLE IF NOT EXISTS topology_test_run_histories ("id" BIGINT NOT NULL, "topologyId" BIGINT NOT NULL, "versionId" BIGINT, "testRecords" TEXT NOT NULL, "finished" CHAR(5) NOT NULL, "success" CHAR(5) NOT NULL, "expectedOutputRecords" VARCHAR, "actualOutputRecords" VARCHAR, "matched" CHAR(5), "startTime" BIGINT, "finishTime" BIGINT, "timestamp" BIGINT, CONSTRAINT pk PRIMARY KEY ("id"))
+CREATE TABLE IF NOT EXISTS sequence_table ("id" VARCHAR, "file" BIGINT, "topology_version" BIGINT, "topology" BIGINT, "topology_component_bundle" BIGINT,"topology_component" BIGINT, "tag" BIGINT,  "topology_stream" BIGINT, "notifier" BIGINT, "topology_source" BIGINT, "topology_sink" BIGINT, "topology_processor" BIGINT, "topology_edge" BIGINT,"topology_rule" BIGINT, "topology_window" BIGINT, "udf" BIGINT, "cluster" BIGINT, "service" BIGINT, "service_configuration" BIGINT,"topology_branchrule" BIGINT, "component" BIGINT, "dashboard" BIGINT, "widget" BIGINT, "datasource" BIGINT, "namespace" BIGINT, "ml_model" BIGINT, "topology_state" BIGINT, "service_bundle" BIGINT, "acl_entry" BIGINT, "role" BIGINT, "role_hierarchy" BIGINT, "user_entry" BIGINT, "user_role" BIGINT, "topology_editor_toolbar" BIGINT, "topology_test_run_case" BIGINT, "topology_test_run_case_source" BIGINT, "topology_test_run_case_sink" BIGINT, "topology_test_run_histories" BIGINT, CONSTRAINT pk PRIMARY KEY ("id"))
 
 CREATE SEQUENCE IF NOT EXISTS topology_version_sequence
 CREATE SEQUENCE IF NOT EXISTS topology_sequence
@@ -72,3 +76,7 @@ CREATE SEQUENCE IF NOT EXISTS role_hierarchy_sequence
 CREATE SEQUENCE IF NOT EXISTS user_entry_sequence
 CREATE SEQUENCE IF NOT EXISTS user_role_sequence
 CREATE SEQUENCE IF NOT EXISTS topology_editor_toolbar_sequence
+CREATE SEQUENCE IF NOT EXISTS topology_test_run_case_sequence
+CREATE SEQUENCE IF NOT EXISTS topology_test_run_case_source_sequence
+CREATE SEQUENCE IF NOT EXISTS topology_test_run_case_sink_sequence
+CREATE SEQUENCE IF NOT EXISTS topology_test_run_histories_sequence

--- a/bootstrap/sql/phoenix/drop_tables.sql
+++ b/bootstrap/sql/phoenix/drop_tables.sql
@@ -38,6 +38,10 @@ DROP TABLE IF EXISTS role_hierarchy
 DROP TABLE IF EXISTS user_entry
 DROP TABLE IF EXISTS user_role
 DROP TABLE IF EXISTS topology_editor_toolbar
+DROP TABLE IF EXISTS topology_test_run_case
+DROP TABLE IF EXISTS topology_test_run_case_source
+DROP TABLE IF EXISTS topology_test_run_case_sink
+DROP TABLE IF EXISTS topology_test_run_histories
 DROP SEQUENCE IF EXISTS topology_version_sequence
 DROP SEQUENCE IF EXISTS topology_sequence
 DROP SEQUENCE IF EXISTS topology_component_bundle_sequence
@@ -71,3 +75,7 @@ DROP SEQUENCE IF EXISTS role_hierarchy_sequence
 DROP SEQUENCE IF EXISTS user_entry_sequence
 DROP SEQUENCE IF EXISTS user_role_sequence
 DROP SEQUENCE IF EXISTS topology_editor_toolbar_sequence
+DROP SEQUENCE IF EXISTS topology_test_run_case_sequence
+DROP SEQUENCE IF EXISTS topology_test_run_case_source_sequence
+DROP SEQUENCE IF EXISTS topology_test_run_case_sink_sequence
+DROP SEQUENCE IF EXISTS topology_test_run_histories_sequence

--- a/bootstrap/sql/postgresql/create_tables.sql
+++ b/bootstrap/sql/postgresql/create_tables.sql
@@ -416,7 +416,8 @@ CREATE TABLE IF NOT EXISTS topology_test_run_case_source (
   "timestamp" BIGINT,
   PRIMARY KEY (id),
   FOREIGN KEY (testCaseId) REFERENCES topology_test_run_case(id),
-  FOREIGN KEY (sourceId) REFERENCES topology_source(id)
+  FOREIGN KEY (sourceId) REFERENCES topology_source(id),
+  UNIQUE KEY testcase_source (testCaseId, sourceId)
 );
 
 CREATE TABLE IF NOT EXISTS topology_test_run_case_sink (
@@ -427,7 +428,8 @@ CREATE TABLE IF NOT EXISTS topology_test_run_case_sink (
   timestamp BIGINT,
   PRIMARY KEY (id),
   FOREIGN KEY (testCaseId) REFERENCES topology_test_run_case(id),
-  FOREIGN KEY (sinkId) REFERENCES topology_sink(id)
+  FOREIGN KEY (sinkId) REFERENCES topology_sink(id),
+  UNIQUE KEY testcase_sink (testCaseId, sinkId)
 );
 
 CREATE TABLE IF NOT EXISTS topology_test_run_histories (

--- a/bootstrap/sql/postgresql/create_tables.sql
+++ b/bootstrap/sql/postgresql/create_tables.sql
@@ -398,3 +398,52 @@ CREATE TABLE IF NOT EXISTS topology_editor_toolbar (
   "timestamp" BIGINT,
   PRIMARY KEY ("userId")
 );
+
+CREATE TABLE IF NOT EXISTS topology_test_run_case (
+  "id" SERIAL NOT NULL,
+  "name" VARCHAR(256) NOT NULL,
+  "topologyId" BIGINT NOT NULL,
+  "timestamp" BIGINT,
+  PRIMARY KEY (id),
+  FOREIGN KEY (topologyId) REFERENCES topology(id)
+);
+
+CREATE TABLE IF NOT EXISTS topology_test_run_case_source (
+  "id" SERIAL NOT NULL,
+  "testCaseId" BIGINT NOT NULL,
+  "sourceId" BIGINT NOT NULL,
+  "records" TEXT NOT NULL,
+  "timestamp" BIGINT,
+  PRIMARY KEY (id),
+  FOREIGN KEY (testCaseId) REFERENCES topology_test_run_case(id),
+  FOREIGN KEY (sourceId) REFERENCES topology_source(id)
+);
+
+CREATE TABLE IF NOT EXISTS topology_test_run_case_sink (
+  id SERIAL NOT NULL,
+  testCaseId BIGINT NOT NULL,
+  sinkId BIGINT NOT NULL,
+  records TEXT NOT NULL,
+  timestamp BIGINT,
+  PRIMARY KEY (id),
+  FOREIGN KEY (testCaseId) REFERENCES topology_test_run_case(id),
+  FOREIGN KEY (sinkId) REFERENCES topology_sink(id)
+);
+
+CREATE TABLE IF NOT EXISTS topology_test_run_histories (
+  "id" SERIAL NOT NULL,
+  "topologyId" BIGINT NOT NULL,
+  "versionId" BIGINT,
+  "testRecords" TEXT NOT NULL,
+  "finished" CHAR(5) NOT NULL,
+  "success" CHAR(5) NOT NULL,
+  "expectedOutputRecords" TEXT,
+  "actualOutputRecords" TEXT,
+  "matched" CHAR(5),
+  "startTime" BIGINT,
+  "finishTime" BIGINT,
+  "timestamp" BIGINT,
+  PRIMARY KEY (id),
+  FOREIGN KEY (topologyId) REFERENCES topology(id),
+  FOREIGN KEY (versionId) REFERENCES topology_version(id)
+);

--- a/bootstrap/sql/postgresql/drop_tables.sql
+++ b/bootstrap/sql/postgresql/drop_tables.sql
@@ -37,3 +37,6 @@ DROP TABLE IF EXISTS role_hierarchy CASCADE;
 DROP TABLE IF EXISTS user_role CASCADE;
 DROP TABLE IF EXISTS role CASCADE;
 DROP TABLE IF EXISTS user_entry CASCADE;
+DROP TABLE IF EXISTS topology_test_run_case CASCADE;
+DROP TABLE IF EXISTS topology_test_run_case_source CASCADE;
+DROP TABLE IF EXISTS topology_test_run_histories CASCADE;

--- a/conf/streamline-dev.yaml
+++ b/conf/streamline-dev.yaml
@@ -11,6 +11,8 @@ modules:
       #change the below to the path on your local machine
       streamlineStormJar: /tmp/streamline-runtime-storm-0.1.0-SNAPSHOT.jar
       stormHomeDir: /usr/local/Cellar/storm/0.10.0/
+      # directory to store the results of topology test run
+      topologyTestRunResultDir: /tmp
       # schema registry configuration
       schemaRegistryUrl: "http://localhost:9090/api/v1"
       mavenRepoUrl: "hwx-public^http://repo.hortonworks.com/content/groups/public/,hwx-private^http://nexus-private.hortonworks.com/nexus/content/groups/public/"

--- a/conf/streamline.mysql.yaml
+++ b/conf/streamline.mysql.yaml
@@ -9,6 +9,8 @@ modules:
     className: com.hortonworks.streamline.streams.service.StreamsModule
     config:
       stormHomeDir: /usr/local/Cellar/storm/0.10.0/
+      # directory to store the results of topology test run
+      topologyTestRunResultDir: /tmp
       # schema registry configuration
       schemaRegistryUrl: "http://localhost:9090/api/v1"
       #Custom processor upload configuration

--- a/conf/streamline.phoenix.yaml
+++ b/conf/streamline.phoenix.yaml
@@ -9,6 +9,8 @@ modules:
     className: com.hortonworks.streamline.streams.service.StreamsModule
     config:
       stormHomeDir: /usr/local/Cellar/storm/0.10.0/
+      # directory to store the results of topology test run
+      topologyTestRunResultDir: /tmp
       # schema registry configuration
       schemaRegistryUrl: "http://localhost:9090/api/v1"
       mavenRepoUrl: "hwx-public^http://repo.hortonworks.com/content/groups/public/,hwx-private^http://nexus-private.hortonworks.com/nexus/content/groups/public/"

--- a/conf/streamline.yaml
+++ b/conf/streamline.yaml
@@ -9,6 +9,8 @@ modules:
     className: com.hortonworks.streamline.streams.service.StreamsModule
     config:
       stormHomeDir: /usr/local/Cellar/storm/0.10.0/
+      # directory to store the results of topology test run
+      topologyTestRunResultDir: /tmp
       # schema registry configuration
       schemaRegistryUrl: "http://localhost:9090/api/v1"
       #Custom processor upload configuration

--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/TopologyActions.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/TopologyActions.java
@@ -16,8 +16,11 @@
 package com.hortonworks.streamline.streams.actions;
 
 import com.hortonworks.streamline.streams.layout.component.TopologyLayout;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSink;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSource;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -31,6 +34,13 @@ public interface TopologyActions {
     // Deploy the artifact generated using the underlying streaming
     // engine
     void deploy(TopologyLayout topology, String mavenArtifacts, TopologyActionContext ctx) throws Exception;
+
+    // Compose and run parameter topology as test mode using the underlying streaming engine.
+    // The parameter 'topology' should contain its own topology DAG.
+    // Please refer the javadoc of TestRunSource and also TestRunSink to see which information this method requires.
+    void testRun(TopologyLayout topology, String mavenArtifacts,
+                 Map<String, TestRunSource> testRunSourcesForEachSource,
+                 Map<String, TestRunSink> testRunSinksForEachSink) throws Exception;
 
     //Kill the artifact that was deployed using deploy
     void kill (TopologyLayout topology) throws Exception;

--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyActionsService.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyActionsService.java
@@ -104,7 +104,7 @@ public class TopologyActionsService implements ContainingNamespaceAwareContainer
 
         this.topologyActionsContainer = new TopologyActionsContainer(environmentService, conf);
         this.stateFactory = TopologyStateFactory.getInstance();
-        this.topologyTestRunner = new TopologyTestRunner(catalogService, topologyTestRunResultDir);
+        this.topologyTestRunner = new TopologyTestRunner(catalogService, this, topologyTestRunResultDir);
     }
 
     public Void deployTopology(Topology topology) throws Exception {
@@ -123,10 +123,7 @@ public class TopologyActionsService implements ContainingNamespaceAwareContainer
         ensureValid(dag);
         TopologyActions topologyActions = getTopologyActionsInstance(topology);
         LOG.debug("Running topology {} in test mode", topology);
-        setUpClusterArtifacts(topology, topologyActions);
-        String mavenArtifacts = setUpExtraJars(topology, topologyActions);
-
-        return topologyTestRunner.runTest(topologyActions, topology, mavenArtifacts, testRunInputJson);
+        return topologyTestRunner.runTest(topologyActions, topology, testRunInputJson);
     }
 
     public void killTopology(Topology topology) throws Exception {

--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunner.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunner.java
@@ -1,0 +1,263 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.actions.topology.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hortonworks.streamline.streams.actions.TopologyActions;
+import com.hortonworks.streamline.streams.catalog.CatalogToLayoutConverter;
+import com.hortonworks.streamline.streams.catalog.Topology;
+import com.hortonworks.streamline.streams.catalog.TopologyTestRunCase;
+import com.hortonworks.streamline.streams.catalog.TopologyTestRunCaseSink;
+import com.hortonworks.streamline.streams.catalog.TopologyTestRunCaseSource;
+import com.hortonworks.streamline.streams.catalog.TopologyTestRunHistory;
+import com.hortonworks.streamline.streams.catalog.service.StreamCatalogService;
+import com.hortonworks.streamline.streams.layout.component.StreamlineSink;
+import com.hortonworks.streamline.streams.layout.component.StreamlineSource;
+import com.hortonworks.streamline.streams.layout.component.TopologyLayout;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSink;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSource;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * The class takes care of preparation of topology test run, and request test run to the TopologyActions instance.
+ */
+public class TopologyTestRunner {
+    private static final Logger LOG = LoggerFactory.getLogger(TopologyTestRunner.class);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final StreamCatalogService catalogService;
+    private final String topologyTestRunResultDir;
+
+    public TopologyTestRunner(StreamCatalogService catalogService, String topologyTestRunResultDir) {
+        this.catalogService = catalogService;
+        this.topologyTestRunResultDir = topologyTestRunResultDir;
+    }
+
+    public TopologyTestRunHistory runTest(TopologyActions topologyActions, Topology topology, String mavenArtifacts,
+                                          String testRunInputJson) throws IOException {
+        Map<String, Object> testRunInputMap = objectMapper.readValue(testRunInputJson, Map.class);
+
+        if (!testRunInputMap.containsKey("testCaseId")) {
+            throw new IllegalArgumentException("'testCaseId' needs to be presented.");
+        }
+
+        Long testCaseId = Long.valueOf(testRunInputMap.get("testCaseId").toString());
+        TopologyTestRunCase testCase = loadTestRunCase(topology.getId(), testCaseId);
+
+        if (testCase == null) {
+            throw new IllegalArgumentException("test case doesn't exist");
+        }
+
+        List<StreamlineSource> sources = topology.getTopologyDag().getOutputComponents().stream()
+                .filter(c -> c instanceof StreamlineSource)
+                .map(c -> (StreamlineSource) c)
+                .collect(toList());
+
+        List<StreamlineSink> sinks = topology.getTopologyDag().getInputComponents().stream()
+                .filter(c -> c instanceof StreamlineSink)
+                .map(c -> (StreamlineSink) c)
+                .collect(toList());
+
+        // load test case sources for all sources
+        List<TopologyTestRunCaseSource> testRunCaseSources = sources.stream()
+                .map(s -> catalogService.getTopologyTestRunCaseSourceBySourceId(testCaseId, Long.valueOf(s.getId())))
+                .collect(toList());
+
+        if (testRunCaseSources.stream().anyMatch(Objects::isNull)) {
+            throw new IllegalArgumentException("Not every source register test records.");
+        }
+
+        // load test case sources for all sinks
+        List<TopologyTestRunCaseSink> testRunCaseSinks = sinks.stream()
+                .map(s -> catalogService.getTopologyTestRunCaseSinkBySinkId(testCaseId, Long.valueOf(s.getId())))
+                .collect(toList());
+
+        Map<Long, Map<String, List<Map<String, Object>>>> testRecordsForEachSources = readTestRecordsFromTestCaseSources(testRunCaseSources);
+        Map<String, List<Map<String, Object>>> expectedOutputRecordsMap = readExpectedRecordsFromTestCaseSinks(sinks, testRunCaseSinks);
+
+        Map<String, TestRunSource> testRunSourceMap = sources.stream()
+                .collect(toMap(s -> s.getName(),
+                        s -> new TestRunSource(s.getOutputStreams(), testRecordsForEachSources.get(Long.valueOf(s.getId())))));
+
+        Map<String, TestRunSink> testRunSinkMap = sinks.stream()
+                .collect(toMap(s -> s.getName(), s -> {
+                    String uuid = UUID.randomUUID().toString();
+                    return new TestRunSink(getTopologyTestRunResult(uuid));
+                }));
+
+        TopologyTestRunHistory history = initializeTopologyTestRunHistory(topology, testRecordsForEachSources, expectedOutputRecordsMap);
+        catalogService.addTopologyTestRunHistory(history);
+
+        TopologyLayout topologyLayout = CatalogToLayoutConverter.getTopologyLayout(topology, topology.getTopologyDag());
+        try {
+            topologyActions.testRun(topologyLayout, mavenArtifacts, testRunSourceMap, testRunSinkMap);
+
+            history.finishSuccessfully();
+
+            Map<String, List<Map<String, Object>>> actualOutputRecordsMap = parseTestRunOutputFiles(testRunSinkMap);
+            history.setActualOutputRecords(objectMapper.writeValueAsString(actualOutputRecordsMap));
+
+            if (expectedOutputRecordsMap != null) {
+                boolean matched = equalsOutputRecords(expectedOutputRecordsMap, actualOutputRecordsMap);
+                history.setMatched(matched);
+            }
+        } catch (Throwable e) {
+            LOG.warn("Exception thrown while running Topology as test mode. Marking as 'failed'. topology id: {}",
+                    topology.getId(), e);
+            history.finishWithFailures();
+        }
+
+        catalogService.addOrUpdateTopologyTestRunHistory(history.getId(), history);
+        return history;
+    }
+
+    private Map<Long, Map<String, List<Map<String, Object>>>> readTestRecordsFromTestCaseSources(List<TopologyTestRunCaseSource> testRunCaseSources) {
+        return testRunCaseSources.stream()
+                    .collect(toMap(s -> s.getId(), s -> {
+                        try {
+                            return objectMapper.readValue(s.getRecords(),
+                                    new TypeReference<Map<String, List<Map<String, Object>>>>() {
+                                    });
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }));
+    }
+
+    private Map<String, List<Map<String, Object>>> readExpectedRecordsFromTestCaseSinks(List<StreamlineSink> sinks,
+                                                                                        List<TopologyTestRunCaseSink> testRunCaseSinks) {
+        Map<String, String> sinkIdToName = sinks.stream()
+                .collect(toMap(s -> s.getId(), s -> s.getName()));
+        return testRunCaseSinks.stream()
+                .filter(Objects::nonNull)
+                .collect(toMap(s -> sinkIdToName.get(String.valueOf(s.getSinkId())), s -> {
+                    try {
+                        String records = s.getRecords();
+                        if (StringUtils.isEmpty(records)) {
+                            return new ArrayList<Map<String, Object>>();
+                        } else {
+                            return objectMapper.readValue(records,
+                                    new TypeReference<List<Map<String, Object>>>() {
+                                    });
+                        }
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }));
+    }
+
+    private TopologyTestRunCase loadTestRunCase(Long topologyId, Long testCaseId) {
+        TopologyTestRunCase testCase = catalogService.getTopologyTestRunCase(topologyId, testCaseId);
+        if (testCase == null) {
+            throw new IllegalArgumentException("Given topology test case doesn't exist - topology id: " +
+                    topologyId + " , id: " + testCaseId);
+        }
+        return testCase;
+    }
+
+    private TopologyTestRunHistory initializeTopologyTestRunHistory(Topology topology,
+                                                                    Map<Long, Map<String, List<Map<String, Object>>>> collectedTestRecords,
+                                                                    Map<String, List<Map<String, Object>>> expectedOutputRecords)
+            throws JsonProcessingException {
+        TopologyTestRunHistory history = new TopologyTestRunHistory();
+        history.setTopologyId(topology.getId());
+        history.setTestRecords(objectMapper.writeValueAsString(collectedTestRecords));
+
+        if (expectedOutputRecords != null) {
+            String expectedOutputRecordsJson = objectMapper.writeValueAsString(expectedOutputRecords);
+            history.setExpectedOutputRecords(expectedOutputRecordsJson);
+        }
+
+        history.setFinished(false);
+        history.setStartTime(System.currentTimeMillis());
+        return history;
+    }
+
+    private String getTopologyTestRunResult(String uuid) {
+        return topologyTestRunResultDir + File.separator + uuid;
+    }
+
+    private Map<String, List<Map<String, Object>>> parseTestRunOutputFiles(Map<String, TestRunSink> testRunSinkMap) {
+        return testRunSinkMap.entrySet().stream()
+                .collect(toMap(s -> s.getKey(), s -> {
+                    String filePath = s.getValue().getOutputFilePath();
+
+                    try (BufferedReader br = new BufferedReader(new FileReader(filePath))) {
+                        return br.lines().map(line -> {
+                            try {
+                                return (Map<String, Object>) objectMapper.readValue(line,
+                                        new TypeReference<Map<String, Object>>() {
+                                        });
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        }).collect(toList());
+                    } catch (FileNotFoundException e) {
+                        throw new RuntimeException("Output file not found - file path: " + filePath, e);
+                    } catch (IOException e) {
+                        throw new RuntimeException("Fail to read output file - file path: " + filePath, e);
+                    }
+                }));
+    }
+
+    private boolean equalsOutputRecords(Map<String, List<Map<String, Object>>> expectedOutputRecordsMap,
+                                        Map<String, List<Map<String, Object>>> actualOutputRecordsMap) {
+        if (expectedOutputRecordsMap.size() != actualOutputRecordsMap.size()) {
+            return false;
+        }
+
+        for (Map.Entry<String, List<Map<String, Object>>> expectedEntry : expectedOutputRecordsMap.entrySet()) {
+            String sinkName = expectedEntry.getKey();
+
+            if (!actualOutputRecordsMap.containsKey(sinkName)) {
+                return false;
+            }
+
+            List<Map<String, Object>> expectedRecords = expectedEntry.getValue();
+            List<Map<String, Object>> actualRecords = actualOutputRecordsMap.get(sinkName);
+
+            // both should be not null
+            if (expectedRecords == null || actualRecords == null) {
+                return false;
+            } else if (expectedRecords.size() != actualRecords.size()) {
+                return false;
+            } else if (!expectedRecords.containsAll(actualRecords)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+}

--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/TopologyTestRunCase.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/TopologyTestRunCase.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.catalog;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.hortonworks.registries.common.Schema;
+import com.hortonworks.streamline.storage.PrimaryKey;
+import com.hortonworks.streamline.storage.annotation.StorableEntity;
+import com.hortonworks.streamline.storage.catalog.AbstractStorable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class stores test cases of topology test run.
+ * Note that actual test records are stored to TopologyTestRunCaseSource for each source.
+ */
+@StorableEntity
+public class TopologyTestRunCase extends AbstractStorable {
+    public static final String NAMESPACE = "topology_test_run_case";
+
+    private Long id;
+    private String name;
+    private Long topologyId;
+    private Long timestamp;
+
+    @JsonIgnore
+    @Override
+    public String getNameSpace() {
+        return NAMESPACE;
+    }
+
+    @JsonIgnore
+    @Override
+    public PrimaryKey getPrimaryKey() {
+        Map<Schema.Field, Object> fieldToObjectMap = new HashMap<Schema.Field, Object>();
+        fieldToObjectMap.put(new Schema.Field("id", Schema.Type.LONG), this.id);
+        return new PrimaryKey(fieldToObjectMap);
+    }
+
+    /**
+     * The primary key
+     */
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * The name of test run case
+     */
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * The foreign key reference to the topology id.
+     */
+    public Long getTopologyId() {
+        return topologyId;
+    }
+
+    public void setTopologyId(Long topologyId) {
+        this.topologyId = topologyId;
+    }
+
+    public Long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TopologyTestRunCase)) return false;
+
+        TopologyTestRunCase that = (TopologyTestRunCase) o;
+
+        if (getId() != null ? !getId().equals(that.getId()) : that.getId() != null) return false;
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+        if (getTopologyId() != null ? !getTopologyId().equals(that.getTopologyId()) : that.getTopologyId() != null)
+            return false;
+        return getTimestamp() != null ? getTimestamp().equals(that.getTimestamp()) : that.getTimestamp() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getId() != null ? getId().hashCode() : 0;
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        result = 31 * result + (getTopologyId() != null ? getTopologyId().hashCode() : 0);
+        result = 31 * result + (getTimestamp() != null ? getTimestamp().hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "TopologyTestRunCase{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", topologyId=" + topologyId +
+                ", timestamp=" + timestamp +
+                '}';
+    }
+}

--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/TopologyTestRunCaseSink.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/TopologyTestRunCaseSink.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.catalog;
+
+import com.hortonworks.registries.common.Schema;
+import com.hortonworks.streamline.storage.PrimaryKey;
+import com.hortonworks.streamline.storage.annotation.StorableEntity;
+import com.hortonworks.streamline.storage.catalog.AbstractStorable;
+import org.codehaus.jackson.annotate.JsonIgnore;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class stores expected records for specific test sink.
+ */
+@StorableEntity
+public class TopologyTestRunCaseSink extends AbstractStorable {
+    public static final String NAMESPACE = "topology_test_run_case_sink";
+
+    private Long id;
+    private Long testCaseId;
+    private Long sinkId;
+    private String records;
+    private Long timestamp;
+
+    @JsonIgnore
+    @Override
+    public String getNameSpace() {
+        return NAMESPACE;
+    }
+
+    @JsonIgnore
+    @Override
+    public PrimaryKey getPrimaryKey() {
+        Map<Schema.Field, Object> fieldToObjectMap = new HashMap<Schema.Field, Object>();
+        fieldToObjectMap.put(new Schema.Field("id", Schema.Type.LONG), this.id);
+        return new PrimaryKey(fieldToObjectMap);
+    }
+
+    /**
+     * The primary key
+     */
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * The foreign key reference to the test case id.
+     */
+    public Long getTestCaseId() {
+        return testCaseId;
+    }
+
+    public void setTestCaseId(Long testCaseId) {
+        this.testCaseId = testCaseId;
+    }
+
+    /**
+     * The foreign key reference to the topology sink id.
+     */
+    public Long getSinkId() {
+        return sinkId;
+    }
+
+    public void setSinkId(Long sinkId) {
+        this.sinkId = sinkId;
+    }
+
+    /**
+     * Test expected records for given sink.
+     */
+    public String getRecords() {
+        return records;
+    }
+
+    public void setRecords(String records) {
+        this.records = records;
+    }
+
+    public Long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TopologyTestRunCaseSink)) return false;
+
+        TopologyTestRunCaseSink that = (TopologyTestRunCaseSink) o;
+
+        if (getId() != null ? !getId().equals(that.getId()) : that.getId() != null) return false;
+        if (getTestCaseId() != null ? !getTestCaseId().equals(that.getTestCaseId()) : that.getTestCaseId() != null)
+            return false;
+        if (getSinkId() != null ? !getSinkId().equals(that.getSinkId()) : that.getSinkId() != null)
+            return false;
+        if (getRecords() != null ? !getRecords().equals(that.getRecords()) : that.getRecords() != null) return false;
+        return getTimestamp() != null ? getTimestamp().equals(that.getTimestamp()) : that.getTimestamp() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getId() != null ? getId().hashCode() : 0;
+        result = 31 * result + (getTestCaseId() != null ? getTestCaseId().hashCode() : 0);
+        result = 31 * result + (getSinkId() != null ? getSinkId().hashCode() : 0);
+        result = 31 * result + (getRecords() != null ? getRecords().hashCode() : 0);
+        result = 31 * result + (getTimestamp() != null ? getTimestamp().hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "TopologyTestRunCaseSource{" +
+                "id=" + id +
+                ", testCaseId=" + testCaseId +
+                ", sinkId=" + sinkId +
+                ", records='" + records + '\'' +
+                ", timestamp=" + timestamp +
+                '}';
+    }
+}

--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/TopologyTestRunCaseSource.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/TopologyTestRunCaseSource.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.catalog;
+
+import com.hortonworks.registries.common.Schema;
+import com.hortonworks.streamline.storage.PrimaryKey;
+import com.hortonworks.streamline.storage.annotation.StorableEntity;
+import com.hortonworks.streamline.storage.catalog.AbstractStorable;
+import org.codehaus.jackson.annotate.JsonIgnore;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class stores actual test records for specific test source.
+ */
+@StorableEntity
+public class TopologyTestRunCaseSource extends AbstractStorable {
+    public static final String NAMESPACE = "topology_test_run_case_source";
+
+    private Long id;
+    private Long testCaseId;
+    private Long sourceId;
+    private String records;
+    private Long timestamp;
+
+    @JsonIgnore
+    @Override
+    public String getNameSpace() {
+        return NAMESPACE;
+    }
+
+    @JsonIgnore
+    @Override
+    public PrimaryKey getPrimaryKey() {
+        Map<Schema.Field, Object> fieldToObjectMap = new HashMap<Schema.Field, Object>();
+        fieldToObjectMap.put(new Schema.Field("id", Schema.Type.LONG), this.id);
+        return new PrimaryKey(fieldToObjectMap);
+    }
+
+    /**
+     * The primary key
+     */
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * The foreign key reference to the test case id.
+     */
+    public Long getTestCaseId() {
+        return testCaseId;
+    }
+
+    public void setTestCaseId(Long testCaseId) {
+        this.testCaseId = testCaseId;
+    }
+
+    /**
+     * The foreign key reference to the topology source id.
+     */
+    public Long getSourceId() {
+        return sourceId;
+    }
+
+    public void setSourceId(Long sourceId) {
+        this.sourceId = sourceId;
+    }
+
+    /**
+     * Test records for given source.
+     */
+    public String getRecords() {
+        return records;
+    }
+
+    public void setRecords(String records) {
+        this.records = records;
+    }
+
+    public Long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TopologyTestRunCaseSource)) return false;
+
+        TopologyTestRunCaseSource that = (TopologyTestRunCaseSource) o;
+
+        if (getId() != null ? !getId().equals(that.getId()) : that.getId() != null) return false;
+        if (getTestCaseId() != null ? !getTestCaseId().equals(that.getTestCaseId()) : that.getTestCaseId() != null)
+            return false;
+        if (getSourceId() != null ? !getSourceId().equals(that.getSourceId()) : that.getSourceId() != null)
+            return false;
+        if (getRecords() != null ? !getRecords().equals(that.getRecords()) : that.getRecords() != null) return false;
+        return getTimestamp() != null ? getTimestamp().equals(that.getTimestamp()) : that.getTimestamp() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getId() != null ? getId().hashCode() : 0;
+        result = 31 * result + (getTestCaseId() != null ? getTestCaseId().hashCode() : 0);
+        result = 31 * result + (getSourceId() != null ? getSourceId().hashCode() : 0);
+        result = 31 * result + (getRecords() != null ? getRecords().hashCode() : 0);
+        result = 31 * result + (getTimestamp() != null ? getTimestamp().hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "TopologyTestRunCaseSource{" +
+                "id=" + id +
+                ", testCaseId=" + testCaseId +
+                ", sourceId=" + sourceId +
+                ", records='" + records + '\'' +
+                ", timestamp=" + timestamp +
+                '}';
+    }
+}

--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/TopologyTestRunHistory.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/TopologyTestRunHistory.java
@@ -1,0 +1,370 @@
+package com.hortonworks.streamline.streams.catalog;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.hortonworks.registries.common.Schema;
+import com.hortonworks.streamline.storage.PrimaryKey;
+import com.hortonworks.streamline.storage.Storable;
+import com.hortonworks.streamline.storage.StorableKey;
+import com.hortonworks.streamline.storage.annotation.StorableEntity;
+import com.hortonworks.streamline.storage.catalog.AbstractStorable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class stores the information of topology test run.
+ */
+@StorableEntity
+public class TopologyTestRunHistory extends AbstractStorable {
+    public static final String NAMESPACE = "topology_test_run_histories";
+
+    public static final String ID = "id";
+    public static final String TOPOLOGY_ID = "topologyId";
+    public static final String VERSION_ID = "versionId";
+    public static final String TEST_RECORDS = "testRecords";
+    private static final String FINISHED = "finished";
+    private static final String SUCCESS = "success";
+    private static final String EXPECTED_OUTPUT_RECORDS = "expectedOutputRecords";
+    private static final String ACTUAL_OUTPUT_RECORDS = "actualOutputRecords";
+    private static final String MATCHED = "matched";
+    private static final String START_TIME = "startTime";
+    private static final String FINISH_TIME = "finishTime";
+    private static final String TIMESTAMP = "timestamp";
+
+    private Long id;
+    private Long topologyId;
+    private Long versionId;
+    private String testRecords;
+    private Boolean finished = false;
+    private Boolean success = false;
+    private String expectedOutputRecords;
+    private String actualOutputRecords;
+    private Boolean matched = false;
+    private Long startTime;
+    private Long finishTime;
+    private Long timestamp;
+
+    @JsonIgnore
+    @Override
+    public String getNameSpace() {
+        return NAMESPACE;
+    }
+
+    @JsonIgnore
+    @Override
+    public PrimaryKey getPrimaryKey() {
+        Map<Schema.Field, Object> fieldToObjectMap = new HashMap<Schema.Field, Object>();
+        fieldToObjectMap.put(new Schema.Field("id", Schema.Type.LONG), this.id);
+        return new PrimaryKey(fieldToObjectMap);
+    }
+
+    /**
+     * The primary key
+     */
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     *  The foreign key reference to the topology id.
+     */
+    public Long getTopologyId() {
+        return topologyId;
+    }
+
+    public void setTopologyId(Long topologyId) {
+        this.topologyId = topologyId;
+    }
+
+    /**
+     * The foreign key reference to the version id.
+     */
+    public Long getVersionId() {
+        return versionId;
+    }
+
+    public void setVersionId(Long versionId) {
+        this.versionId = versionId;
+    }
+
+    /**
+     * Collected test records JSON (source -> stream -> test records).
+     */
+    public String getTestRecords() {
+        return testRecords;
+    }
+
+    public void setTestRecords(String testRecords) {
+        this.testRecords = testRecords;
+    }
+
+    /**
+     * The flag indicating topology test run is finished.
+     */
+    public Boolean getFinished() {
+        return finished;
+    }
+
+    public void setFinished(Boolean finished) {
+        this.finished = finished;
+    }
+
+    /**
+     * The Flag indicating topology test run works without problem. It doesn't cover streaming runtime errors.
+     */
+    public Boolean getSuccess() {
+        return success;
+    }
+
+    public void setSuccess(Boolean success) {
+        this.success = success;
+    }
+
+    /**
+     * The JSON representation of expected output records.
+     */
+    public String getExpectedOutputRecords() {
+        return expectedOutputRecords;
+    }
+
+    public void setExpectedOutputRecords(String expectedOutputRecords) {
+        this.expectedOutputRecords = expectedOutputRecords;
+    }
+
+    /**
+     * The JSON representation of actual output records.
+     */
+    public String getActualOutputRecords() {
+        return actualOutputRecords;
+    }
+
+    public void setActualOutputRecords(String actualOutputRecords) {
+        this.actualOutputRecords = actualOutputRecords;
+    }
+
+    /**
+     * The flag indicating whether expected and actual are matched or not.
+     */
+    public Boolean getMatched() {
+        return matched;
+    }
+
+    public void setMatched(Boolean matched) {
+        this.matched = matched;
+    }
+
+    /**
+     * The timestamp of start time of test run.
+     */
+    public Long getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(Long startTime) {
+        this.startTime = startTime;
+    }
+
+    /**
+     * The timestamp of finish time of test run.
+     */
+    public Long getFinishTime() {
+        return finishTime;
+    }
+
+    public void setFinishTime(Long finishTime) {
+        this.finishTime = finishTime;
+    }
+
+    public Long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public void start() {
+        finished = false;
+        startTime = System.currentTimeMillis();
+    }
+
+    public void finish() {
+        this.finished = true;
+        this.startTime = System.currentTimeMillis();
+    }
+
+    public void finishSuccessfully() {
+        this.finished = true;
+        this.finishTime = System.currentTimeMillis();
+        this.success = true;
+    }
+
+    public void finishWithFailures() {
+        this.finished = true;
+        this.finishTime = System.currentTimeMillis();
+        this.success = false;
+    }
+
+    @Override
+    public Schema getSchema() {
+        return Schema.of(
+                new Schema.Field(ID, Schema.Type.LONG),
+                new Schema.Field(TOPOLOGY_ID, Schema.Type.LONG),
+                new Schema.Field(VERSION_ID, Schema.Type.LONG),
+                new Schema.Field(TEST_RECORDS, Schema.Type.STRING),
+                new Schema.Field(FINISHED, Schema.Type.STRING),
+                Schema.Field.optional(SUCCESS, Schema.Type.STRING),
+                Schema.Field.optional(EXPECTED_OUTPUT_RECORDS, Schema.Type.STRING),
+                Schema.Field.optional(ACTUAL_OUTPUT_RECORDS, Schema.Type.STRING),
+                Schema.Field.optional(MATCHED, Schema.Type.STRING),
+                new Schema.Field(START_TIME, Schema.Type.LONG),
+                Schema.Field.optional(FINISH_TIME, Schema.Type.LONG),
+                new Schema.Field(TIMESTAMP, Schema.Type.LONG)
+        );
+    }
+
+    @Override
+    public StorableKey getStorableKey() {
+        return new StorableKey(getNameSpace(), getPrimaryKey());
+    }
+
+    @Override
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<String, Object>();
+        map.put(ID, id);
+        map.put(TOPOLOGY_ID, topologyId);
+        map.put(VERSION_ID, versionId);
+        map.put(TEST_RECORDS, testRecords);
+
+        if (finished != null) {
+            map.put(FINISHED, finished.toString());
+        } else {
+            map.put(FINISHED, null);
+        }
+
+        if (success != null) {
+            map.put(SUCCESS, success.toString());
+        } else {
+            map.put(SUCCESS, null);
+        }
+
+        map.put(EXPECTED_OUTPUT_RECORDS, expectedOutputRecords);
+        map.put(ACTUAL_OUTPUT_RECORDS, actualOutputRecords);
+
+        if (matched != null) {
+            map.put(MATCHED, matched.toString());
+        } else {
+            map.put(MATCHED, null);
+        }
+
+        map.put(START_TIME, startTime);
+        map.put(FINISH_TIME, finishTime);
+        map.put(TIMESTAMP, timestamp);
+        return map;
+    }
+
+    @Override
+    public Storable fromMap(Map<String, Object> map) {
+        id = (Long) map.get(ID);
+        topologyId = (Long) map.get(TOPOLOGY_ID);
+        versionId = (Long) map.get(VERSION_ID);
+        testRecords = (String) map.get(TEST_RECORDS);
+
+        if (map.get(FINISHED) != null) {
+            finished = Boolean.valueOf((String) map.get(FINISHED));
+        } else {
+            finished = null;
+        }
+
+        if (map.get(SUCCESS) != null) {
+            success = Boolean.valueOf((String) map.get(SUCCESS));
+        } else {
+            success = null;
+        }
+
+        expectedOutputRecords = (String) map.get(EXPECTED_OUTPUT_RECORDS);
+        actualOutputRecords = (String) map.get(ACTUAL_OUTPUT_RECORDS);
+
+        if (map.get(MATCHED) != null) {
+            matched = Boolean.valueOf((String) map.get(MATCHED));
+        } else {
+            matched = null;
+        }
+
+        startTime = (Long) map.get(START_TIME);
+        finishTime = (Long) map.get(FINISH_TIME);
+        timestamp = (Long) map.get(TIMESTAMP);
+
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TopologyTestRunHistory)) return false;
+
+        TopologyTestRunHistory that = (TopologyTestRunHistory) o;
+
+        if (getId() != null ? !getId().equals(that.getId()) : that.getId() != null) return false;
+        if (getTopologyId() != null ? !getTopologyId().equals(that.getTopologyId()) : that.getTopologyId() != null)
+            return false;
+        if (getVersionId() != null ? !getVersionId().equals(that.getVersionId()) : that.getVersionId() != null)
+            return false;
+        if (getTestRecords() != null ? !getTestRecords().equals(that.getTestRecords()) : that.getTestRecords() != null)
+            return false;
+        if (getFinished() != null ? !getFinished().equals(that.getFinished()) : that.getFinished() != null)
+            return false;
+        if (getSuccess() != null ? !getSuccess().equals(that.getSuccess()) : that.getSuccess() != null) return false;
+        if (getExpectedOutputRecords() != null ? !getExpectedOutputRecords().equals(that.getExpectedOutputRecords()) : that.getExpectedOutputRecords() != null)
+            return false;
+        if (getActualOutputRecords() != null ? !getActualOutputRecords().equals(that.getActualOutputRecords()) : that.getActualOutputRecords() != null)
+            return false;
+        if (getMatched() != null ? !getMatched().equals(that.getMatched()) : that.getMatched() != null) return false;
+        if (getStartTime() != null ? !getStartTime().equals(that.getStartTime()) : that.getStartTime() != null)
+            return false;
+        if (getFinishTime() != null ? !getFinishTime().equals(that.getFinishTime()) : that.getFinishTime() != null)
+            return false;
+        return getTimestamp() != null ? getTimestamp().equals(that.getTimestamp()) : that.getTimestamp() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getId() != null ? getId().hashCode() : 0;
+        result = 31 * result + (getTopologyId() != null ? getTopologyId().hashCode() : 0);
+        result = 31 * result + (getVersionId() != null ? getVersionId().hashCode() : 0);
+        result = 31 * result + (getTestRecords() != null ? getTestRecords().hashCode() : 0);
+        result = 31 * result + (getFinished() != null ? getFinished().hashCode() : 0);
+        result = 31 * result + (getSuccess() != null ? getSuccess().hashCode() : 0);
+        result = 31 * result + (getExpectedOutputRecords() != null ? getExpectedOutputRecords().hashCode() : 0);
+        result = 31 * result + (getActualOutputRecords() != null ? getActualOutputRecords().hashCode() : 0);
+        result = 31 * result + (getMatched() != null ? getMatched().hashCode() : 0);
+        result = 31 * result + (getStartTime() != null ? getStartTime().hashCode() : 0);
+        result = 31 * result + (getFinishTime() != null ? getFinishTime().hashCode() : 0);
+        result = 31 * result + (getTimestamp() != null ? getTimestamp().hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "TopologyTestRunHistory{" +
+                "id=" + id +
+                ", topologyId=" + topologyId +
+                ", versionId=" + versionId +
+                ", testRecords=" + testRecords +
+                ", finished=" + finished +
+                ", success=" + success +
+                ", expectedOutputRecords='" + expectedOutputRecords + '\'' +
+                ", actualOutputRecords='" + actualOutputRecords + '\'' +
+                ", matched=" + matched +
+                ", startTime=" + startTime +
+                ", finishTime=" + finishTime +
+                ", timestamp=" + timestamp +
+                '}';
+    }
+}

--- a/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/TopologyLayout.java
+++ b/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/TopologyLayout.java
@@ -43,6 +43,13 @@ public class TopologyLayout {
         this.topologyDag = topologyDag;
     }
 
+    public TopologyLayout(Long id, String name, Config config, TopologyDag topologyDag) {
+        this.id = id;
+        this.name = name;
+        this.config = config;
+        this.topologyDag = topologyDag;
+    }
+
     public Long getId() {
         return id;
     }

--- a/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/testing/TestRunSink.java
+++ b/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/testing/TestRunSink.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.layout.component.impl.testing;
+
+import com.hortonworks.streamline.streams.layout.component.StreamlineSink;
+
+public class TestRunSink extends StreamlineSink {
+    private String outputFilePath;
+
+    public TestRunSink() {
+        this.outputFilePath = "";
+    }
+
+    public TestRunSink(String outputFilePath) {
+        this.outputFilePath = outputFilePath;
+    }
+
+    public String getOutputFilePath() {
+        return outputFilePath;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TestRunSink)) return false;
+        if (!super.equals(o)) return false;
+
+        TestRunSink that = (TestRunSink) o;
+
+        return getOutputFilePath() != null ? getOutputFilePath().equals(that.getOutputFilePath()) : that.getOutputFilePath() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (getOutputFilePath() != null ? getOutputFilePath().hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "TestRunSink{" +
+                "outputFilePath='" + outputFilePath + '\'' +
+                '}' + super.toString();
+    }
+
+}

--- a/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/testing/TestRunSource.java
+++ b/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/testing/TestRunSource.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.layout.component.impl.testing;
+
+import com.hortonworks.streamline.streams.layout.component.Stream;
+import com.hortonworks.streamline.streams.layout.component.StreamlineSource;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Source for topology test run. This class contains test records which will be emitted from test run Spout.
+ */
+public class TestRunSource extends StreamlineSource {
+    private final Map<String, List<Map<String, Object>>> testRecordsForEachStream;
+
+    public TestRunSource() {
+        this(Collections.EMPTY_SET, Collections.EMPTY_MAP);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param outputStreams output streams.
+     * @param testRecordsForEachStream (output stream name) -> list of test record (each map represents a record)
+     */
+    public TestRunSource(Set<Stream> outputStreams, Map<String, List<Map<String, Object>>> testRecordsForEachStream) {
+        super(outputStreams);
+        this.testRecordsForEachStream = testRecordsForEachStream;
+    }
+
+    public Map<String, List<Map<String, Object>>> getTestRecordsForEachStream() {
+        return testRecordsForEachStream;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TestRunSource)) return false;
+        if (!super.equals(o)) return false;
+
+        TestRunSource that = (TestRunSource) o;
+
+        return getTestRecordsForEachStream() != null ?
+                getTestRecordsForEachStream().equals(that.getTestRecordsForEachStream()) :
+                that.getTestRecordsForEachStream() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (getTestRecordsForEachStream() != null ? getTestRecordsForEachStream().hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "TestRunSource{" +
+                "testRecordsForEachStream=" + testRecordsForEachStream +
+                '}' + super.toString();
+    }
+}

--- a/streams/runners/storm/actions/pom.xml
+++ b/streams/runners/storm/actions/pom.xml
@@ -24,6 +24,15 @@
             <groupId>com.hortonworks.streamline</groupId>
             <artifactId>streamline-layout-storm</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/StormTopologyActionsImpl.java
+++ b/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/StormTopologyActionsImpl.java
@@ -186,10 +186,6 @@ public class StormTopologyActionsImpl implements TopologyActions {
         commands.addAll(getExtraJarsArg(testTopology));
         commands.addAll(getMavenArtifactsRelatedArgs(mavenArtifacts));
         commands.addAll(getNimbusConf());
-        // FIXME: debug
-        commands.add("-c");
-        commands.add("topology.debug=true");
-        // FIXME: debug
         commands.add("org.apache.storm.flux.Flux");
         commands.add("--local");
         commands.add("-s");

--- a/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/StormTopologyActionsImpl.java
+++ b/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/StormTopologyActionsImpl.java
@@ -16,9 +16,10 @@
 package com.hortonworks.streamline.streams.actions.storm.topology;
 
 import com.google.common.base.Joiner;
-import com.hortonworks.streamline.common.exception.DuplicateEntityException;
 import com.hortonworks.streamline.common.exception.service.exception.request.TopologyAlreadyExistsOnCluster;
 import com.hortonworks.streamline.streams.actions.TopologyActionContext;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSink;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSource;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -51,6 +52,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,6 +69,7 @@ import static java.util.stream.Collectors.toList;
 public class StormTopologyActionsImpl implements TopologyActions {
     private static final Logger LOG = LoggerFactory.getLogger(StormTopologyActionsImpl.class);
     public static final int DEFAULT_WAIT_TIME_SEC = 30;
+    public static final int TEST_RUN_TOPOLOGY_WAIT_MILLIS_FOR_SHUTDOWN = 30_000;
 
     private static final String NIMBUS_SEEDS = "nimbus.seeds";
     private static final String NIMBUS_PORT = "nimbus.port";
@@ -161,87 +164,45 @@ public class StormTopologyActionsImpl implements TopologyActions {
         }
     }
 
-    private List<String> getMavenArtifactsRelatedArgs (String mavenArtifacts) {
-        List<String> args = new ArrayList<>();
-        if (mavenArtifacts != null && !mavenArtifacts.isEmpty()) {
-            args.add("--artifacts");
-            args.add(mavenArtifacts);
-            args.add("--artifactRepositories");
-            args.add(conf.get("mavenRepoUrl"));
+    @Override
+    public void testRun(TopologyLayout topology, String mavenArtifacts,
+                        Map<String, TestRunSource> testRunSourcesForEachSource,
+                        Map<String, TestRunSink> testRunSinksForEachSink) throws Exception {
+        TopologyDag originalTopologyDag = topology.getTopologyDag();
+
+        TestTopologyDagCreatingVisitor visitor = new TestTopologyDagCreatingVisitor(originalTopologyDag,
+                testRunSourcesForEachSource, testRunSinksForEachSink);
+        originalTopologyDag.traverse(visitor);
+        TopologyDag testTopologyDag = visitor.getTestTopologyDag();
+
+        TopologyLayout testTopology = copyTopologyLayout(topology, testTopologyDag);
+
+        Path jarToDeploy = addArtifactsToJar(getArtifactsLocation(testTopology));
+        String fileName = createYamlFile(testTopology);
+        List<String> commands = new ArrayList<String>();
+        commands.add(stormCliPath);
+        commands.add("jar");
+        commands.add(jarToDeploy.toString());
+        commands.addAll(getExtraJarsArg(testTopology));
+        commands.addAll(getMavenArtifactsRelatedArgs(mavenArtifacts));
+        commands.addAll(getNimbusConf());
+        // FIXME: debug
+        commands.add("-c");
+        commands.add("topology.debug=true");
+        // FIXME: debug
+        commands.add("org.apache.storm.flux.Flux");
+        commands.add("--local");
+        commands.add("-s");
+        commands.add(String.valueOf(TEST_RUN_TOPOLOGY_WAIT_MILLIS_FOR_SHUTDOWN));
+        commands.add(fileName);
+
+        ShellProcessResult shellProcessResult = executeShellProcess(commands);
+        int exitValue = shellProcessResult.exitValue;
+        if (exitValue != 0) {
+            LOG.error("Topology deploy command as test mode failed - exit code: {} / output: {}", exitValue, shellProcessResult.stdout);
+            throw new Exception("Topology could not be run " +
+                    "successfully as test mode: storm deploy command failed");
         }
-        return args;
-    }
-
-    private List<String> getExtraJarsArg(TopologyLayout topology) {
-        List<String> args = new ArrayList<>();
-        List<String> jars = new ArrayList<>();
-        Path extraJarsPath = getExtraJarsLocation(topology);
-        if (extraJarsPath.toFile().isDirectory()) {
-            File[] jarFiles = extraJarsPath.toFile().listFiles();
-            if (jarFiles != null && jarFiles.length > 0) {
-                for (File jarFile : jarFiles) {
-                    jars.add(jarFile.getAbsolutePath());
-                }
-            }
-        } else {
-            LOG.debug("Extra jars directory {} does not exist, not adding any extra jars", extraJarsPath);
-        }
-        if (!jars.isEmpty()) {
-            args.add("--jars");
-            args.add(Joiner.on(",").join(jars));
-        }
-        return args;
-    }
-
-    private List<String> getNimbusConf() {
-        List<String> args = new ArrayList<>();
-
-        // FIXME: Can't find how to pass list to nimbus.seeds for Storm CLI
-        // Maybe we need to fix Storm to parse string when expected parameter type is list
-        args.add("-c");
-        args.add("nimbus.host=" + nimbusSeeds.split(",")[0]);
-
-        args.add("-c");
-        args.add("nimbus.port=" + String.valueOf(nimbusPort));
-
-        return args;
-    }
-
-    private Path addArtifactsToJar(Path artifactsLocation) throws Exception {
-        Path jarFile = Paths.get(stormJarLocation);
-        if (artifactsLocation.toFile().isDirectory()) {
-            File[] artifacts = artifactsLocation.toFile().listFiles();
-            if (artifacts != null && artifacts.length > 0) {
-                Path newJar = Files.copy(jarFile, artifactsLocation.resolve(jarFile.getFileName()));
-
-                List<String> artifactFileNames = Arrays.stream(artifacts).filter(File::isFile)
-                        .map(File::getName).collect(toList());
-                List<String> commands = new ArrayList<>();
-
-                commands.add(javaJarCommand);
-                commands.add("uf");
-                commands.add(newJar.toString());
-
-                artifactFileNames.stream().forEachOrdered(name -> {
-                    commands.add("-C");
-                    commands.add(artifactsLocation.toString());
-                    commands.add(name);
-                });
-
-                ShellProcessResult shellProcessResult = executeShellProcess(commands);
-                if (shellProcessResult.exitValue != 0) {
-                    LOG.error("Adding artifacts to jar command failed - exit code: {} / output: {}",
-                            shellProcessResult.exitValue, shellProcessResult.stdout);
-                    throw new RuntimeException("Topology could not be deployed " +
-                            "successfully: fail to add artifacts to jar");
-                }
-                LOG.debug("Added files {} to jar {}", artifactFileNames, jarFile);
-                return newJar;
-            }
-        } else {
-            LOG.debug("Artifacts directory {} does not exist, not adding any artifacts to jar", artifactsLocation);
-        }
-        return jarFile;
     }
 
     @Override
@@ -328,6 +289,93 @@ public class StormTopologyActionsImpl implements TopologyActions {
             throw new TopologyNotAliveException("Topology not found in Storm Cluster - topology id: " + topology.getId());
         }
         return stormTopologyId;
+    }
+
+    private TopologyLayout copyTopologyLayout(TopologyLayout topology, TopologyDag replacedTopologyDag) {
+        return new TopologyLayout(topology.getId(), topology.getName(), topology.getConfig(), replacedTopologyDag);
+    }
+
+    private List<String> getMavenArtifactsRelatedArgs (String mavenArtifacts) {
+        List<String> args = new ArrayList<>();
+        if (mavenArtifacts != null && !mavenArtifacts.isEmpty()) {
+            args.add("--artifacts");
+            args.add(mavenArtifacts);
+            args.add("--artifactRepositories");
+            args.add(conf.get("mavenRepoUrl"));
+        }
+        return args;
+    }
+
+    private List<String> getExtraJarsArg(TopologyLayout topology) {
+        List<String> args = new ArrayList<>();
+        List<String> jars = new ArrayList<>();
+        Path extraJarsPath = getExtraJarsLocation(topology);
+        if (extraJarsPath.toFile().isDirectory()) {
+            File[] jarFiles = extraJarsPath.toFile().listFiles();
+            if (jarFiles != null && jarFiles.length > 0) {
+                for (File jarFile : jarFiles) {
+                    jars.add(jarFile.getAbsolutePath());
+                }
+            }
+        } else {
+            LOG.debug("Extra jars directory {} does not exist, not adding any extra jars", extraJarsPath);
+        }
+        if (!jars.isEmpty()) {
+            args.add("--jars");
+            args.add(Joiner.on(",").join(jars));
+        }
+        return args;
+    }
+
+    private List<String> getNimbusConf() {
+        List<String> args = new ArrayList<>();
+
+        // FIXME: Can't find how to pass list to nimbus.seeds for Storm CLI
+        // Maybe we need to fix Storm to parse string when expected parameter type is list
+        args.add("-c");
+        args.add("nimbus.host=" + nimbusSeeds.split(",")[0]);
+
+        args.add("-c");
+        args.add("nimbus.port=" + String.valueOf(nimbusPort));
+
+        return args;
+    }
+
+    private Path addArtifactsToJar(Path artifactsLocation) throws Exception {
+        Path jarFile = Paths.get(stormJarLocation);
+        if (artifactsLocation.toFile().isDirectory()) {
+            File[] artifacts = artifactsLocation.toFile().listFiles();
+            if (artifacts != null && artifacts.length > 0) {
+                Path newJar = Files.copy(jarFile, artifactsLocation.resolve(jarFile.getFileName()));
+
+                List<String> artifactFileNames = Arrays.stream(artifacts).filter(File::isFile)
+                        .map(File::getName).collect(toList());
+                List<String> commands = new ArrayList<>();
+
+                commands.add(javaJarCommand);
+                commands.add("uf");
+                commands.add(newJar.toString());
+
+                artifactFileNames.stream().forEachOrdered(name -> {
+                    commands.add("-C");
+                    commands.add(artifactsLocation.toString());
+                    commands.add(name);
+                });
+
+                ShellProcessResult shellProcessResult = executeShellProcess(commands);
+                if (shellProcessResult.exitValue != 0) {
+                    LOG.error("Adding artifacts to jar command failed - exit code: {} / output: {}",
+                            shellProcessResult.exitValue, shellProcessResult.stdout);
+                    throw new RuntimeException("Topology could not be deployed " +
+                            "successfully: fail to add artifacts to jar");
+                }
+                LOG.debug("Added files {} to jar {}", artifactFileNames, jarFile);
+                return newJar;
+            }
+        } else {
+            LOG.debug("Artifacts directory {} does not exist, not adding any artifacts to jar", artifactsLocation);
+        }
+        return jarFile;
     }
 
     private String createYamlFile (TopologyLayout topology) throws Exception {
@@ -424,4 +472,5 @@ public class StormTopologyActionsImpl implements TopologyActions {
             this.stdout = stdout;
         }
     }
+
 }

--- a/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/TestTopologyDagCreatingVisitor.java
+++ b/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/TestTopologyDagCreatingVisitor.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.actions.storm.topology;
+
+import com.hortonworks.streamline.common.Config;
+import com.hortonworks.streamline.streams.layout.component.Edge;
+import com.hortonworks.streamline.streams.layout.component.InputComponent;
+import com.hortonworks.streamline.streams.layout.component.OutputComponent;
+import com.hortonworks.streamline.streams.layout.component.StreamlineProcessor;
+import com.hortonworks.streamline.streams.layout.component.StreamlineSink;
+import com.hortonworks.streamline.streams.layout.component.StreamlineSource;
+import com.hortonworks.streamline.streams.layout.component.TopologyDag;
+import com.hortonworks.streamline.streams.layout.component.TopologyDagVisitor;
+import com.hortonworks.streamline.streams.layout.component.impl.RulesProcessor;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSink;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSource;
+import com.hortonworks.streamline.streams.layout.storm.TestRunSinkBoltFluxComponent;
+import com.hortonworks.streamline.streams.layout.storm.TestRunSourceSpoutFluxComponent;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TestTopologyDagCreatingVisitor extends TopologyDagVisitor {
+
+    private final Map<String, StreamlineSource> sourceToReplacedTestSourceMap;
+    private final Map<String, StreamlineSink> sinkToReplacedTestSinkMap;
+    private final Map<String, TestRunSource> testRunSourcesForEachSource;
+    private final Map<String, TestRunSink> testRunSinksForEachSink;
+    private final TopologyDag originTopologyDag;
+
+    private TopologyDag testTopologyDag;
+
+    public TestTopologyDagCreatingVisitor(TopologyDag originTopologyDag,
+                                          Map<String, TestRunSource> testRunSourcesForEachSource,
+                                          Map<String, TestRunSink> testRunSinksForEachSink) {
+        this.originTopologyDag = originTopologyDag;
+        this.testRunSourcesForEachSource = testRunSourcesForEachSource;
+        this.testRunSinksForEachSink = testRunSinksForEachSink;
+
+        this.testTopologyDag = new TopologyDag();
+        this.sourceToReplacedTestSourceMap = new HashMap<>();
+        this.sinkToReplacedTestSinkMap = new HashMap<>();
+    }
+
+    @Override
+    public void visit(RulesProcessor rulesProcessor) {
+        visit((StreamlineProcessor) rulesProcessor);
+    }
+
+    @Override
+    public void visit(StreamlineSource source) {
+        String id = source.getId();
+        String sourceName = source.getName();
+
+        if (!testRunSourcesForEachSource.containsKey(sourceName)) {
+            throw new IllegalStateException("Not all sources have corresponding TestRunSource instance. source name: " + sourceName);
+        }
+
+        Config config = new Config(source.getConfig());
+
+        TestRunSource testRunSource = testRunSourcesForEachSource.get(sourceName);
+
+        testRunSource.setId(id);
+        testRunSource.setName(sourceName);
+        testRunSource.setConfig(config);
+        testRunSource.setTransformationClass(TestRunSourceSpoutFluxComponent.class.getName());
+
+        testTopologyDag.add(testRunSource);
+        sourceToReplacedTestSourceMap.put(sourceName, testRunSource);
+    }
+
+    @Override
+    public void visit(StreamlineSink sink) {
+        String id = sink.getId();
+        String sinkName = sink.getName();
+
+        if (!testRunSinksForEachSink.containsKey(sinkName)) {
+            throw new IllegalStateException("Not all sinks have corresponding TestRunSink instance. sink name: " + sinkName);
+        }
+
+        Config config = new Config(sink.getConfig());
+
+        TestRunSink testRunSink = testRunSinksForEachSink.get(sinkName);
+
+        testRunSink.setId(id);
+        testRunSink.setName(sinkName);
+        testRunSink.setConfig(config);
+        testRunSink.setTransformationClass(TestRunSinkBoltFluxComponent.class.getName());
+
+        testTopologyDag.add(testRunSink);
+        sinkToReplacedTestSinkMap.put(sinkName, testRunSink);
+
+        copyEdges(sink);
+    }
+
+    @Override
+    public void visit(StreamlineProcessor processor) {
+        testTopologyDag.add(processor);
+
+        copyEdges(processor);
+    }
+
+    private void copyEdges(InputComponent inputComponent) {
+        List<Edge> edgesTo = originTopologyDag.getEdgesTo(inputComponent);
+        edgesTo.forEach(e -> {
+            OutputComponent from = e.getFrom();
+            InputComponent to = e.getTo();
+            Edge newEdge = new Edge(e.getId(), e.getFrom(), e.getTo(), e.getStreamGroupings());
+
+            StreamlineSource replacedSource = sourceToReplacedTestSourceMap.get(from.getName());
+            StreamlineSink replacedSink = sinkToReplacedTestSinkMap.get(to.getName());
+
+            if (replacedSource != null) {
+                newEdge.setFrom(replacedSource);
+            }
+
+            if (replacedSink != null) {
+                newEdge.setTo(replacedSink);
+            }
+
+            testTopologyDag.addEdge(newEdge);
+        });
+    }
+
+    @Override
+    public void visit(Edge edge) {
+        // no-op
+    }
+
+    public TopologyDag getTestTopologyDag() {
+        return testTopologyDag;
+    }
+}

--- a/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/storm/topology/TestTopologyDagCreatingVisitorTest.java
+++ b/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/storm/topology/TestTopologyDagCreatingVisitorTest.java
@@ -1,0 +1,320 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.actions.storm.topology;
+
+import com.hortonworks.streamline.streams.actions.utils.TopologyTestHelper;
+import com.hortonworks.streamline.streams.layout.component.Edge;
+import com.hortonworks.streamline.streams.layout.component.InputComponent;
+import com.hortonworks.streamline.streams.layout.component.OutputComponent;
+import com.hortonworks.streamline.streams.layout.component.Stream;
+import com.hortonworks.streamline.streams.layout.component.StreamlineProcessor;
+import com.hortonworks.streamline.streams.layout.component.StreamlineSink;
+import com.hortonworks.streamline.streams.layout.component.StreamlineSource;
+import com.hortonworks.streamline.streams.layout.component.TopologyDag;
+import com.hortonworks.streamline.streams.layout.component.impl.RulesProcessor;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSink;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSource;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class TestTopologyDagCreatingVisitorTest {
+    @Test
+    public void visitSource() throws Exception {
+        StreamlineSource originSource = TopologyTestHelper.createStreamlineSource("1");
+
+        TopologyDag originTopologyDag = new TopologyDag();
+        originTopologyDag.add(originSource);
+
+        TestRunSource testSource = createTestRunSource(originSource);
+
+        TestTopologyDagCreatingVisitor visitor =
+                new TestTopologyDagCreatingVisitor(originTopologyDag,
+                        Collections.singletonMap(originSource.getName(), testSource),
+                        Collections.emptyMap());
+        visitor.visit(originSource);
+
+        TopologyDag testTopologyDag = visitor.getTestTopologyDag();
+
+        List<OutputComponent> testSources = testTopologyDag.getOutputComponents().stream()
+                .filter(o -> (o instanceof TestRunSource && o.getName().equals(originSource.getName())))
+                .collect(toList());
+
+        assertEquals(1, testSources.size());
+
+        TestRunSource testRunSource = (TestRunSource) testSources.get(0);
+        assertEquals(originSource.getId(), testRunSource.getId());
+        assertEquals(testSource.getTestRecordsForEachStream(), testRunSource.getTestRecordsForEachStream());
+    }
+
+    @Test
+    public void visitSource_noMatchingTestRunSource() throws Exception {
+        StreamlineSource originSource = TopologyTestHelper.createStreamlineSource("1");
+
+        TopologyDag originTopologyDag = new TopologyDag();
+        originTopologyDag.add(originSource);
+
+        TestTopologyDagCreatingVisitor visitor =
+                new TestTopologyDagCreatingVisitor(originTopologyDag, Collections.emptyMap(), Collections.emptyMap());
+
+        try {
+            visitor.visit(originSource);
+            fail("IllegalStateException should be thrown.");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains(originSource.getName()));
+        }
+    }
+
+    @Test
+    public void visitSink_connectedFromSource() throws Exception {
+        StreamlineSource originSource = TopologyTestHelper.createStreamlineSource("1");
+        StreamlineSink originSink = TopologyTestHelper.createStreamlineSink("2");
+
+        TopologyDag originTopologyDag = new TopologyDag();
+        originTopologyDag.add(originSource);
+        originTopologyDag.add(originSink);
+        originTopologyDag.addEdge(new Edge("e1", originSource, originSink, "default", Stream.Grouping.SHUFFLE));
+
+        TestRunSource testSource = createTestRunSource(originSource);
+        TestRunSink testSink = createTestRunSink();
+
+        TestTopologyDagCreatingVisitor visitor =
+                new TestTopologyDagCreatingVisitor(originTopologyDag,
+                        Collections.singletonMap(originSource.getName(), testSource),
+                        Collections.singletonMap(originSink.getName(), testSink));
+
+        visitor.visit(originSource);
+        visitor.visit(originSink);
+
+        TopologyDag testTopologyDag = visitor.getTestTopologyDag();
+
+        List<OutputComponent> testSources = testTopologyDag.getOutputComponents().stream()
+                .filter(o -> (o instanceof TestRunSource && o.getName().equals(originSource.getName())))
+                .collect(toList());
+
+        List<InputComponent> testSinks = testTopologyDag.getInputComponents().stream()
+                .filter(o -> (o instanceof TestRunSink && o.getName().equals(originSink.getName())))
+                .collect(toList());
+
+        assertEquals(1, testSinks.size());
+
+        TestRunSource testRunSource = (TestRunSource) testSources.get(0);
+        TestRunSink testRunSink = (TestRunSink) testSinks.get(0);
+        assertEquals(originSink.getId(), testRunSink.getId());
+        assertEquals(testSink.getOutputFilePath(), testRunSink.getOutputFilePath());
+
+        assertEquals(1, testTopologyDag.getEdgesFrom(testRunSource).size());
+        assertEquals(1, testTopologyDag.getEdgesTo(testRunSink).size());
+
+        assertTrue(testTopologyDag.getEdgesFrom(testRunSource).get(0) == testTopologyDag.getEdgesTo(testRunSink).get(0));
+    }
+
+    @Test
+    public void visitSink_connectedFromProcessor() throws Exception {
+        StreamlineProcessor originProcessor = TopologyTestHelper.createStreamlineProcessor("1");
+        StreamlineSink originSink = TopologyTestHelper.createStreamlineSink("2");
+
+        TopologyDag originTopologyDag = new TopologyDag();
+        originTopologyDag.add(originProcessor);
+        originTopologyDag.add(originSink);
+        originTopologyDag.addEdge(new Edge("e1", originProcessor, originSink, "default", Stream.Grouping.SHUFFLE));
+
+        TestRunSink testSink = createTestRunSink();
+
+        TestTopologyDagCreatingVisitor visitor =
+                new TestTopologyDagCreatingVisitor(originTopologyDag,
+                        Collections.emptyMap(),
+                        Collections.singletonMap(originSink.getName(), testSink));
+
+        visitor.visit(originProcessor);
+        visitor.visit(originSink);
+
+        TopologyDag testTopologyDag = visitor.getTestTopologyDag();
+
+        List<InputComponent> testSinks = testTopologyDag.getInputComponents().stream()
+                .filter(o -> (o instanceof TestRunSink && o.getName().equals(originSink.getName())))
+                .collect(toList());
+
+        assertEquals(1, testSinks.size());
+
+        TestRunSink testRunSink = (TestRunSink) testSinks.get(0);
+        assertEquals(originSink.getId(), testRunSink.getId());
+        assertEquals(testSink.getOutputFilePath(), testRunSink.getOutputFilePath());
+
+        assertEquals(1, testTopologyDag.getEdgesFrom(originProcessor).size());
+        assertEquals(1, testTopologyDag.getEdgesTo(testRunSink).size());
+
+        assertTrue(testTopologyDag.getEdgesFrom(originProcessor).get(0) == testTopologyDag.getEdgesTo(testRunSink).get(0));
+    }
+
+    @Test
+    public void visitSink_noMatchingTestRunSink() throws Exception {
+        TopologyDag originTopologyDag = new TopologyDag();
+        StreamlineSink originSink = TopologyTestHelper.createStreamlineSink("1");
+        originTopologyDag.add(originSink);
+
+        TestTopologyDagCreatingVisitor visitor =
+                new TestTopologyDagCreatingVisitor(originTopologyDag, Collections.emptyMap(), Collections.emptyMap());
+
+        try {
+            visitor.visit(originSink);
+            fail("IllegalStateException should be thrown.");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains(originSink.getName()));
+        }
+    }
+
+    @Test
+    public void visitProcessor_connectedFromSource() throws Exception {
+        StreamlineSource originSource = TopologyTestHelper.createStreamlineSource("1");
+        StreamlineProcessor originProcessor = TopologyTestHelper.createStreamlineProcessor("2");
+
+        TopologyDag originTopologyDag = new TopologyDag();
+        originTopologyDag.add(originSource);
+        originTopologyDag.add(originProcessor);
+        originTopologyDag.addEdge(new Edge("e1", originSource, originProcessor, "default", Stream.Grouping.SHUFFLE));
+
+        TestRunSource testSource = createTestRunSource(originSource);
+
+        TestTopologyDagCreatingVisitor visitor =
+                new TestTopologyDagCreatingVisitor(originTopologyDag,
+                        Collections.singletonMap(originSource.getName(), testSource),
+                        Collections.emptyMap());
+
+        visitor.visit(originSource);
+        visitor.visit(originProcessor);
+
+        TopologyDag testTopologyDag = visitor.getTestTopologyDag();
+
+        List<OutputComponent> testSources = testTopologyDag.getOutputComponents().stream()
+                .filter(o -> (o instanceof TestRunSource && o.getName().equals(originSource.getName())))
+                .collect(toList());
+
+        TestRunSource testRunSource = (TestRunSource) testSources.get(0);
+
+        assertEquals(1, testTopologyDag.getEdgesFrom(testRunSource).size());
+        assertEquals(1, testTopologyDag.getEdgesTo(originProcessor).size());
+
+        assertTrue(testTopologyDag.getEdgesFrom(testRunSource).get(0) == testTopologyDag.getEdgesTo(originProcessor).get(0));
+    }
+
+    @Test
+    public void visitProcessor_connectedFromProcessor() throws Exception {
+        StreamlineProcessor originProcessor = TopologyTestHelper.createStreamlineProcessor("1");
+        StreamlineProcessor originProcessor2 = TopologyTestHelper.createStreamlineProcessor("2");
+
+        TopologyDag originTopologyDag = new TopologyDag();
+        originTopologyDag.add(originProcessor);
+        originTopologyDag.add(originProcessor2);
+        originTopologyDag.addEdge(new Edge("e1", originProcessor, originProcessor2, "default", Stream.Grouping.SHUFFLE));
+
+        TestTopologyDagCreatingVisitor visitor =
+                new TestTopologyDagCreatingVisitor(originTopologyDag,
+                        Collections.emptyMap(),
+                        Collections.emptyMap());
+
+        visitor.visit(originProcessor);
+        visitor.visit(originProcessor2);
+
+        TopologyDag testTopologyDag = visitor.getTestTopologyDag();
+
+        assertEquals(1, testTopologyDag.getEdgesFrom(originProcessor).size());
+        assertEquals(1, testTopologyDag.getEdgesTo(originProcessor2).size());
+
+        assertTrue(testTopologyDag.getEdgesFrom(originProcessor).get(0) == testTopologyDag.getEdgesTo(originProcessor2).get(0));
+    }
+
+    @Test
+    public void visitRulesProcessor_connectedFromSource() throws Exception {
+        StreamlineSource originSource = TopologyTestHelper.createStreamlineSource("1");
+        RulesProcessor rulesProcessor = TopologyTestHelper.createRulesProcessor("2");
+
+        TopologyDag originTopologyDag = new TopologyDag();
+        originTopologyDag.add(originSource);
+        originTopologyDag.add(rulesProcessor);
+        originTopologyDag.addEdge(new Edge("e1", originSource, rulesProcessor, "default", Stream.Grouping.SHUFFLE));
+
+        TestRunSource testSource = createTestRunSource(originSource);
+
+        TestTopologyDagCreatingVisitor visitor =
+                new TestTopologyDagCreatingVisitor(originTopologyDag,
+                        Collections.singletonMap(originSource.getName(), testSource),
+                        Collections.emptyMap());
+
+        visitor.visit(originSource);
+        visitor.visit(rulesProcessor);
+
+        TopologyDag testTopologyDag = visitor.getTestTopologyDag();
+
+        List<OutputComponent> testSources = testTopologyDag.getOutputComponents().stream()
+                .filter(o -> (o instanceof TestRunSource && o.getName().equals(originSource.getName())))
+                .collect(toList());
+
+        TestRunSource testRunSource = (TestRunSource) testSources.get(0);
+
+        assertEquals(1, testTopologyDag.getEdgesFrom(testRunSource).size());
+        assertEquals(1, testTopologyDag.getEdgesTo(rulesProcessor).size());
+
+        assertTrue(testTopologyDag.getEdgesFrom(testRunSource).get(0) == testTopologyDag.getEdgesTo(rulesProcessor).get(0));
+    }
+
+    @Test
+    public void visitRulesProcessor_connectedFromProcessor() throws Exception {
+        StreamlineProcessor originProcessor = TopologyTestHelper.createStreamlineProcessor("1");
+        RulesProcessor rulesProcessor = TopologyTestHelper.createRulesProcessor("2");
+
+        TopologyDag originTopologyDag = new TopologyDag();
+        originTopologyDag.add(originProcessor);
+        originTopologyDag.add(rulesProcessor);
+        originTopologyDag.addEdge(new Edge("e1", originProcessor, rulesProcessor, "default", Stream.Grouping.SHUFFLE));
+
+        TestTopologyDagCreatingVisitor visitor =
+                new TestTopologyDagCreatingVisitor(originTopologyDag,
+                        Collections.emptyMap(),
+                        Collections.emptyMap());
+
+        visitor.visit(originProcessor);
+        visitor.visit(rulesProcessor);
+
+        TopologyDag testTopologyDag = visitor.getTestTopologyDag();
+
+        assertEquals(1, testTopologyDag.getEdgesFrom(originProcessor).size());
+        assertEquals(1, testTopologyDag.getEdgesTo(rulesProcessor).size());
+
+        assertTrue(testTopologyDag.getEdgesFrom(originProcessor).get(0) == testTopologyDag.getEdgesTo(rulesProcessor).get(0));
+    }
+
+    private TestRunSource createTestRunSource(StreamlineSource originSource) {
+        Map<String, List<Map<String, Object>>> testRecordsMap = new HashMap<>();
+        for (Stream stream : originSource.getOutputStreams()) {
+            testRecordsMap.put(stream.getId(), TopologyTestHelper.createTestRecords());
+        }
+        return new TestRunSource(originSource.getOutputStreams(), testRecordsMap);
+    }
+
+    private TestRunSink createTestRunSink() {
+        return new TestRunSink("dummyFilePath");
+    }
+}

--- a/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunnerTest.java
+++ b/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunnerTest.java
@@ -1,0 +1,561 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.actions.topology.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Files;
+import com.hortonworks.streamline.streams.actions.TopologyActions;
+import com.hortonworks.streamline.streams.actions.utils.TopologyTestHelper;
+import com.hortonworks.streamline.streams.catalog.Topology;
+import com.hortonworks.streamline.streams.catalog.TopologyTestRunCase;
+import com.hortonworks.streamline.streams.catalog.TopologyTestRunCaseSink;
+import com.hortonworks.streamline.streams.catalog.TopologyTestRunCaseSource;
+import com.hortonworks.streamline.streams.catalog.TopologyTestRunHistory;
+import com.hortonworks.streamline.streams.catalog.service.StreamCatalogService;
+import com.hortonworks.streamline.streams.layout.component.Edge;
+import com.hortonworks.streamline.streams.layout.component.Stream;
+import com.hortonworks.streamline.streams.layout.component.StreamlineProcessor;
+import com.hortonworks.streamline.streams.layout.component.StreamlineSink;
+import com.hortonworks.streamline.streams.layout.component.StreamlineSource;
+import com.hortonworks.streamline.streams.layout.component.TopologyDag;
+import com.hortonworks.streamline.streams.layout.component.TopologyLayout;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSink;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSource;
+import mockit.Delegate;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.VerificationsInOrder;
+import mockit.integration.junit4.JMockit;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JMockit.class)
+public class TopologyTestRunnerTest {
+
+    private static String topologyTestRunResultDir;
+
+    @Injectable
+    private StreamCatalogService catalogService;
+
+    @Injectable
+    private TopologyActions topologyActions;
+
+    private TopologyTestRunner topologyTestRunner;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        File tempDir = Files.createTempDir();
+        tempDir.deleteOnExit();
+        topologyTestRunResultDir = tempDir.getAbsolutePath();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        topologyTestRunner = new TopologyTestRunner(catalogService, topologyTestRunResultDir);
+    }
+
+    @Test
+    public void runTest_withTestCaseId() throws Exception {
+        Topology topology = createSimpleDAGInjectedTestTopology();
+
+        Long topologyId = topology.getId();
+        Long testCaseId = 1L;
+        Map<String, Object> testRunInputMap = new HashMap<>();
+        testRunInputMap.put("testCaseId", testCaseId);
+
+        TopologyTestRunCase testCase = new TopologyTestRunCase();
+        testCase.setId(testCaseId);
+        testCase.setTopologyId(topology.getId());
+        testCase.setName("testcase1");
+        testCase.setTimestamp(System.currentTimeMillis());
+
+        setTopologyTestRunCaseExpectations(topology, testCase);
+        setTopologyTestRunCaseSinkNotFoundExpectations(topology, testCase);
+        setTopologyTestRunHistoryExpectations();
+        setSucceedTopologyActionsExpectations();
+
+        long sourceCount = topology.getTopologyDag().getOutputComponents().stream()
+                .filter(c -> c instanceof StreamlineSource)
+                .count();
+
+        long sinkCount = topology.getTopologyDag().getInputComponents().stream()
+                .filter(c -> c instanceof StreamlineSink)
+                .count();
+
+        TopologyTestRunHistory resultHistory = topologyTestRunner.runTest(topologyActions, topology, "",
+                objectMapper.writeValueAsString(testRunInputMap));
+
+        assertNotNull(resultHistory);
+        assertTrue(resultHistory.getFinished());
+        assertTrue(resultHistory.getSuccess());
+
+        new VerificationsInOrder() {{
+            catalogService.getTopologyTestRunCase(topologyId, testCaseId);
+            times = 1;
+
+            catalogService.getTopologyTestRunCaseSourceBySourceId(testCaseId, anyLong);
+            times = (int) sourceCount;
+
+            catalogService.getTopologyTestRunCaseSinkBySinkId(testCaseId, anyLong);
+            times = (int) sinkCount;
+
+            TopologyTestRunHistory runHistory;
+            // some fields are already modified after calling the method, so don't need to capture it
+            catalogService.addTopologyTestRunHistory(withInstanceOf(TopologyTestRunHistory.class));
+            times = 1;
+            catalogService.addOrUpdateTopologyTestRunHistory(anyLong, runHistory = withCapture());
+            times = 1;
+
+            assertEquals(topology.getId(), runHistory.getTopologyId());
+            assertTestRecords(topology, runHistory.getTestRecords());
+            assertTrue(runHistory.getFinished());
+            assertTrue(runHistory.getSuccess());
+            assertNotNull(runHistory.getStartTime());
+            assertNotNull(runHistory.getFinishTime());
+            assertTrue(runHistory.getFinishTime() - runHistory.getStartTime() >= 0);
+            assertTrue(isEmptyJson(runHistory.getExpectedOutputRecords()));
+            assertTrue(isNotEmptyJson(runHistory.getActualOutputRecords()));
+            assertFalse(runHistory.getMatched());
+        }};
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void runTest_withNotExistingTestCaseId() throws Exception {
+        Topology topology = createSimpleDAGInjectedTestTopology();
+
+        Long topologyId = topology.getId();
+        Long testCaseId = 1L;
+        Map<String, Object> testRunInputMap = new HashMap<>();
+        testRunInputMap.put("testCaseId", testCaseId);
+
+        new Expectations() {{
+            catalogService.getTopologyTestRunCase(topologyId, testCaseId);
+            result = null;
+        }};
+
+        topologyTestRunner.runTest(topologyActions, topology, "",
+                objectMapper.writeValueAsString(testRunInputMap));
+    }
+
+    @Test
+    public void runTest_topologyActionsTestRunFails() throws Exception {
+        Topology topology = createSimpleDAGInjectedTestTopology();
+
+        Long topologyId = topology.getId();
+        Long testCaseId = 1L;
+        Map<String, Object> testRunInputMap = new HashMap<>();
+        testRunInputMap.put("testCaseId", testCaseId);
+
+        TopologyTestRunCase testCase = new TopologyTestRunCase();
+        testCase.setId(testCaseId);
+        testCase.setTopologyId(topology.getId());
+        testCase.setName("testcase1");
+        testCase.setTimestamp(System.currentTimeMillis());
+
+        setTopologyTestRunCaseExpectations(topology, testCase);
+        setTopologyTestRunCaseSinkNotFoundExpectations(topology, testCase);
+        setTopologyTestRunHistoryExpectations();
+        setTopologyActionsThrowingExceptionExpectations();
+
+        long sourceCount = topology.getTopologyDag().getOutputComponents().stream()
+                .filter(c -> c instanceof StreamlineSource)
+                .count();
+
+        long sinkCount = topology.getTopologyDag().getInputComponents().stream()
+                .filter(c -> c instanceof StreamlineSink)
+                .count();
+
+        TopologyTestRunHistory resultHistory = topologyTestRunner.runTest(topologyActions, topology, "",
+                objectMapper.writeValueAsString(testRunInputMap));
+
+        assertNotNull(resultHistory);
+
+        new VerificationsInOrder() {{
+            catalogService.getTopologyTestRunCase(topologyId, testCaseId);
+            times = 1;
+
+            catalogService.getTopologyTestRunCaseSourceBySourceId(testCaseId, anyLong);
+            times = (int) sourceCount;
+
+            catalogService.getTopologyTestRunCaseSinkBySinkId(testCaseId, anyLong);
+            times = (int) sinkCount;
+
+            TopologyTestRunHistory runHistory;
+            // some fields are already modified after calling the method, so don't need to capture it
+            catalogService.addTopologyTestRunHistory(withInstanceOf(TopologyTestRunHistory.class));
+            times = 1;
+            catalogService.addOrUpdateTopologyTestRunHistory(anyLong, runHistory = withCapture());
+            times = 1;
+
+            assertEquals(topology.getId(), runHistory.getTopologyId());
+            assertTestRecords(topology, runHistory.getTestRecords());
+            assertTrue(runHistory.getFinished());
+            assertFalse(runHistory.getSuccess());
+            assertNotNull(runHistory.getStartTime());
+            assertNotNull(runHistory.getFinishTime());
+            assertTrue(runHistory.getFinishTime() - runHistory.getStartTime() >= 0);
+            assertTrue(isEmptyJson(runHistory.getExpectedOutputRecords()));
+            assertNull(runHistory.getActualOutputRecords());
+            assertFalse(runHistory.getMatched());
+        }};
+    }
+
+    @Test
+    public void runTest_withMatchedExpectedOutputRecords() throws Exception {
+        Topology topology = createSimpleDAGInjectedTestTopology();
+
+        Long testCaseId = 1L;
+        Map<String, Object> testRunInputMap = new HashMap<>();
+        testRunInputMap.put("testCaseId", testCaseId);
+
+        TopologyTestRunCase testCase = new TopologyTestRunCase();
+        testCase.setId(testCaseId);
+        testCase.setTopologyId(topology.getId());
+        testCase.setName("testcase1");
+        testCase.setTimestamp(System.currentTimeMillis());
+
+        Set<String> sinkNames = topology.getTopologyDag().getInputComponents()
+                .stream()
+                .filter(c -> c instanceof StreamlineSink)
+                .map(c -> c.getName())
+                .collect(Collectors.toSet());
+
+        setTopologyTestRunCaseExpectations(topology, testCase);
+        setTopologyTestRunCaseSinkExpectations(topology, testCase);
+        setTopologyTestRunHistoryExpectations();
+        setSucceedTopologyActionsExpectations();
+
+        TopologyTestRunHistory resultHistory = topologyTestRunner.runTest(topologyActions, topology, "",
+                objectMapper.writeValueAsString(testRunInputMap));
+
+        assertNotNull(resultHistory);
+
+        new VerificationsInOrder() {{
+            TopologyTestRunHistory runHistory;
+            // some fields are already modified after calling the method, so don't need to capture it
+            catalogService.addTopologyTestRunHistory(withInstanceOf(TopologyTestRunHistory.class));
+            times = 1;
+            catalogService.addOrUpdateTopologyTestRunHistory(anyLong, runHistory = withCapture());
+            times = 1;
+
+            assertEquals(topology.getId(), runHistory.getTopologyId());
+            assertTestRecords(topology, runHistory.getTestRecords());
+            assertTrue(runHistory.getFinished());
+            assertTrue(runHistory.getSuccess());
+            assertNotNull(runHistory.getStartTime());
+            assertNotNull(runHistory.getFinishTime());
+            assertTrue(runHistory.getFinishTime() - runHistory.getStartTime() >= 0);
+            assertTrue(isNotEmptyJson(runHistory.getExpectedOutputRecords()));
+            assertTrue(isNotEmptyJson(runHistory.getActualOutputRecords()));
+            assertTrue(runHistory.getMatched());
+        }};
+    }
+
+    @Test
+    public void runTest_withMismatchedExpectedOutputRecords() throws Exception {
+        Topology topology = createSimpleDAGInjectedTestTopology();
+
+        Long testCaseId = 1L;
+        Map<String, Object> testRunInputMap = new HashMap<>();
+        testRunInputMap.put("testCaseId", testCaseId);
+
+        TopologyTestRunCase testCase = new TopologyTestRunCase();
+        testCase.setId(testCaseId);
+        testCase.setTopologyId(topology.getId());
+        testCase.setName("testcase1");
+        testCase.setTimestamp(System.currentTimeMillis());
+
+        setTopologyTestRunCaseExpectations(topology, testCase);
+        setTopologyTestRunCaseSinkMismatchedRecordsExpectations(topology, testCase);
+        setTopologyTestRunHistoryExpectations();
+        setSucceedTopologyActionsExpectations();
+
+        TopologyTestRunHistory resultHistory = topologyTestRunner.runTest(topologyActions, topology, "",
+                objectMapper.writeValueAsString(testRunInputMap));
+
+        assertNotNull(resultHistory);
+
+        new VerificationsInOrder() {{
+            TopologyTestRunHistory runHistory;
+            // some fields are already modified after calling the method, so don't need to capture it
+            catalogService.addTopologyTestRunHistory(withInstanceOf(TopologyTestRunHistory.class));
+            times = 1;
+            catalogService.addOrUpdateTopologyTestRunHistory(anyLong, runHistory = withCapture());
+            times = 1;
+
+            assertEquals(topology.getId(), runHistory.getTopologyId());
+            assertTestRecords(topology, runHistory.getTestRecords());
+            assertTrue(runHistory.getFinished());
+            assertTrue(runHistory.getSuccess());
+            assertNotNull(runHistory.getStartTime());
+            assertNotNull(runHistory.getFinishTime());
+            assertTrue(runHistory.getFinishTime() - runHistory.getStartTime() >= 0);
+            assertTrue(isNotEmptyJson(runHistory.getExpectedOutputRecords()));
+            assertTrue(isNotEmptyJson(runHistory.getActualOutputRecords()));
+            assertFalse(runHistory.getMatched());
+        }};
+    }
+
+    private void setTopologyTestRunHistoryExpectations() throws Exception {
+        new Expectations() {{
+            catalogService.addTopologyTestRunHistory(withInstanceOf(TopologyTestRunHistory.class));
+            result = new Delegate<TopologyTestRunHistory>() {
+                TopologyTestRunHistory delegate(TopologyTestRunHistory history) {
+                    history.setId(1L);
+                    history.setTimestamp(System.currentTimeMillis());
+                    return history;
+                }
+            };
+
+            catalogService.addOrUpdateTopologyTestRunHistory(anyLong, withInstanceOf(TopologyTestRunHistory.class));
+            result = new Delegate<TopologyTestRunHistory>() {
+                TopologyTestRunHistory delegate(Long id, TopologyTestRunHistory history) {
+                    history.setId(id);
+                    history.setTimestamp(System.currentTimeMillis());
+                    return history;
+                }
+            };
+        }};
+    }
+
+    private void setSucceedTopologyActionsExpectations() throws Exception {
+        new Expectations() {{
+            topologyActions.testRun(withInstanceOf(TopologyLayout.class), anyString, withInstanceOf(Map.class),
+                    withInstanceOf(Map.class));
+            result = new Delegate<Object>() {
+                Object delegate(TopologyLayout topology, String mavenArtifacts,
+                                Map<String, TestRunSource> testRunSourcesForEachSource,
+                                Map<String, TestRunSink> testRunSinksForEachSink) throws Exception {
+                    Map<String, List<Map<String, Object>>> testOutputRecords =
+                            TopologyTestHelper.createTestOutputRecords(testRunSinksForEachSink.keySet());
+
+                    testRunSinksForEachSink.entrySet()
+                            .forEach(entry -> {
+                                String sinkName = entry.getKey();
+                                TestRunSink sink = entry.getValue();
+                                try (FileWriter fw = new FileWriter(sink.getOutputFilePath())) {
+                                    List<Map<String, Object>> outputRecords = testOutputRecords.get(sinkName);
+                                    for (Map<String, Object> record : outputRecords) {
+                                        fw.write(objectMapper.writeValueAsString(record) + "\n");
+                                    }
+                                } catch (IOException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            });
+
+                    return null;
+                }
+            };
+        }};
+    }
+
+    private void setTopologyActionsThrowingExceptionExpectations() throws Exception {
+        new Expectations() {{
+            topologyActions.testRun(withInstanceOf(TopologyLayout.class), anyString, withInstanceOf(Map.class),
+                    withInstanceOf(Map.class));
+            result = new RuntimeException("Topology test run failed!");
+        }};
+    }
+
+    private Topology createSimpleDAGInjectedTestTopology() {
+        Long topologyId = 1L;
+        Long topologyVersionId = 1L;
+        Long namespaceId = 1L;
+
+        Topology topology = TopologyTestHelper.createTopology(topologyId, topologyVersionId, namespaceId);
+        injectTestTopology(topology);
+        return topology;
+    }
+
+    private void setTopologyTestRunCaseExpectations(Topology topology, TopologyTestRunCase testCase) {
+        new Expectations() {{
+            catalogService.getTopologyTestRunCase(topology.getId(), testCase.getId());
+            result = testCase;
+
+            topology.getTopologyDag().getOutputComponents().stream()
+                    .filter(c -> c instanceof StreamlineSource)
+                    .forEach(source -> {
+                        catalogService.getTopologyTestRunCaseSourceBySourceId(testCase.getId(), Long.valueOf(source.getId()));
+                        result = createTopologyTestRunCaseSource(testCase, (StreamlineSource) source);
+                    });
+        }};
+    }
+
+    private void setTopologyTestRunCaseSinkExpectations(Topology topology, TopologyTestRunCase testCase) {
+        new Expectations() {{
+            topology.getTopologyDag().getInputComponents().stream()
+                    .filter(c -> c instanceof StreamlineSink)
+                    .forEach(sink -> {
+                        catalogService.getTopologyTestRunCaseSinkBySinkId(testCase.getId(), Long.valueOf(sink.getId()));
+                        result = createTopologyTestRunCaseSink(testCase, (StreamlineSink) sink);
+                    });
+        }};
+    }
+
+    private void setTopologyTestRunCaseSinkMismatchedRecordsExpectations(Topology topology, TopologyTestRunCase testCase) {
+        new Expectations() {{
+            topology.getTopologyDag().getInputComponents().stream()
+                    .filter(c -> c instanceof StreamlineSink)
+                    .forEach(sink -> {
+                        catalogService.getTopologyTestRunCaseSinkBySinkId(testCase.getId(), Long.valueOf(sink.getId()));
+                        result = createTopologyTestRunCaseSinkWithMismatchedRecords(testCase, (StreamlineSink) sink);
+                    });
+        }};
+    }
+
+    private void setTopologyTestRunCaseSinkNotFoundExpectations(Topology topology, TopologyTestRunCase testCase) {
+        new Expectations() {{
+            topology.getTopologyDag().getInputComponents().stream()
+                    .filter(c -> c instanceof StreamlineSink)
+                    .forEach(sink -> {
+                        catalogService.getTopologyTestRunCaseSinkBySinkId(testCase.getId(), Long.valueOf(sink.getId()));
+                        result = null;
+                    });
+        }};
+    }
+
+    private TopologyTestRunCaseSource createTopologyTestRunCaseSource(TopologyTestRunCase testRunCase,
+                                                                      StreamlineSource source) {
+
+        Map<String, List<Map<String, Object>>> testRecords =
+                Collections.singletonMap("default", TopologyTestHelper.createTestRecords());
+
+        TopologyTestRunCaseSource testRunSource = new TopologyTestRunCaseSource();
+        testRunSource.setId(Long.valueOf(source.getId()));
+        testRunSource.setTestCaseId(testRunCase.getId());
+        testRunSource.setSourceId(Long.valueOf(source.getId()));
+        try {
+            testRunSource.setRecords(objectMapper.writeValueAsString(testRecords));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Can't serialize test records map into JSON");
+        }
+
+        testRunSource.setTimestamp(System.currentTimeMillis());
+
+        return testRunSource;
+    }
+
+    private TopologyTestRunCaseSink createTopologyTestRunCaseSink(TopologyTestRunCase testRunCase, StreamlineSink sink) {
+        List<Map<String, Object>> expectedRecords = TopologyTestHelper.createTestRecords();
+
+        TopologyTestRunCaseSink testRunSink = new TopologyTestRunCaseSink();
+        testRunSink.setId(Long.valueOf(sink.getId()));
+        testRunSink.setTestCaseId(testRunCase.getId());
+        testRunSink.setSinkId(Long.valueOf(sink.getId()));
+        try {
+            testRunSink.setRecords(objectMapper.writeValueAsString(expectedRecords));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Can't serialize expected records map into JSON");
+        }
+
+        testRunSink.setTimestamp(System.currentTimeMillis());
+
+        return testRunSink;
+    }
+
+    private TopologyTestRunCaseSink createTopologyTestRunCaseSinkWithMismatchedRecords(TopologyTestRunCase testRunCase,
+                                                                                       StreamlineSink sink) {
+        List<Map<String, Object>> expectedRecords = TopologyTestHelper.createTestRecords();
+        expectedRecords.add(Collections.singletonMap("hello", "world"));
+
+        TopologyTestRunCaseSink testRunSink = new TopologyTestRunCaseSink();
+        testRunSink.setId(Long.valueOf(sink.getId()));
+        testRunSink.setTestCaseId(testRunCase.getId());
+        testRunSink.setSinkId(Long.valueOf(sink.getId()));
+        try {
+            testRunSink.setRecords(objectMapper.writeValueAsString(expectedRecords));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Can't serialize expected records map into JSON");
+        }
+
+        testRunSink.setTimestamp(System.currentTimeMillis());
+
+        return testRunSink;
+    }
+
+    private void injectTestTopology(Topology topology) {
+        StreamlineSource originSource = TopologyTestHelper.createStreamlineSource("1");
+        StreamlineProcessor originProcessor = TopologyTestHelper.createStreamlineProcessor("2");
+        StreamlineSink originSink = TopologyTestHelper.createStreamlineSink("3");
+
+        TopologyDag topologyDag = new TopologyDag();
+        topologyDag.add(originSource);
+        topologyDag.add(originProcessor);
+        topologyDag.add(originSink);
+        topologyDag.addEdge(new Edge("e1", originSource, originProcessor, "default", Stream.Grouping.SHUFFLE));
+        topologyDag.addEdge(new Edge("e2", originProcessor, originSink, "default", Stream.Grouping.SHUFFLE));
+
+        topology.setTopologyDag(topologyDag);
+    }
+
+    private Map<Long, Map<String, List<Map<String, Object>>>> readTestRecordsFromTestCaseSources(Topology topology) {
+        return topology.getTopologyDag().getOutputComponents().stream()
+                .filter(c -> c instanceof StreamlineSource)
+                .collect(toMap(c -> Long.valueOf(c.getId()),
+                        c -> Collections.singletonMap("default", TopologyTestHelper.createTestRecords()))
+                );
+    }
+
+    private void assertTestRecords(Topology topology, String testRecords) {
+        Map<Long, Map<String, List<Map<String, Object>>>> collectedTestRecords = readTestRecordsFromTestCaseSources(topology);
+
+        try {
+            Map<Long, Map<String, List<Map<String, Object>>>> testRecordsMap = objectMapper.readValue(
+                    testRecords, new TypeReference<Map<Long, Map<String, List<Map<String, Object>>>>>() {});
+
+            assertEquals(collectedTestRecords, testRecordsMap);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private boolean isEmptyJson(String expectedOutputRecords) {
+        try {
+            Map<?, ?> recordsMap = (Map<?, ?>) objectMapper.readValue(expectedOutputRecords, Map.class);
+            return recordsMap.isEmpty();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private boolean isNotEmptyJson(String expectedOutputRecords) {
+        return !isEmptyJson(expectedOutputRecords);
+    }
+}

--- a/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/utils/TopologyTestHelper.java
+++ b/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/utils/TopologyTestHelper.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.actions.utils;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.hortonworks.streamline.common.Config;
+import com.hortonworks.registries.common.Schema;
+import com.hortonworks.streamline.streams.catalog.Topology;
+import com.hortonworks.streamline.streams.layout.component.Stream;
+import com.hortonworks.streamline.streams.layout.component.StreamlineProcessor;
+import com.hortonworks.streamline.streams.layout.component.StreamlineSink;
+import com.hortonworks.streamline.streams.layout.component.StreamlineSource;
+import com.hortonworks.streamline.streams.layout.component.impl.RulesProcessor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toMap;
+
+public class TopologyTestHelper {
+
+    private TopologyTestHelper() {
+    }
+
+    public static Topology createTopology(Long id, Long versionId, Long namespaceId) {
+        Topology topology = new Topology();
+        topology.setId(id);
+        topology.setName("testTopology_" + id);
+        topology.setNamespaceId(namespaceId);
+        topology.setVersionId(versionId);
+        topology.setVersionTimestamp(System.currentTimeMillis());
+        return topology;
+    }
+
+    public static StreamlineSource createStreamlineSource(String id) {
+        Stream stream = createDefaultStream();
+        StreamlineSource source = new StreamlineSource(Sets.newHashSet(stream));
+        source.setId(id);
+        source.setName("testSource_" + id);
+        source.setConfig(new Config());
+        source.setTransformationClass("dummyTransformation");
+        return source;
+    }
+
+    public static StreamlineProcessor createStreamlineProcessor(String id) {
+        Stream stream = createDefaultStream();
+        StreamlineProcessor processor = new StreamlineProcessor(Sets.newHashSet(stream));
+        processor.setId(id);
+        processor.setName("testProcessor_" + id);
+        processor.setConfig(new Config());
+        processor.setTransformationClass("dummyTransformation");
+        return processor;
+    }
+
+    public static RulesProcessor createRulesProcessor(String id) {
+        RulesProcessor processor = new RulesProcessor();
+        processor.setId(id);
+        processor.setName("testRuleProcessor_" + id);
+        processor.setConfig(new Config());
+        processor.setTransformationClass("dummyTransformation");
+        processor.setProcessAll(true);
+        processor.setRules(Collections.emptyList());
+        return processor;
+    }
+
+    public static StreamlineSink createStreamlineSink(String id) {
+        StreamlineSink sink = new StreamlineSink();
+        sink.setId(id);
+        sink.setName("testSink_" + id);
+        sink.setConfig(new Config());
+        sink.setTransformationClass("dummyTransformation");
+        return sink;
+    }
+
+    public static List<Map<String, Object>> createTestRecords() {
+        List<Map<String, Object>> testRecords = new ArrayList<>();
+
+        Map<String, Object> testRecord1 = new HashMap<>();
+        testRecord1.put("A", 1);
+        testRecord1.put("B", 2);
+
+        Map<String, Object> testRecord2 = new HashMap<>();
+        testRecord2.put("A", 1);
+        testRecord2.put("B", 2);
+
+        testRecords.add(testRecord1);
+        testRecords.add(testRecord2);
+
+        return testRecords;
+    }
+
+    public static Stream createDefaultStream() {
+        Schema.Field field = Schema.Field.of("A", Schema.Type.INTEGER);
+        Schema.Field field2 = Schema.Field.of("B", Schema.Type.INTEGER);
+        return new Stream("default", Lists.newArrayList(field, field2));
+    }
+
+    public static Map<String, List<Map<String, Object>>> createTestOutputRecords(Set<String> sinkNames) {
+        return sinkNames.stream()
+                .collect(toMap(s -> s, s -> createTestRecords()));
+    }
+
+}

--- a/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/TestRunSinkBoltFluxComponent.java
+++ b/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/TestRunSinkBoltFluxComponent.java
@@ -1,0 +1,51 @@
+/**
+  * Copyright 2017 Hortonworks.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+
+  *   http://www.apache.org/licenses/LICENSE-2.0
+
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.layout.storm;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSink;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestRunSinkBoltFluxComponent extends AbstractFluxComponent {
+    private final Logger log = LoggerFactory.getLogger(TestRunSinkBoltFluxComponent.class);
+
+    protected TestRunSink testRunSink;
+
+    @Override
+    protected void generateComponent() {
+        testRunSink = (TestRunSink) conf.get(StormTopologyLayoutConstants.STREAMLINE_COMPONENT_CONF_KEY);
+        String boltId = "testRunSinkBolt" + UUID_FOR_COMPONENTS;
+        String boltClassName = "com.hortonworks.streamline.streams.runtime.storm.testing.TestRunSinkBolt";
+        List<Object> constructorArgs = new ArrayList<>();
+        ObjectMapper mapper = new ObjectMapper();
+        String testRunSourceJson = null;
+        try {
+            testRunSourceJson = mapper.writeValueAsString(testRunSink);
+        } catch (JsonProcessingException e) {
+            log.error("Error creating json config string for TestRunSink", e);
+        }
+        constructorArgs.add(testRunSourceJson);
+        component = createComponent(boltId, boltClassName, null, constructorArgs, null);
+        addParallelismToComponent();
+    }
+
+}

--- a/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/TestRunSourceSpoutFluxComponent.java
+++ b/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/TestRunSourceSpoutFluxComponent.java
@@ -1,0 +1,50 @@
+/**
+  * Copyright 2017 Hortonworks.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+
+  *   http://www.apache.org/licenses/LICENSE-2.0
+
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.layout.storm;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestRunSourceSpoutFluxComponent extends AbstractFluxComponent {
+    private final Logger log = LoggerFactory.getLogger(TestRunSourceSpoutFluxComponent.class);
+
+    protected TestRunSource testRunSource;
+
+    @Override
+    protected void generateComponent() {
+        testRunSource = (TestRunSource) conf.get(StormTopologyLayoutConstants.STREAMLINE_COMPONENT_CONF_KEY);
+        String spoutId = "testRunSourceSpout" + UUID_FOR_COMPONENTS;
+        String spoutClassName = "com.hortonworks.streamline.streams.runtime.storm.testing.TestRunSourceSpout";
+        List<Object> constructorArgs = new ArrayList<>();
+        ObjectMapper mapper = new ObjectMapper();
+        String testRunSourceJson = null;
+        try {
+            testRunSourceJson = mapper.writeValueAsString(testRunSource);
+        } catch (JsonProcessingException e) {
+            log.error("Error creating json config string for TestRunSource", e);
+        }
+        constructorArgs.add(testRunSourceJson);
+        component = createComponent(spoutId, spoutClassName, null, constructorArgs, null);
+        addParallelismToComponent();
+    }
+
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunSinkBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunSinkBolt.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.runtime.storm.testing;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hortonworks.streamline.common.util.Utils;
+import com.hortonworks.streamline.streams.StreamlineEvent;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSink;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.topology.base.BaseRichBolt;
+import org.apache.storm.tuple.Tuple;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Map;
+
+public class TestRunSinkBolt extends BaseRichBolt {
+    private static final Logger LOG = LoggerFactory.getLogger(TestRunSinkBolt.class);
+
+    private transient OutputCollector collector;
+    private transient ObjectMapper objectMapper;
+
+    private final TestRunSink testRunSink;
+
+    public TestRunSinkBolt(String testRunSinkJson) {
+        this(Utils.createObjectFromJson(testRunSinkJson, TestRunSink.class));
+    }
+
+    public TestRunSinkBolt(TestRunSink testRunSink) {
+        this.testRunSink = testRunSink;
+    }
+
+    @Override
+    public void prepare(Map stormConf, TopologyContext context, OutputCollector collector) {
+        if (this.testRunSink == null) {
+            throw new RuntimeException("testRunSink cannot be null");
+        }
+        if (StringUtils.isEmpty(this.testRunSink.getOutputFilePath())) {
+            throw new RuntimeException("output file path cannot be null or empty");
+        }
+
+        this.collector = collector;
+        this.objectMapper = new ObjectMapper();
+
+        String outputFilePath = testRunSink.getOutputFilePath();
+        LOG.info("output file path: " + outputFilePath);
+        try (FileWriter fw = new FileWriter(outputFilePath, true)) {
+            // no op
+        } catch (IOException e) {
+            LOG.error("Can't open file for preparing to write: " + outputFilePath);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void execute(Tuple input) {
+        String outputFilePath = testRunSink.getOutputFilePath();
+        try (FileWriter fw = new FileWriter(outputFilePath, true)) {
+            LOG.info("writing event to file " + outputFilePath);
+            Object value = input.getValueByField(StreamlineEvent.STREAMLINE_EVENT);
+            StreamlineEvent event = (StreamlineEvent) value;
+            fw.write(objectMapper.writeValueAsString(event) + "\n");
+            fw.flush();
+            collector.ack(input);
+        } catch (FileNotFoundException e) {
+            LOG.error("Can't open file for write: " + outputFilePath);
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            LOG.error("Fail to write event to output file " + outputFilePath + " : exception occurred.", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        // nothing to emit
+    }
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunSourceSpout.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunSourceSpout.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.runtime.storm.testing;
+
+import com.hortonworks.streamline.common.util.Utils;
+import com.hortonworks.streamline.streams.StreamlineEvent;
+import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSource;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.topology.base.BaseRichSpout;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Values;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+
+public class TestRunSourceSpout extends BaseRichSpout {
+    private static final Logger LOG = LoggerFactory.getLogger(TestRunSourceSpout.class);
+    private SpoutOutputCollector _collector;
+
+    private final TestRunSource testRunSource;
+    private final Map<String, Queue<Map<String, Object>>> testRecordsQueueMap;
+
+    public TestRunSourceSpout(String testRunSourceJson) {
+        this(Utils.createObjectFromJson(testRunSourceJson, TestRunSource.class));
+    }
+
+    public TestRunSourceSpout(TestRunSource testRunSource) {
+        this.testRunSource = testRunSource;
+        testRecordsQueueMap = new HashMap<>();
+        if (testRunSource != null) {
+            Map<String, List<Map<String, Object>>> testRecords = testRunSource.getTestRecordsForEachStream();
+            for (Map.Entry<String, List<Map<String, Object>>> entry : testRecords.entrySet()) {
+                testRecordsQueueMap.put(entry.getKey(), new LinkedList<>(entry.getValue()));
+            }
+        }
+    }
+
+    @Override
+    public void open(Map conf, TopologyContext context, SpoutOutputCollector collector) {
+        if (this.testRunSource == null) {
+            throw new RuntimeException("testRunSource cannot be null");
+        }
+        _collector = collector;
+    }
+
+    @Override
+    public void nextTuple() {
+        int emitCount = 0;
+
+        // loop output stream and emit at most one record per output stream
+        for (Map.Entry<String, Queue<Map<String, Object>>> entry : testRecordsQueueMap.entrySet()) {
+            String outputStream = entry.getKey();
+            Queue<Map<String, Object>> queue = entry.getValue();
+
+            Map<String, Object> record = queue.poll();
+            if (record != null) {
+                StreamlineEventImpl streamlineEvent = new StreamlineEventImpl(record, testRunSource.getId());
+                LOG.info("Emitting event {} to stream {}", streamlineEvent, outputStream);
+                _collector.emit(outputStream, new Values(streamlineEvent), streamlineEvent.getId());
+
+                emitCount++;
+            }
+        }
+
+        if (emitCount == 0) {
+            LOG.info("No more records, sleeping...");
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                // no-op
+            }
+            return;
+        }
+    }
+
+    @Override
+    public void ack(Object msgId) {
+        LOG.info("Receive ack for msgid " + msgId);
+    }
+
+    @Override
+    public void fail(Object msgId) {
+        LOG.info("Receive fail for msgid " + msgId);
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        if (testRunSource == null) {
+            throw new RuntimeException("testRunSource cannot be null");
+        }
+        Fields outputFields = getOutputFields();
+        testRunSource.getOutputStreams().forEach(s -> declarer.declareStream(s.getId(), outputFields));
+    }
+
+    public Fields getOutputFields() {
+        return new Fields(StreamlineEvent.STREAMLINE_EVENT);
+    }
+}

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/StreamsModule.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/StreamsModule.java
@@ -134,7 +134,8 @@ public class StreamsModule implements ModuleRegistration, StorageManagerAware {
                 new RuleCatalogResource(authorizer, streamcatalogService),
                 new BranchRuleCatalogResource(authorizer, streamcatalogService),
                 new WindowCatalogResource(authorizer, streamcatalogService),
-                new TopologyEditorToolbarResource(authorizer, streamcatalogService, securityCatalogService)
+                new TopologyEditorToolbarResource(authorizer, streamcatalogService, securityCatalogService),
+                new TopologyTestRunResource(streamcatalogService, actionsService)
         );
     }
 

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyCatalogResource.java
@@ -23,6 +23,8 @@ import com.google.common.base.Stopwatch;
 import com.hortonworks.streamline.common.exception.service.exception.request.BadRequestException;
 import com.hortonworks.streamline.common.exception.service.exception.request.EntityNotFoundException;
 import com.hortonworks.streamline.common.exception.service.exception.request.TopologyAlreadyExistsOnCluster;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import com.hortonworks.streamline.common.util.ParallelStreamUtil;
 import com.hortonworks.streamline.common.util.WSUtils;
 import com.hortonworks.streamline.streams.actions.TopologyActions;
@@ -41,9 +43,6 @@ import com.hortonworks.streamline.streams.security.Roles;
 import com.hortonworks.streamline.streams.security.SecurityUtil;
 import com.hortonworks.streamline.streams.security.StreamlineAuthorizer;
 import com.hortonworks.streamline.streams.storm.common.StormNotReachableException;
-import com.hortonworks.streamline.streams.storm.common.TopologyNotAliveException;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,7 +94,6 @@ public class TopologyCatalogResource {
     private static final Boolean DEFAULT_SORT_ORDER_ASCENDING = false;
 
     private static final int FORK_JOIN_POOL_PARALLELISM = 10;
-
     private final ForkJoinPool forkJoinPool = new ForkJoinPool(FORK_JOIN_POOL_PARALLELISM);
 
     private final URL SCHEMA = Thread.currentThread().getContextClassLoader()
@@ -454,6 +452,7 @@ public class TopologyCatalogResource {
         }
         throw EntityNotFoundException.byId(topologyId.toString());
     }
+
 
     @POST
     @Path("/topologies/{topologyId}/versions/{versionId}/actions/deploy")

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyTestRunResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyTestRunResource.java
@@ -1,0 +1,327 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.streamline.streams.service;
+
+import com.codahale.metrics.annotation.Timed;
+import com.hortonworks.streamline.common.exception.service.exception.request.BadRequestException;
+import com.hortonworks.streamline.common.exception.service.exception.request.EntityNotFoundException;
+import com.hortonworks.streamline.common.util.WSUtils;
+import com.hortonworks.streamline.streams.actions.topology.service.TopologyActionsService;
+import com.hortonworks.streamline.streams.catalog.Topology;
+import com.hortonworks.streamline.streams.catalog.TopologyTestRunCase;
+import com.hortonworks.streamline.streams.catalog.TopologyTestRunCaseSink;
+import com.hortonworks.streamline.streams.catalog.TopologyTestRunCaseSource;
+import com.hortonworks.streamline.streams.catalog.TopologyTestRunHistory;
+import com.hortonworks.streamline.streams.catalog.service.StreamCatalogService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.Collection;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.OK;
+
+@Path("/v1/catalog")
+@Produces(MediaType.APPLICATION_JSON)
+public class TopologyTestRunResource {
+    private static final Logger LOG = LoggerFactory.getLogger(TopologyTestRunResource.class);
+
+    private static final Integer DEFAULT_LIST_ENTITIES_COUNT = 5;
+
+    private final StreamCatalogService catalogService;
+    private final TopologyActionsService actionsService;
+
+    public TopologyTestRunResource(StreamCatalogService catalogService, TopologyActionsService actionsService) {
+        this.catalogService = catalogService;
+        this.actionsService = actionsService;
+    }
+
+    @POST
+    @Path("/topologies/{topologyId}/actions/testrun")
+    @Timed
+    public Response testRunTopology (@Context UriInfo urlInfo,
+                                     @PathParam("topologyId") Long topologyId,
+                                     String testRunInputJson) throws Exception {
+        Topology result = catalogService.getTopology(topologyId);
+        if (result != null) {
+            TopologyTestRunHistory history = actionsService.testRunTopology(result, testRunInputJson);
+            return WSUtils.respondEntity(history, OK);
+        }
+
+        throw EntityNotFoundException.byId(topologyId.toString());
+    }
+
+    @GET
+    @Path("/topologies/{topologyId}/actions/testrun/histories")
+    @Timed
+    public Response getHistoriesOfTestRunTopology (@Context UriInfo urlInfo,
+                                                   @PathParam("topologyId") Long topologyId,
+                                                   @QueryParam("limit") Integer limit) throws Exception {
+        Collection<TopologyTestRunHistory> histories = catalogService.listTopologyTestRunHistory(topologyId);
+        if (histories == null) {
+            throw EntityNotFoundException.byFilter("topology id " + topologyId);
+        }
+
+        List<TopologyTestRunHistory> filteredHistories = filterHistories(limit, histories);
+        return WSUtils.respondEntities(filteredHistories, OK);
+    }
+
+    @GET
+    @Path("/topologies/{topologyId}/versions/{versionId}/actions/testrun/histories")
+    @Timed
+    public Response getHistoriesOfTestRunTopology (@Context UriInfo urlInfo,
+                                                   @PathParam("topologyId") Long topologyId,
+                                                   @PathParam("versionId") Long versionId,
+                                                   @QueryParam("limit") Integer limit) throws Exception {
+        Collection<TopologyTestRunHistory> histories = catalogService.listTopologyTestRunHistory(topologyId, versionId);
+        if (histories == null) {
+            throw EntityNotFoundException.byFilter("topology id " + topologyId);
+        }
+
+        List<TopologyTestRunHistory> filteredHistories = filterHistories(limit, histories);
+        return WSUtils.respondEntities(filteredHistories, OK);
+    }
+
+    private List<TopologyTestRunHistory> filterHistories(Integer limit, Collection<TopologyTestRunHistory> histories) {
+        if (limit == null) {
+            limit = DEFAULT_LIST_ENTITIES_COUNT;
+        }
+
+        return histories.stream()
+                // reverse order
+                .sorted((h1, h2) -> (int) (h2.getId() - h1.getId()))
+                .limit(limit)
+                .collect(toList());
+    }
+
+    @POST
+    @Path("/topologies/{topologyId}/testcases")
+    public Response addTestRunCase(@PathParam("topologyId") Long topologyId,
+                                      TopologyTestRunCase testRunCase) {
+        testRunCase.setTopologyId(topologyId);
+        TopologyTestRunCase addedCase = catalogService.addTopologyTestRunCase(testRunCase);
+        return WSUtils.respondEntity(addedCase, CREATED);
+    }
+
+    @PUT
+    @Path("/topologies/{topologyId}/testcases/{testCaseId}")
+    public Response addOrUpdateTestRunCase(@PathParam("topologyId") Long topologyId,
+                                           @PathParam("testCaseId") Long testCaseId,
+                                           TopologyTestRunCase testRunCase) {
+        testRunCase.setTopologyId(topologyId);
+        testRunCase.setId(testCaseId);
+        TopologyTestRunCase updatedCase = catalogService.addOrUpdateTopologyTestRunCase(topologyId, testRunCase);
+        return WSUtils.respondEntity(updatedCase, OK);
+    }
+
+    @GET
+    @Path("/topologies/{topologyId}/testcases/{testCaseId}")
+    public Response getTestRunCase(@PathParam("topologyId") Long topologyId,
+                                   @PathParam("testCaseId") Long testCaseId) {
+        TopologyTestRunCase testcase = catalogService.getTopologyTestRunCase(topologyId, testCaseId);
+        if (testcase == null) {
+            throw EntityNotFoundException.byId(Long.toString(testCaseId));
+        }
+
+        return WSUtils.respondEntity(testcase, OK);
+    }
+
+    @GET
+    @Path("/topologies/{topologyId}/testcases")
+    @Timed
+    public Response listTestRunCases(@Context UriInfo urlInfo,
+                                     @PathParam("topologyId") Long topologyId,
+                                     @QueryParam("limit") Integer limit) throws Exception {
+        Collection<TopologyTestRunCase> cases = catalogService.listTopologyTestRunCase(topologyId);
+
+        if (cases == null) {
+            throw EntityNotFoundException.byFilter("topology id " + topologyId);
+        }
+
+        List<TopologyTestRunCase> filteredCases = filterTestRunCases(limit, cases);
+        return WSUtils.respondEntities(filteredCases, OK);
+    }
+
+    @DELETE
+    @Path("/topologies/{topologyId}/testcases/{testCaseId}")
+    public Response removeTestRunCase(@PathParam("topologyId") Long topologyId,
+                                      @PathParam("testCaseId") Long testCaseId) {
+        TopologyTestRunCase testRunCase = catalogService.removeTestRunCase(topologyId, testCaseId);
+        if (testRunCase != null) {
+            return WSUtils.respondEntity(testRunCase, OK);
+        }
+
+        throw EntityNotFoundException.byId(testCaseId.toString());
+    }
+
+    private List<TopologyTestRunCase> filterTestRunCases(Integer limit, Collection<TopologyTestRunCase> cases) {
+        if (limit == null) {
+            limit = DEFAULT_LIST_ENTITIES_COUNT;
+        }
+
+        return cases.stream()
+                // reverse order
+                .sorted((h1, h2) -> (int) (h2.getId() - h1.getId()))
+                .limit(limit)
+                .collect(toList());
+    }
+
+    @POST
+    @Path("/topologies/{topologyId}/testcases/{testCaseId}/sources")
+    public Response addTestRunCaseSource(@PathParam("topologyId") Long topologyId,
+                                         @PathParam("testCaseId") Long testCaseId,
+                                         TopologyTestRunCaseSource testRunCaseSource) {
+        TopologyTestRunCase testCase = catalogService.getTopologyTestRunCase(topologyId, testCaseId);
+        if (testCase == null) {
+            throw EntityNotFoundException.byId("Topology test case with topology id " + topologyId +
+                    " and test case id " + testCaseId);
+        }
+
+        TopologyTestRunCaseSource addedCaseSource = catalogService.addTopologyTestRunCaseSource(testRunCaseSource);
+        return WSUtils.respondEntity(addedCaseSource, CREATED);
+    }
+
+    @PUT
+    @Path("/topologies/{topologyId}/testcases/{testCaseId}/sources/{id}")
+    public Response addOrUpdateTestRunCaseSource(@PathParam("topologyId") Long topologyId,
+                                           @PathParam("testCaseId") Long testCaseId,
+                                           @PathParam("id") Long id,
+                                           TopologyTestRunCaseSource testRunCaseSource) {
+        testRunCaseSource.setTestCaseId(testCaseId);
+        testRunCaseSource.setId(id);
+        TopologyTestRunCaseSource updatedCase = catalogService.addOrUpdateTopologyTestRunCaseSource(testRunCaseSource.getId(), testRunCaseSource);
+        return WSUtils.respondEntity(updatedCase, OK);
+    }
+
+    @GET
+    @Path("/topologies/{topologyId}/testcases/{testcaseId}/sources/{id}")
+    public Response getTestRunCaseSource(@PathParam("topologyId") Long topologyId,
+                                         @PathParam("testcaseId") Long testcaseId,
+                                         @PathParam("id") Long id) {
+        TopologyTestRunCaseSource testCaseSource = catalogService.getTopologyTestRunCaseSource(testcaseId, id);
+        if (testCaseSource == null) {
+            throw EntityNotFoundException.byId(Long.toString(id));
+        }
+
+        return WSUtils.respondEntity(testCaseSource, OK);
+    }
+
+    @GET
+    @Path("/topologies/{topologyId}/testcases/{testCaseId}/sources/topologysource/{sourceId}")
+    public Response getTestRunCaseSourceByTopologySource(@PathParam("topologyId") Long topologyId,
+                                                         @PathParam("testCaseId") Long testCaseId,
+                                                         @PathParam("sourceId") Long sourceId) {
+        TopologyTestRunCaseSource testCaseSource = catalogService.getTopologyTestRunCaseSourceBySourceId(testCaseId, sourceId);
+        if (testCaseSource == null) {
+            throw EntityNotFoundException.byId("test case id: " + testCaseId + " , topology source id: " + sourceId);
+        }
+
+        return WSUtils.respondEntity(testCaseSource, OK);
+    }
+
+    @GET
+    @Path("/topologies/{topologyId}/testcases/{testCaseId}/sources")
+    public Response listTestRunCaseSource(@PathParam("topologyId") Long topologyId,
+                                          @PathParam("testCaseId") Long testCaseId) {
+        Collection<TopologyTestRunCaseSource> sources = catalogService.listTopologyTestRunCaseSource(topologyId, testCaseId);
+        if (sources == null) {
+            throw EntityNotFoundException.byFilter("topologyId: " + topologyId + " / testCaseId: " + testCaseId);
+        }
+
+        return WSUtils.respondEntities(sources, OK);
+    }
+
+    @POST
+    @Path("/topologies/{topologyId}/testcases/{testCaseId}/sinks")
+    public Response addTestRunCaseSink(@PathParam("topologyId") Long topologyId,
+                                         @PathParam("testCaseId") Long testCaseId,
+                                         TopologyTestRunCaseSink testRunCaseSink) {
+        TopologyTestRunCase testCase = catalogService.getTopologyTestRunCase(topologyId, testCaseId);
+        if (testCase == null) {
+            throw EntityNotFoundException.byId("Topology test case with topology id " + topologyId +
+                    " and test case id " + testCaseId);
+        }
+
+        TopologyTestRunCaseSink addedCaseSink = catalogService.addTopologyTestRunCaseSink(testRunCaseSink);
+        return WSUtils.respondEntity(addedCaseSink, CREATED);
+    }
+
+    @PUT
+    @Path("/topologies/{topologyId}/testcases/{testCaseId}/sinks/{id}")
+    public Response addOrUpdateTestRunCaseSink(@PathParam("topologyId") Long topologyId,
+                                           @PathParam("testCaseId") Long testCaseId,
+                                           @PathParam("id") Long id,
+                                           TopologyTestRunCaseSink testRunCaseSink) {
+        testRunCaseSink.setTestCaseId(testCaseId);
+        testRunCaseSink.setId(id);
+        TopologyTestRunCaseSink updatedCase = catalogService.addOrUpdateTopologyTestRunCaseSink(testRunCaseSink.getId(), testRunCaseSink);
+        return WSUtils.respondEntity(updatedCase, OK);
+    }
+
+    @GET
+    @Path("/topologies/{topologyId}/testcases/{testcaseId}/sinks/{id}")
+    public Response getTestRunCaseSink(@PathParam("topologyId") Long topologyId,
+                                         @PathParam("testcaseId") Long testcaseId,
+                                         @PathParam("id") Long id) {
+        TopologyTestRunCaseSink testCaseSink = catalogService.getTopologyTestRunCaseSink(testcaseId, id);
+        if (testCaseSink == null) {
+            throw EntityNotFoundException.byId(Long.toString(id));
+        }
+
+        return WSUtils.respondEntity(testCaseSink, OK);
+    }
+
+    @GET
+    @Path("/topologies/{topologyId}/testcases/{testCaseId}/sinks/topologysink/{sinkId}")
+    public Response getTestRunCaseSinkByTopologySink(@PathParam("topologyId") Long topologyId,
+                                                         @PathParam("testCaseId") Long testCaseId,
+                                                         @PathParam("sinkId") Long sinkId) {
+        TopologyTestRunCaseSink testCaseSink = catalogService.getTopologyTestRunCaseSinkBySinkId(testCaseId, sinkId);
+        if (testCaseSink == null) {
+            throw EntityNotFoundException.byId("test case id: " + testCaseId + " , topology source id: " + sinkId);
+        }
+
+        return WSUtils.respondEntity(testCaseSink, OK);
+    }
+
+    @GET
+    @Path("/topologies/{topologyId}/testcases/{testCaseId}/sinks")
+    public Response listTestRunCaseSink(@PathParam("topologyId") Long topologyId,
+                                          @PathParam("testCaseId") Long testCaseId) {
+        Collection<TopologyTestRunCaseSink> sources = catalogService.listTopologyTestRunCaseSink(topologyId, testCaseId);
+        if (sources == null) {
+            throw EntityNotFoundException.byFilter("topologyId: " + topologyId + " / testCaseId: " + testCaseId);
+        }
+
+        return WSUtils.respondEntities(sources, OK);
+    }
+
+}

--- a/webservice/src/test/resources/streamline-test.yaml
+++ b/webservice/src/test/resources/streamline-test.yaml
@@ -9,6 +9,8 @@ modules:
       #change the below to the path on your local machine
       streamlineStormJar: /tmp/streamline-runtime-storm-0.1.0-SNAPSHOT.jar
       stormHomeDir: /usr/local/Cellar/storm/0.10.0/
+      # directory to store the results of topology test run
+      topologyTestRunResultDir: /tmp
       # schema registry configuration
       schemaRegistryUrl: "http://localhost:9090/api/v1"
       #Custom processor upload configuration


### PR DESCRIPTION
This is on top of #518. I've fixed a NPE bug so might be better to move on and integrate UI based on this directly. I can fix the bug from #518 if needed.

With this patch, topology test run goes asynchronously. It will only be blocked for constructing history for initial state, and return initial state of history. 
Later phases will be done in async (background).

Also added new API endpoint: GET topology run history (with 'simplify' param) and changed some API endpoint path to reduce length.
Please refer API Endpoints description for more details.

@shahsank3t @harshach Please review, test and comment. Thanks in advance.

----


API Endpoints
----

> POST /api/v1/catalog/topologies/:topologyId/testcases

>> Description

The endpoint adds test case for topology test run. Note that actual test records are stored to topology test run case source for each source.

>> Input parameters

* JSON String payload representing TopologyTestRunCase

```
{
  "name": "testcase1",
  "topologyId": 1
}
```

> PUT/GET/DELETE API endpoints for `testcases` available

> POST /api/v1/catalog/topologies/:topologyId/testcases/:testcaseId/sources

>> Description

The endpoint adds actual test records for specific test source on test case.

>> Input parameters

* JSON String payload representing TopologyTestRunCaseSource

```
{
  "testCaseId": 1,
  "sourceId": 1,
  "records": "{\"kafka_stream_1\": [{\"driverId\":24,\"truckId\":97,\"eventTime\":\"00:13.0\",\"eventType\":\"Normal\",\"longitude\":-88.77,\"latitude\":40.76,\"eventKey\":\"24|97|9223370572464762855\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Don Hilborn\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":426},{\"driverId\":32,\"truckId\":42,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-90.04,\"latitude\":35.19,\"eventKey\":\"32|42|9223370572464762755\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Ryan Templeton\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":183},{\"driverId\":31,\"truckId\":18,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-94.35,\"latitude\":38.33,\"eventKey\":\"31|18|9223370572464762726\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Rommel Garcia\",\"routeId\":1594289134,\"routeName\":\"Memphis to Little Rock Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":34}]}"
}
```

> PUT/GET/LIST API endpoints for `testcases/sources` available (Do we need to have DELETE for sources?)

> GET /api/v1/catalog/topologies/:topologyId/testcases/:testcaseId/sources/topologysource/:topologySourceId

>> Similar as GET API endpoints for `testcases/sources`, but makes possible to get via topologySourceId rather than sourceId (topology test run case source's id)

> POST /api/v1/catalog/topologies/:topologyId/testcases/:testcaseId/sinks

>> Description

The endpoint adds expected records for specific test sink on test case.

>> Input parameters

* JSON String payload representing TopologyTestRunCaseSink

```
{
  "testCaseId": 2,
  "sinkId": 10,
  "records": "[{\"driverId\":24,\"truckId\":97,\"eventTime\":\"00:13.0\",\"eventType\":\"Normal\",\"longitude\":-88.77,\"latitude\":40.76,\"eventKey\":\"24|97|9223370572464762855\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Don Hilborn\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":426},{\"driverId\":32,\"truckId\":42,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-90.04,\"latitude\":35.19,\"eventKey\":\"32|42|9223370572464762755\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Ryan Templeton\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":183},{\"driverId\":31,\"truckId\":18,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-94.35,\"latitude\":38.33,\"eventKey\":\"31|18|9223370572464762726\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Rommel Garcia\",\"routeId\":1594289134,\"routeName\":\"Memphis to Little Rock Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":34}]"
}
```

> PUT/GET/LIST API endpoints for `testcases/sinks` available (Do we need to have DELETE for sinks?)

> GET /api/v1/catalog/topologies/:topologyId/testcases/:testcaseId/sinks/topologysink/:topologySinkId

>> Similar as GET API endpoints for `testcases/sinks`, but makes possible to get via topologySinkId rather than sinkId (topology test run case sink's id)

> POST /api/v1/catalog/topologies/:topologyId/actions/testrun

>> Description

The endpoint runs given topology on test mode, and return the result of test run. Implementation details for running topology on test mode will be covered later.

>> Input parameters

* topologyId (Long)
* JSON String payload containing either test case ID

```
{
  “testCaseId”: 1
}
```

Assertion: All data sources should be covered. It will return HTTP status 400 if the assertion fails.

>> Output Format (success case)

Please refer the output format of GET topology test history. (simplify=false)

> GET /api/v1/catalog/topologies/:topologyId/(versions/:versionId)/testhistories

>> Description

The endpoint retrieves the histories of topology test run for given topology, and return recent N history entities.

>> Input parameters

* topologyId (Long)
* limit (Int) - optional, will fix the default value

>> Output format (success case)

On succeed case, the response shows history entities matched to given criteria.

```
[
  {
    "id": 99,
    "topologyId": 1,
    "versionId": 1,
    "testRecords": "{\"1\":{\"kafka_stream_1\":[{\"driverId\":24,\"truckId\":97,\"eventTime\":\"00:13.0\",\"eventType\":\"Normal\",\"longitude\":-88.77,\"latitude\":40.76,\"eventKey\":\"24|97|9223370572464762855\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Don Hilborn\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":426},{\"driverId\":32,\"truckId\":42,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-90.04,\"latitude\":35.19,\"eventKey\":\"32|42|9223370572464762755\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Ryan Templeton\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":183},{\"driverId\":31,\"truckId\":18,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-94.35,\"latitude\":38.33,\"eventKey\":\"31|18|9223370572464762726\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Rommel Garcia\",\"routeId\":1594289134,\"routeName\":\"Memphis to Little Rock Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":34}]},\"2\":{\"kafka_stream_2\":[{\"driverId\":24,\"truckId\":97,\"eventTime\":\"00:13.0\",\"eventType\":\"Normal\",\"longitude\":-88.77,\"latitude\":40.76,\"eventKey\":\"24|97|9223370572464762855\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Don Hilborn\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":426},{\"driverId\":32,\"truckId\":42,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-90.04,\"latitude\":35.19,\"eventKey\":\"32|42|9223370572464762755\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Ryan Templeton\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":183},{\"driverId\":31,\"truckId\":18,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-94.35,\"latitude\":38.33,\"eventKey\":\"31|18|9223370572464762726\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Rommel Garcia\",\"routeId\":1594289134,\"routeName\":\"Memphis to Little Rock Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":34}]}}"
    "finish": true,
    "success": true,
    "expectedOutputRecords": "{\"KAFKA-SINK-1\":[{\"driverId\":24,\"truckId\":97,\"eventTime\":\"00:13.0\",\"eventType\":\"Normal\",\"longitude\":-88.77,\"latitude\":40.76,\"eventKey\":\"24|97|9223370572464762855\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Don Hilborn\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":426},{\"driverId\":32,\"truckId\":42,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-90.04,\"latitude\":35.19,\"eventKey\":\"32|42|9223370572464762755\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Ryan Templeton\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":183},{\"driverId\":31,\"truckId\":18,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-94.35,\"latitude\":38.33,\"eventKey\":\"31|18|9223370572464762726\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Rommel Garcia\",\"routeId\":1594289134,\"routeName\":\"Memphis to Little Rock Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":34}],\"KAFKA-1\":[{\"driverId\":24,\"truckId\":97,\"eventTime\":\"00:13.0\",\"eventType\":\"Normal\",\"longitude\":-88.77,\"latitude\":40.76,\"eventKey\":\"24|97|9223370572464762855\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Don Hilborn\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":426},{\"driverId\":32,\"truckId\":42,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-90.04,\"latitude\":35.19,\"eventKey\":\"32|42|9223370572464762755\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Ryan Templeton\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":183},{\"driverId\":31,\"truckId\":18,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-94.35,\"latitude\":38.33,\"eventKey\":\"31|18|9223370572464762726\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Rommel Garcia\",\"routeId\":1594289134,\"routeName\":\"Memphis to Little Rock Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":34}]}",
    "actualOutputRecords": "{\"KAFKA-SINK-1\":[{\"driverId\":24,\"truckId\":97,\"eventTime\":\"00:13.0\",\"eventType\":\"Normal\",\"longitude\":-88.77,\"latitude\":40.76,\"eventKey\":\"24|97|9223370572464762855\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Don Hilborn\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":426},{\"driverId\":32,\"truckId\":42,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-90.04,\"latitude\":35.19,\"eventKey\":\"32|42|9223370572464762755\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Ryan Templeton\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":183},{\"driverId\":31,\"truckId\":18,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-94.35,\"latitude\":38.33,\"eventKey\":\"31|18|9223370572464762726\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Rommel Garcia\",\"routeId\":1594289134,\"routeName\":\"Memphis to Little Rock Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":34}],\"KAFKA-1\":[{\"driverId\":24,\"truckId\":97,\"eventTime\":\"00:13.0\",\"eventType\":\"Normal\",\"longitude\":-88.77,\"latitude\":40.76,\"eventKey\":\"24|97|9223370572464762855\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Don Hilborn\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":426},{\"driverId\":32,\"truckId\":42,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-90.04,\"latitude\":35.19,\"eventKey\":\"32|42|9223370572464762755\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Ryan Templeton\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":183},{\"driverId\":31,\"truckId\":18,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-94.35,\"latitude\":38.33,\"eventKey\":\"31|18|9223370572464762726\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Rommel Garcia\",\"routeId\":1594289134,\"routeName\":\"Memphis to Little Rock Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":34}]}",
    “matched” : true,
    "startTime": 1234567890,
    "finishTime": 2345678901,
    "timestamp": 2345678901
  },
  …
]
```

> GET /api/v1/catalog/topologies/:topologyId/(versions/:versionId)/testhistories/:historyId

>> Description

The endpoint retrieves a history of topology test run for given topology.

>> Input parameters

* topologyId (Long)
* simplify (Boolean) - optional, default = false

>> Output format (success case)

On succeed case, the response shows history entity matched to given criteria.

* `simplify = true`:

```
{
  "id": 18,
  "topologyId": 1,
  "versionId": null,
  "finished": true,
  "success": true,
  "matched": true,
  "startTime": 1491807166624,
  "finishTime": 1491807214064,
  "timestamp": 1491807214068
}
```

* `simplify = false`:
```
{
  "id": 18,
  "topologyId": 1,
  "versionId": null,
  "testRecords": "{\"1\":{\"kafka_stream_1\":[{\"driverId\":24,\"truckId\":97,\"eventTime\":\"00:13.0\",\"eventType\":\"Normal\",\"longitude\":-88.77,\"latitude\":40.76,\"eventKey\":\"24|97|9223370572464762855\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Don Hilborn\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":426},{\"driverId\":32,\"truckId\":42,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-90.04,\"latitude\":35.19,\"eventKey\":\"32|42|9223370572464762755\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Ryan Templeton\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":183},{\"driverId\":31,\"truckId\":18,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-94.35,\"latitude\":38.33,\"eventKey\":\"31|18|9223370572464762726\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Rommel Garcia\",\"routeId\":1594289134,\"routeName\":\"Memphis to Little Rock Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":34}]},\"2\":{\"kafka_stream_2\":[{\"driverId\":24,\"truckId\":97,\"eventTime\":\"00:13.0\",\"eventType\":\"Normal\",\"longitude\":-88.77,\"latitude\":40.76,\"eventKey\":\"24|97|9223370572464762855\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Don Hilborn\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":426},{\"driverId\":32,\"truckId\":42,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-90.04,\"latitude\":35.19,\"eventKey\":\"32|42|9223370572464762755\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Ryan Templeton\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":183},{\"driverId\":31,\"truckId\":18,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-94.35,\"latitude\":38.33,\"eventKey\":\"31|18|9223370572464762726\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Rommel Garcia\",\"routeId\":1594289134,\"routeName\":\"Memphis to Little Rock Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":34}]}}",
  "finished": true,
  "success": true,
  "expectedOutputRecords": "{\"KAFKA-SINK-1\":[{\"driverId\":24,\"truckId\":97,\"eventTime\":\"00:13.0\",\"eventType\":\"Normal\",\"longitude\":-88.77,\"latitude\":40.76,\"eventKey\":\"24|97|9223370572464762855\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Don Hilborn\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":426},{\"driverId\":32,\"truckId\":42,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-90.04,\"latitude\":35.19,\"eventKey\":\"32|42|9223370572464762755\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Ryan Templeton\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":183},{\"driverId\":31,\"truckId\":18,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-94.35,\"latitude\":38.33,\"eventKey\":\"31|18|9223370572464762726\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Rommel Garcia\",\"routeId\":1594289134,\"routeName\":\"Memphis to Little Rock Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":34}],\"KAFKA-1\":[{\"driverId\":24,\"truckId\":97,\"eventTime\":\"00:13.0\",\"eventType\":\"Normal\",\"longitude\":-88.77,\"latitude\":40.76,\"eventKey\":\"24|97|9223370572464762855\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Don Hilborn\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":426},{\"driverId\":32,\"truckId\":42,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-90.04,\"latitude\":35.19,\"eventKey\":\"32|42|9223370572464762755\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Ryan Templeton\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":183},{\"driverId\":31,\"truckId\":18,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-94.35,\"latitude\":38.33,\"eventKey\":\"31|18|9223370572464762726\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Rommel Garcia\",\"routeId\":1594289134,\"routeName\":\"Memphis to Little Rock Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":34}]}",
  "actualOutputRecords": "{\"KAFKA-SINK-1\":[{\"driverId\":24,\"truckId\":97,\"eventTime\":\"00:13.0\",\"eventType\":\"Normal\",\"longitude\":-88.77,\"latitude\":40.76,\"eventKey\":\"24|97|9223370572464762855\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Don Hilborn\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":426},{\"driverId\":32,\"truckId\":42,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-90.04,\"latitude\":35.19,\"eventKey\":\"32|42|9223370572464762755\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Ryan Templeton\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":183},{\"driverId\":31,\"truckId\":18,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-94.35,\"latitude\":38.33,\"eventKey\":\"31|18|9223370572464762726\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Rommel Garcia\",\"routeId\":1594289134,\"routeName\":\"Memphis to Little Rock Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":34}],\"KAFKA-1\":[{\"driverId\":24,\"truckId\":97,\"eventTime\":\"00:13.0\",\"eventType\":\"Normal\",\"longitude\":-88.77,\"latitude\":40.76,\"eventKey\":\"24|97|9223370572464762855\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Don Hilborn\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":426},{\"driverId\":32,\"truckId\":42,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-90.04,\"latitude\":35.19,\"eventKey\":\"32|42|9223370572464762755\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Ryan Templeton\",\"routeId\":1090292248,\"routeName\":\"Peoria to Ceder Rapids Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":183},{\"driverId\":31,\"truckId\":18,\"eventTime\":\"00:13.1\",\"eventType\":\"Normal\",\"longitude\":-94.35,\"latitude\":38.33,\"eventKey\":\"31|18|9223370572464762726\",\"correlationId\":\"3.66088E+18\",\"driverName\":\"Rommel Garcia\",\"routeId\":1594289134,\"routeName\":\"Memphis to Little Rock Route 2\",\"eventDate\":\"2016-05-27-22\",\"miles\":34}]}",
  "matched": true,
  "startTime": 1491807166624,
  "finishTime": 1491807214064,
  "timestamp": 1491807214068
}
```