### PR TITLE
STREAMLINE-751 Email as service option in Manual Cluster

### DIFF
--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -166,6 +166,7 @@ function add_all_bundles {
     post /servicebundles ${service_dir}/hdfs-bundle.json
     post /servicebundles ${service_dir}/hbase-bundle.json
     post /servicebundles ${service_dir}/hive-bundle.json
+    post /servicebundles ${service_dir}/email-bundle.json
 
     # === anonymous user ===
     post /users ${user_role_dir}/user_anon.json

--- a/bootstrap/components/sinks/notification-sink-topology-component.json
+++ b/bootstrap/components/sinks/notification-sink-topology-component.json
@@ -5,6 +5,7 @@
   "builtin": true,
   "streamingEngine": "STORM",
   "transformationClass": "com.hortonworks.streamline.streams.layout.storm.NotificationBoltFluxComponent",
+  "fieldHintProviderClass": "com.hortonworks.streamline.streams.cluster.bundle.impl.NotificationSinkBundleHintProvider",
   "topologyComponentUISpecification": {
     "fields": [
       {

--- a/bootstrap/services/email-bundle.json
+++ b/bootstrap/services/email-bundle.json
@@ -1,0 +1,54 @@
+{
+  "name": "EMAIL",
+  "registerClass": "com.hortonworks.streamline.streams.cluster.register.impl.EmailServiceRegistrar",
+  "serviceUISpecification": {
+    "fields": [
+      {
+        "uiName": "Host",
+        "fieldName": "host",
+        "isOptional": false,
+        "tooltip": "Hostname for email server",
+        "type": "string"
+      },
+      {
+        "uiName": "Port",
+        "fieldName": "port",
+        "isOptional": false,
+        "tooltip": "Port for email server",
+        "type": "number"
+      },
+      {
+        "uiName": "SSL?",
+        "fieldName": "ssl",
+        "isOptional": true,
+        "tooltip": "Flag to indicate it connection should be over SSL",
+        "type": "boolean",
+        "defaultValue": false
+      },
+      {
+        "uiName": "Start tls?",
+        "fieldName": "starttls",
+        "isOptional": true,
+        "tooltip": "Flag to indicate TLS setting",
+        "type": "boolean",
+        "defaultValue": false
+      },
+      {
+        "uiName": "Email server protocol",
+        "fieldName": "protocol",
+        "isOptional": true,
+        "tooltip": "Email server protocol",
+        "type": "string",
+        "defaultValue": "smtp"
+      },
+      {
+        "uiName": "Authenticate?",
+        "fieldName": "auth",
+        "isOptional": true,
+        "tooltip": "Flag to indicate if authentication to be performed",
+        "type": "boolean",
+        "defaultValue": true
+      }
+    ]
+  }
+}

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/Constants.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/Constants.java
@@ -4,6 +4,17 @@ public final class Constants {
     private Constants() {
     }
 
+    public static class Email {
+        public static final String SERVICE_NAME = "EMAIL";
+        public static final String CONF_TYPE_PROPERTIES = "properties";
+        public static final String PROPERTY_KEY_HOST = "host";
+        public static final String PROPERTY_KEY_PORT = "port";
+        public static final String PROPERTY_KEY_SSL = "ssl";
+        public static final String PROPERTY_KEY_STARTTLS = "starttls";
+        public static final String PROPERTY_KEY_PROTOCOL = "protocol";
+        public static final String PROPERTY_KEY_AUTH = "auth";
+    }
+
     public static class Zookeeper {
         public static final String SERVICE_NAME = "ZOOKEEPER";
     }

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/NotificationSinkBundleHintProvider.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/NotificationSinkBundleHintProvider.java
@@ -1,0 +1,71 @@
+package com.hortonworks.streamline.streams.cluster.bundle.impl;
+
+import com.hortonworks.streamline.streams.catalog.Cluster;
+import com.hortonworks.streamline.streams.catalog.Service;
+import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
+import com.hortonworks.streamline.streams.catalog.exception.ServiceConfigurationNotFoundException;
+import com.hortonworks.streamline.streams.catalog.exception.ServiceNotFoundException;
+import com.hortonworks.streamline.streams.cluster.Constants;
+import com.hortonworks.streamline.streams.cluster.bundle.AbstractBundleHintProvider;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class NotificationSinkBundleHintProvider extends AbstractBundleHintProvider {
+
+    public static final String FIELD_NAME_HOST = "properties.host";
+    public static final String FIELD_NAME_PORT = "properties.port";
+    public static final String FIELD_NAME_SSL = "properties.ssl";
+    public static final String FIELD_NAME_STARTTLS = "properties.starttls";
+    public static final String FIELD_NAME_PROTOCOL = "properties.protocol";
+    public static final String FIELD_NAME_AUTH = "properties.auth";
+
+    @Override
+    public String getServiceName() {
+        return Constants.Email.SERVICE_NAME;
+    }
+
+    @Override
+    public Map<String, Object> getHintsOnCluster(Cluster cluster) {
+        Map<String, Object> hintMap = new HashMap<>();
+
+        try {
+            Service email = environmentService.getServiceByName(cluster.getId(), Constants.Email.SERVICE_NAME);
+            if (email == null) {
+                throw new ServiceNotFoundException(Constants.Email.SERVICE_NAME);
+            }
+
+            ServiceConfiguration properties = environmentService.getServiceConfigurationByName(email.getId(), Constants.Email.CONF_TYPE_PROPERTIES);
+            if (properties == null) {
+                throw new ServiceConfigurationNotFoundException(Constants.Email.CONF_TYPE_PROPERTIES);
+            }
+
+            Map<String, String> configurationMap = properties.getConfigurationMap();
+            putToHintMapIfAvailable(configurationMap, hintMap, Constants.Email.PROPERTY_KEY_HOST, FIELD_NAME_HOST);
+            putToHintMapIfAvailable(configurationMap, hintMap, Constants.Email.PROPERTY_KEY_PORT, FIELD_NAME_PORT);
+            putToHintMapIfAvailable(configurationMap, hintMap, Constants.Email.PROPERTY_KEY_SSL, FIELD_NAME_SSL);
+            putToHintMapIfAvailable(configurationMap, hintMap, Constants.Email.PROPERTY_KEY_STARTTLS, FIELD_NAME_STARTTLS);
+            putToHintMapIfAvailable(configurationMap, hintMap, Constants.Email.PROPERTY_KEY_PROTOCOL, FIELD_NAME_PROTOCOL);
+            putToHintMapIfAvailable(configurationMap, hintMap, Constants.Email.PROPERTY_KEY_AUTH, FIELD_NAME_AUTH);
+        } catch (ServiceNotFoundException e) {
+            // we access it from mapping information so shouldn't be here
+            throw new IllegalStateException("Service " + Constants.Email.SERVICE_NAME + " in cluster " + cluster.getName() +
+                    " not found but mapping information exists.");
+        } catch (ServiceConfigurationNotFoundException e) {
+            // there's Email service configuration but not having enough information
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        return hintMap;
+    }
+
+    private void putToHintMapIfAvailable(Map<String, String> configurationMap, Map<String, Object> hintMap,
+                                         String confKey, String fieldName) {
+        if (configurationMap.containsKey(confKey)) {
+            hintMap.put(fieldName, configurationMap.get(confKey));
+        }
+    }
+
+}

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/AbstractServiceRegistrar.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/AbstractServiceRegistrar.java
@@ -41,6 +41,8 @@ public abstract class AbstractServiceRegistrar implements ManualServiceRegistrar
 
     protected abstract List<Component> createComponents(Config config, Map<String, String> flattenConfigMap);
 
+    protected abstract List<ServiceConfiguration> createServiceConfigurations(Config config);
+
     protected abstract boolean validateComponents(List<Component> components);
 
     protected abstract boolean validateServiceConfigurations(List<ServiceConfiguration> serviceConfigurations);
@@ -59,6 +61,17 @@ public abstract class AbstractServiceRegistrar implements ManualServiceRegistrar
         List<ServiceConfiguration> configurations = new ArrayList<>();
         Map<String, String> flattenConfigMap = new HashMap<>();
 
+        List<ServiceConfiguration> serviceConfigurations = createServiceConfigurations(config);
+        if (serviceConfigurations != null && !serviceConfigurations.isEmpty()) {
+            serviceConfigurations.forEach(sc -> {
+                configurations.add(sc);
+                try {
+                    flattenConfigMap.putAll(sc.getConfigurationMap());
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
 
         for (ConfigFileInfo configFileInfo : configFileInfos) {
             Map<String, String> configMap = readConfigFile(configFileInfo);
@@ -103,6 +116,9 @@ public abstract class AbstractServiceRegistrar implements ManualServiceRegistrar
 
         return service;
     }
+
+
+
 
     private String getConfType(String fileName) {
         // treat confType as the file name without extension

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/DruidServiceRegistrar.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/DruidServiceRegistrar.java
@@ -37,6 +37,11 @@ public class DruidServiceRegistrar extends AbstractServiceRegistrar {
     }
 
     @Override
+    protected List<ServiceConfiguration> createServiceConfigurations(Config config) {
+        return Collections.emptyList();
+    }
+
+    @Override
     protected boolean validateComponents(List<Component> components) {
         // no need to check components
         return true;

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/EmailServiceRegistrar.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/EmailServiceRegistrar.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.cluster.register.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hortonworks.streamline.common.Config;
+import com.hortonworks.streamline.streams.catalog.Component;
+import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
+import com.hortonworks.streamline.streams.cluster.Constants;
+import com.hortonworks.streamline.streams.cluster.discovery.ambari.ComponentPropertyPattern;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.hortonworks.streamline.streams.cluster.discovery.ambari.ComponentPropertyPattern.ZOOKEEPER_SERVER;
+
+public class EmailServiceRegistrar extends AbstractServiceRegistrar {
+    public static final String PARAM_HOST = "host";
+    public static final String PARAM_PORT = "port";
+    public static final String PARAM_SSL = "ssl";
+    public static final String PARAM_STARTTLS = "starttls";
+    public static final String PARAM_PROTOCOL = "protocol";
+    public static final String PARAM_AUTH = "auth";
+
+    @Override
+    protected String getServiceName() {
+        return Constants.Email.SERVICE_NAME;
+    }
+
+    @Override
+    protected List<Component> createComponents(Config config, Map<String, String> flattenConfigMap) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    protected List<ServiceConfiguration> createServiceConfigurations(Config config) {
+        ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
+        serviceConfiguration.setName(Constants.Email.CONF_TYPE_PROPERTIES);
+
+        Map<String, String> confMap = new HashMap<>();
+        confMap.put(PARAM_HOST, config.get(Constants.Email.PROPERTY_KEY_HOST));
+        confMap.put(PARAM_PORT, String.valueOf((Integer) config.getAny(Constants.Email.PROPERTY_KEY_PORT)));
+        confMap.put(PARAM_SSL, String.valueOf((Boolean) config.getAny(Constants.Email.PROPERTY_KEY_SSL)));
+        confMap.put(PARAM_STARTTLS, String.valueOf((Boolean) config.getAny(Constants.Email.PROPERTY_KEY_STARTTLS)));
+        confMap.put(PARAM_PROTOCOL, config.get(Constants.Email.PROPERTY_KEY_PROTOCOL));
+        confMap.put(PARAM_AUTH, String.valueOf((Boolean) config.getAny(Constants.Email.PROPERTY_KEY_AUTH)));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            String json = objectMapper.writeValueAsString(confMap);
+            serviceConfiguration.setConfiguration(json);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        return Collections.singletonList(serviceConfiguration);
+    }
+
+    @Override
+    protected boolean validateComponents(List<Component> components) {
+        // no component required, we will just use properties
+        return true;
+    }
+
+    @Override
+    protected boolean validateServiceConfigurations(List<ServiceConfiguration> serviceConfigurations) {
+        return serviceConfigurations.stream()
+                .anyMatch(config -> config.getName().equals(Constants.Email.CONF_TYPE_PROPERTIES));
+    }
+
+    @Override
+    protected boolean validateServiceConfiguationsAsFlattenedMap(Map<String, String> configMap) {
+        // all fields are optional for hint provider
+        return true;
+    }
+
+}

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/HBaseServiceRegistrar.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/HBaseServiceRegistrar.java
@@ -41,6 +41,11 @@ public class HBaseServiceRegistrar extends AbstractServiceRegistrar {
     }
 
     @Override
+    protected List<ServiceConfiguration> createServiceConfigurations(Config config) {
+        return Collections.emptyList();
+    }
+
+    @Override
     protected boolean validateComponents(List<Component> components) {
         // no need to check components
         return true;

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/HDFSServiceRegistrar.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/HDFSServiceRegistrar.java
@@ -42,6 +42,11 @@ public class HDFSServiceRegistrar extends AbstractServiceRegistrar {
     }
 
     @Override
+    protected List<ServiceConfiguration> createServiceConfigurations(Config config) {
+        return Collections.emptyList();
+    }
+
+    @Override
     protected boolean validateComponents(List<Component> components) {
         // no need to check components
         return true;

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/HiveServiceRegistrar.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/HiveServiceRegistrar.java
@@ -41,6 +41,11 @@ public class HiveServiceRegistrar extends AbstractServiceRegistrar {
     }
 
     @Override
+    protected List<ServiceConfiguration> createServiceConfigurations(Config config) {
+        return Collections.emptyList();
+    }
+
+    @Override
     protected boolean validateComponents(List<Component> components) {
         // no need to check components
         return true;

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/KafkaServiceRegistrar.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/KafkaServiceRegistrar.java
@@ -49,6 +49,11 @@ public class KafkaServiceRegistrar extends AbstractServiceRegistrar {
     }
 
     @Override
+    protected List<ServiceConfiguration> createServiceConfigurations(Config config) {
+        return Collections.emptyList();
+    }
+
+    @Override
     protected boolean validateComponents(List<Component> components) {
         // requirements
         // 1. KAFKA_BROKER should be available, and it should have one or more hosts and one port, and protocol

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/StormServiceRegistrar.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/StormServiceRegistrar.java
@@ -49,6 +49,11 @@ public class StormServiceRegistrar extends AbstractServiceRegistrar {
     }
 
     @Override
+    protected List<ServiceConfiguration> createServiceConfigurations(Config config) {
+        return Collections.emptyList();
+    }
+
+    @Override
     protected boolean validateComponents(List<Component> components) {
         // requirements
         // 1. STORM_UI_SERVER should be available, and it should have one host and one port

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/ZookeeperServiceRegistrar.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/register/impl/ZookeeperServiceRegistrar.java
@@ -46,6 +46,11 @@ public class ZookeeperServiceRegistrar extends AbstractServiceRegistrar {
     }
 
     @Override
+    protected List<ServiceConfiguration> createServiceConfigurations(Config config) {
+        return Collections.emptyList();
+    }
+
+    @Override
     protected boolean validateComponents(List<Component> components) {
         // requirements
         // 1. ZOOKEEPER_SERVER should be available, and it should have one or more hosts and one port

--- a/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/bundle/impl/NotificationSinkBundleSourceHintProviderTest.java
+++ b/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/bundle/impl/NotificationSinkBundleSourceHintProviderTest.java
@@ -1,0 +1,70 @@
+package com.hortonworks.streamline.streams.cluster.bundle.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hortonworks.streamline.streams.catalog.Cluster;
+import com.hortonworks.streamline.streams.catalog.Service;
+import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
+import com.hortonworks.streamline.streams.cluster.Constants;
+import com.hortonworks.streamline.streams.cluster.service.EnvironmentService;
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(JMockit.class)
+public class NotificationSinkBundleSourceHintProviderTest {
+    private NotificationSinkBundleHintProvider provider = new NotificationSinkBundleHintProvider();
+
+    @Mocked
+    private EnvironmentService environmentService;
+
+    @Test
+    public void getHintsOnCluster() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        Cluster cluster = new Cluster();
+        cluster.setId(1L);
+        cluster.setName("cluster1");
+
+        Service service = new Service();
+        service.setId(1L);
+        service.setName(Constants.Email.SERVICE_NAME);
+
+        Map<String, String> confMap = new HashMap<>();
+        confMap.put(Constants.Email.PROPERTY_KEY_HOST, "svr1");
+        confMap.put(Constants.Email.PROPERTY_KEY_PORT, "1111");
+        confMap.put(Constants.Email.PROPERTY_KEY_SSL, "true");
+        confMap.put(Constants.Email.PROPERTY_KEY_STARTTLS, "true");
+        confMap.put(Constants.Email.PROPERTY_KEY_PROTOCOL, "smtp");
+        confMap.put(Constants.Email.PROPERTY_KEY_AUTH, "true");
+
+        ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
+        serviceConfiguration.setId(1L);
+        serviceConfiguration.setName(Constants.Email.CONF_TYPE_PROPERTIES);
+        serviceConfiguration.setConfiguration(objectMapper.writeValueAsString(confMap));
+
+        new Expectations() {{
+            environmentService.getServiceByName(cluster.getId(), Constants.Email.SERVICE_NAME);
+            result = service;
+
+            environmentService.getServiceConfigurationByName(service.getId(), Constants.Email.CONF_TYPE_PROPERTIES);
+            result = serviceConfiguration;
+        }};
+
+        provider.init(environmentService);
+
+        Map<String, Object> hints = provider.getHintsOnCluster(cluster);
+        Assert.assertNotNull(hints);
+        Assert.assertEquals("svr1", hints.get(NotificationSinkBundleHintProvider.FIELD_NAME_HOST));
+        Assert.assertEquals("1111", hints.get(NotificationSinkBundleHintProvider.FIELD_NAME_PORT));
+        Assert.assertEquals("true", hints.get(NotificationSinkBundleHintProvider.FIELD_NAME_SSL));
+        Assert.assertEquals("true", hints.get(NotificationSinkBundleHintProvider.FIELD_NAME_STARTTLS));
+        Assert.assertEquals("smtp", hints.get(NotificationSinkBundleHintProvider.FIELD_NAME_PROTOCOL));
+        Assert.assertEquals("true", hints.get(NotificationSinkBundleHintProvider.FIELD_NAME_AUTH));
+    }
+}

--- a/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/register/impl/EmailServiceRegistrarTest.java
+++ b/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/register/impl/EmailServiceRegistrarTest.java
@@ -1,0 +1,49 @@
+package com.hortonworks.streamline.streams.cluster.register.impl;
+
+import com.hortonworks.streamline.common.Config;
+import com.hortonworks.streamline.streams.catalog.Cluster;
+import com.hortonworks.streamline.streams.catalog.Service;
+import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
+import com.hortonworks.streamline.streams.cluster.Constants;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+
+public class EmailServiceRegistrarTest extends AbstractServiceRegistrarTest<EmailServiceRegistrar> {
+
+    public EmailServiceRegistrarTest() {
+        super(EmailServiceRegistrar.class);
+    }
+
+    @Before
+    public void setUp() {
+        resetEnvironmentService();
+    }
+
+    @Test
+    public void testRegister() throws Exception {
+        Cluster cluster = getTestCluster(1L);
+
+        EmailServiceRegistrar registrar = initializeServiceRegistrar();
+
+        Config config = new Config();
+        config.setAny("host", "host");
+        config.setAny("port", 1111);
+        config.setAny("ssl", true);
+        config.setAny("starttls", true);
+        config.setAny("protocol", "smtp");
+        config.setAny("auth", true);
+
+        registrar.register(cluster, config, Collections.emptyList());
+
+        Service emailService = environmentService.getServiceByName(cluster.getId(), Constants.Email.SERVICE_NAME);
+        assertNotNull(emailService);
+        ServiceConfiguration propertiesConf = environmentService.getServiceConfigurationByName(emailService.getId(),
+                Constants.Email.CONF_TYPE_PROPERTIES);
+        assertNotNull(propertiesConf);
+    }
+
+}


### PR DESCRIPTION
* implements hint provider for Notification sink
* implements service registrar for Email

@shahsank3t 
I can't test it on the UI since there seems no way to provide hints for nested fields. Other bundles don't require that, so this is a new requirement.
Below is the output format which Notification hint provider will provide.

```
{
  "3": {
    "cluster": {
      "id": 3,
      "name": "EMailTest",
      "ambariImportUrl": "",
      "description": "EmailTest",
      "timestamp": 1491991431783
    },
    "hints": {
      "properties.host": "smtp.gmail.com",
      "properties.ssl": "true",
      "properties.port": "587",
      "properties.protocol": "smtp",
      "properties.auth": "true",
      "properties.starttls": "true"
    }
  }
}
```

Please check and modify UI side accordingly. Thanks in advance!
