### PR TITLE
STREAMLINE-776 - Bug fix in WindowedQueryBolt's handling of streamline event prefix in outputfields

### DIFF
--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/WindowedQueryBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/WindowedQueryBolt.java
@@ -123,7 +123,12 @@ public class WindowedQueryBolt extends JoinBolt {
     }
 
     private static String dropStreamLineEventPrefix(String flattenedKey) {
-        return flattenedKey.substring(flattenedKey.indexOf('.')+1);
+        int pos = flattenedKey.indexOf(EVENT_PREFIX);
+        if (pos==0)
+            return flattenedKey.substring(EVENT_PREFIX.length());
+        if (pos>0)
+            return flattenedKey.substring(0,pos) + flattenedKey.substring(pos+EVENT_PREFIX.length());
+        return flattenedKey;
     }
 
     public void withWindowConfig(Window windowConfig) throws IOException {


### PR DESCRIPTION
In this :

.selectStreamLine("key1, stream1:key2")

Here there is an implicit  "streamline-event." prefix before each name : streamline-event.key1, stream1:streamline-event.key2

This patch ensures that the above case is handled correctly when we use streamname: prefix to resolve ambiguity in keynames.