### PR TITLE
STREAMLINE-457  Adding RealtimeJoinBolt.

### DIFF
--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -152,6 +152,7 @@ function add_all_bundles {
     add_topology_component_bundle /streams/componentbundles/PROCESSOR ${component_dir}/processors/window-topology-component.json
     add_topology_component_bundle /streams/componentbundles/PROCESSOR ${component_dir}/processors/branch-topology-component.json
     add_topology_component_bundle /streams/componentbundles/PROCESSOR ${component_dir}/processors/join-bolt-topology-component.json
+    add_topology_component_bundle /streams/componentbundles/PROCESSOR ${component_dir}/processors/rtjoin-bolt-topology-component.json
     add_topology_component_bundle /streams/componentbundles/PROCESSOR ${component_dir}/processors/model-topology-component.json
     add_topology_component_bundle /streams/componentbundles/PROCESSOR ${component_dir}/processors/projection-topology-component.json
     # === Sink ===

--- a/bootstrap/components/processors/rtjoin-bolt-topology-component.json
+++ b/bootstrap/components/processors/rtjoin-bolt-topology-component.json
@@ -1,7 +1,7 @@
 {
   "type": "PROCESSOR",
-  "name": "Join",
-  "subType": "JOIN",
+  "name": "Realtime Join",
+  "subType": "RT-JOIN",
   "builtin": true,
   "streamingEngine": "STORM",
   "transformationClass": "com.hortonworks.streamline.streams.layout.storm.RealtimeJoinBoltFluxComponent",

--- a/bootstrap/components/processors/rtjoin-bolt-topology-component.json
+++ b/bootstrap/components/processors/rtjoin-bolt-topology-component.json
@@ -29,18 +29,6 @@
         ]
       },
       {
-        "uiName": "Conditions",
-        "fieldName": "Condition",
-        "isOptional": false,
-        "tooltip": "Join condition",
-        "isUserInput": true,
-        "type": "enumstring",
-        "options": [
-          { "name" : "equal", "arity": 2},
-          { "name" : "ignoreCase", "arity": 2}
-        ]
-      },
-      {
         "uiName": "Retention Window",
         "fieldName": "buffer",
         "isOptional": false,

--- a/bootstrap/components/processors/rtjoin-bolt-topology-component.json
+++ b/bootstrap/components/processors/rtjoin-bolt-topology-component.json
@@ -1,0 +1,72 @@
+{
+  "type": "PROCESSOR",
+  "name": "Join",
+  "subType": "JOIN",
+  "builtin": true,
+  "streamingEngine": "STORM",
+  "transformationClass": "com.hortonworks.streamline.streams.layout.storm.RealtimeJoinBoltFluxComponent",
+  "topologyComponentUISpecification": {
+    "fields": [
+      {
+        "uiName": "First Stream",
+        "fieldName": "from",
+        "isOptional": false,
+        "tooltip": "Name of first stream for the join",
+        "type": "string"
+      },
+      {
+        "uiName": "JoinTypes",
+        "fieldName": "jointype",
+        "isOptional": false,
+        "tooltip": "Type of join",
+        "isUserInput": false,
+        "type": "enumstring",
+        "options": [
+          "INNER",
+          "LEFT",
+          "RIGHT",
+          "OUTER"
+        ]
+      },
+      {
+        "uiName": "Buffer Size",
+        "fieldName": "buffer",
+        "isOptional": false,
+        "tooltip": "How much to buffer",
+        "isUserInput": false,
+        "type": "enumstring",
+        "options": [
+          "count",
+          "milliseconds",
+          "seconds",
+          "minutes",
+          "hours"
+        ]
+      },
+      {
+        "uiName": "Output Fields",
+        "fieldName": "outputKeys",
+        "isOptional": false,
+        "tooltip": "List of output fields",
+        "type": "string"
+      },
+      {
+        "uiName": "Output Stream",
+        "fieldName": "outputStream",
+        "isOptional": false,
+        "tooltip": "Name of output stream",
+        "type": "string"
+      },
+      {
+        "uiName": "Parallelism",
+        "fieldName": "parallelism",
+        "isOptional": true,
+        "tooltip": "Parallelism hint for rule bolt",
+        "type": "number",
+        "defaultValue": 1,
+        "min": 1,
+        "hint": "hidden"
+      }
+    ]
+  }
+}

--- a/bootstrap/components/processors/rtjoin-bolt-topology-component.json
+++ b/bootstrap/components/processors/rtjoin-bolt-topology-component.json
@@ -29,6 +29,18 @@
         ]
       },
       {
+        "uiName": "Conditions",
+        "fieldName": "Condition",
+        "isOptional": false,
+        "tooltip": "Join condition",
+        "isUserInput": true,
+        "type": "enumstring",
+        "options": [
+          { "name" : "equal", "arity": 2},
+          { "name" : "ignoreCase", "arity": 2}
+        ]
+      },
+      {
         "uiName": "Buffer Size",
         "fieldName": "buffer",
         "isOptional": false,

--- a/bootstrap/components/processors/rtjoin-bolt-topology-component.json
+++ b/bootstrap/components/processors/rtjoin-bolt-topology-component.json
@@ -4,7 +4,7 @@
   "subType": "RT-JOIN",
   "builtin": true,
   "streamingEngine": "STORM",
-  "transformationClass": "com.hortonworks.streamline.streams.layout.storm.RealtimeJoinBoltFluxComponent",
+  "transformationClass": "com.hortonworks.streamline.streams.layout.storm.SLRealtimeJoinBoltFluxComponent",
   "topologyComponentUISpecification": {
     "fields": [
       {
@@ -41,14 +41,13 @@
         ]
       },
       {
-        "uiName": "Buffer Size",
+        "uiName": "Retention Window",
         "fieldName": "buffer",
         "isOptional": false,
-        "tooltip": "How much to buffer",
+        "tooltip": "How long an event in this stream should wait for its matching events on the other stream to arrive",
         "isUserInput": false,
         "type": "enumstring",
         "options": [
-          "count",
           "milliseconds",
           "seconds",
           "minutes",

--- a/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/JoinBoltFluxComponent.java
+++ b/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/JoinBoltFluxComponent.java
@@ -43,7 +43,7 @@ import java.util.Map;
     {"type" : "left",  "stream": "s3", "key":"k3", "with": "s1"},
     {"type" : "inner", "stream": "s4", "key":"k4", "with": "s2"}
   ],
-  "outputKeys" : [ "k1", "k2 as key2" ],
+  "outputKeys" : [ "k1", "stream1:k2 as key2" ],
   "window" : {"windowLength" : {"class":".Window$Count", "count":100}, "slidingInterval":{"class":".Window$Count", "count":100}, "tsField":null, "lagMs":0},
   "outputStream" : "joinedStream1"
 }

--- a/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/RealtimeJoinBoltFluxComponent.java
+++ b/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/RealtimeJoinBoltFluxComponent.java
@@ -28,10 +28,10 @@ import java.util.stream.Stream;
 
 /* ---- Sample Json of whats expected from UI  ---
 {
-"from" : {"stream": "orders", "count/seconds/minutes/hours/seconds" : 10, "dropDuplicates" : false },
+"from" : {"stream": "orders", "count/seconds/minutes/hours" : 10, "unique" : false },
 
 "joins" : [
-    { "type":"inner/left/right/outer",  "stream":"adImpressions",  "count/seconds/minutes/hours":10,  "dropDuplicates":false,
+    { "type":"inner/left/right/outer",  "stream":"adImpressions",  "count/seconds/minutes/hours":10,  "unique":false,
                "conditions" : [
                   [ "equal",  "adImpressions:userID",  "orders:userId" ],
                   [ "ignoreCase", "product", "orders:product"]
@@ -114,21 +114,21 @@ public class RealtimeJoinBoltFluxComponent extends AbstractFluxComponent {
         {  // from()
             Map<String, Object> fromConf = (Map<String, Object>) conf.get("from");
             String fromStream = fromConf.get("stream").toString();
-            Boolean dropDuplicates = (Boolean) fromConf.get("dropDuplicates");
+            Boolean unique = (Boolean) fromConf.get("unique");
 
             Integer count = (Integer) fromConf.get("count");
             if( count != null ) {
-                result.add(new Object[]{fromStream, count, dropDuplicates});
+                result.add(new Object[]{fromStream, count, unique});
             } else {
                 String durationId = addDurationToComponents(fromConf);
-                result.add(new Object[]{fromStream, getRefYaml(durationId), dropDuplicates});
+                result.add(new Object[]{fromStream, getRefYaml(durationId), unique});
             }
         }
         {  // *Join()
             ArrayList<Map<String, Object>> joinConfig = (ArrayList<Map<String, Object>>) conf.get("joins");
             for (Map<String, Object> joinConf : joinConfig) {
                 String stream = joinConf.get("stream").toString();
-                Boolean dropDuplicates = (Boolean) joinConf.get("dropDuplicates");
+                Boolean unique = (Boolean) joinConf.get("unique");
 
                 ArrayList<Map<String, String> > comparators = new ArrayList<>();
                 for (ArrayList<String> condition : (ArrayList<ArrayList<String> >) joinConf.get("conditions")) {
@@ -136,10 +136,10 @@ public class RealtimeJoinBoltFluxComponent extends AbstractFluxComponent {
                 }
                 Integer count = (Integer) joinConf.get("count");
                 if (count!=null) {
-                    result.add(new Object[]{stream, count, dropDuplicates, comparators.toArray()});
+                    result.add(new Object[]{stream, count, unique, comparators.toArray()});
                 } else {
                     String durationId = addDurationToComponents(joinConf);
-                    result.add(new Object[]{stream, getRefYaml(durationId), dropDuplicates, comparators.toArray()});
+                    result.add(new Object[]{stream, getRefYaml(durationId), unique, comparators.toArray()});
                 }
             }
         }

--- a/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/RealtimeJoinBoltFluxComponent.java
+++ b/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/RealtimeJoinBoltFluxComponent.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.hortonworks.streamline.streams.layout.storm;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+
+/* ---- Sample Json of whats expected from UI  ---
+{
+"from" : {"stream": "orders"},
+"join" : {"type" : "inner", "stream" : "adImpressions", "count" : 10, "dropDuplicates" : false},  # here we can have:  count/seconds/minutes/milliseconds
+"equal" :
+  [
+    { "firstKey" : "userID",    "secondKey" : "userid"},
+    { "firstKey" : "productID", "secondKey" : "productID"}
+  ],
+  "outputKeys" : [ "userID", "orders:productID" ,"orderId", "impressionId" ],
+  "outputStream" : "joinedStream1"
+}
+ */
+
+public class RealtimeJoinBoltFluxComponent extends AbstractFluxComponent {
+
+    @Override
+    protected void generateComponent()  {
+        String boltId        = "rt_joinBolt_" + UUID_FOR_COMPONENTS;
+        String boltClassName = "com.hortonworks.streamline.streams.runtime.storm.bolt.query.RealtimeJoinBolt";
+
+        List<String> boltConstructorArgs = new ArrayList<>();
+
+        String[] configMethodNames = getConfiguredMethodNames(conf);
+        Object[] configValues = getConfiguredMethodArgs(conf);
+
+        List<Map<String, Object>> configMethods = getConfigMethodsYaml(configMethodNames, configValues);
+
+        component = createComponent(boltId, boltClassName, null, boltConstructorArgs, configMethods);
+        addParallelismToComponent();
+
+    }
+
+    private static String[] getConfiguredMethodNames(Map<String, Object> conf) {
+        ArrayList<String> result = new ArrayList<>(conf.size());
+
+        if ( conf.containsKey("from") ) {
+            result.add("dataStream");
+        } else {
+            throw new IllegalArgumentException("'from' parameter is required and cannot be null");
+        }
+
+        Map<String, Object> joinConfig = (Map<String, Object>) conf.get("join");
+        if ( joinConfig!=null ) {
+            String joinType = joinConfig.get("type").toString();
+            if (joinType.equalsIgnoreCase("inner")) {
+                result.add("innerJoin");
+            } else if (joinType.equalsIgnoreCase("left")) {
+                result.add("leftJoin");
+            } else if (joinType.equalsIgnoreCase("right")) {
+                result.add("rightJoin");
+            } else if (joinType.equalsIgnoreCase("outer")) {
+                result.add("outerJoin");
+            } else {
+                throw new IllegalArgumentException("Allowed join types : 'inner'/'left'/'right'/'outer'");
+            }
+        } else {
+            throw new IllegalArgumentException("'join' configuration missing");
+        }
+
+        Object val;
+        if ( (val = conf.get("equal")) != null  ) {
+            for (Object equalMethod : ((List<Object>) val)) {
+                result.add("streamlineEqual");
+            }
+        }
+
+        if ( conf.containsKey("outputKeys") ) {
+            result.add("streamlineSelect");
+        } else {
+            throw new IllegalArgumentException("'outputKeys' parameter is required and cannot be null");
+        }
+
+        if ( conf.containsKey("outputStream")) {
+            result.add("withOutputStream");
+        } else {
+            throw new IllegalArgumentException("'outputStream' parameter is required and cannot be null");
+        }
+
+        return result.toArray(new String[]{});
+    }
+
+
+    private Object[] getConfiguredMethodArgs(Map<String, Object> conf) {
+        ArrayList<Object[]> result = new ArrayList<>(conf.size());
+
+        // dataStream()
+        String fromStream = ((Map<String,Object>)conf.get("from")).get("stream").toString();
+        result.add( new String[]{fromStream} );
+
+
+        // *Join()
+        Map<String, Object> joinConf = (Map<String, Object>) conf.get("join");
+        String stream = joinConf.get("stream").toString();
+        String countOrDurationId =  addCountOrDuration(joinConf);
+        Boolean dropDuplicates = (Boolean) joinConf.get("dropDuplicates");
+        result.add(new Object[]{stream, getRefYaml(countOrDurationId), dropDuplicates });
+
+
+        // streamlineEqual()
+        Object val;
+        if( (val = conf.get("equal")) != null  ) {
+            for (Object joinKeys : ((List<Object>) val)) {
+                Map<String, Object> ji = ((Map<String, Object>) joinKeys);
+                String firstKey = ji.get("firstKey").toString();
+                String secondKey = ji.get("secondKey").toString();
+                result.add( new String[]{firstKey, secondKey} );
+            }
+        }
+
+        // streamlineSelect()
+        ArrayList<String> outputKeys = (ArrayList<String>) conf.get("outputKeys");
+        String outputKeysStr = String.join(",", outputKeys);
+        result.add(new String[]{outputKeysStr});
+
+        // withOutputStream()
+        String outputStreamName = conf.get("outputStream").toString();
+        result.add( new String[]{outputStreamName} );
+
+        return result.toArray(new Object[]{});
+    }
+
+    // returns component ID
+    private String addCountOrDuration(Map<String, Object> joinArgs) {
+        Integer count = (Integer) joinArgs.get("count");
+        if( count != null ) {
+            return addCountToComponents(count);
+        }
+        return addDurationToComponents( joinArgs );
+    }
+
+
+    // Creates component for the Count object and adds it to the components list
+    // returns the component ID
+    private String addCountToComponents(Integer count) {
+        String componentId = "duration_" + UUID_FOR_COMPONENTS;
+        String className = "org.apache.storm.topology.base.BaseWindowedBolt.Count";
+        List<Object> constructorArgs = new ArrayList<>();
+        try {
+            constructorArgs.add(count);
+            this.addToComponents(this.createComponent(componentId, className, null, constructorArgs, null));
+            return componentId;
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to crate json for window definition", e);
+        }
+    }
+
+    // Creates component for the Duration object and adds it to the components list
+    // returns the component ID
+    private String addDurationToComponents(Map<String, Object> joinArgs) {
+        String componentId = "duration_" + UUID_FOR_COMPONENTS;
+        String className = "org.apache.storm.topology.base.BaseWindowedBolt.Duration";
+
+        // Find dthe TimeUnit.enums key in joinArgs .... secs/mins/millis/days/etc
+        String units = Stream.of(TimeUnit.values()).map(TimeUnit::name).filter(
+                k -> joinArgs.containsKey(k.toLowerCase())
+        ).findFirst().get();
+        Integer duration = (Integer) joinArgs.get(units.toLowerCase());
+
+        List<String> constructorArgs = new ArrayList<>();
+        String json = "[" + duration + ", " + TimeUnit.valueOf(units) + "]";
+        constructorArgs.add(json);
+        this.addToComponents(this.createComponent(componentId, className, null, constructorArgs, null));
+        return componentId;
+    }
+
+
+}

--- a/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/SLRealtimeJoinBoltFluxComponent.java
+++ b/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/SLRealtimeJoinBoltFluxComponent.java
@@ -28,7 +28,7 @@ import java.util.stream.Stream;
 
 /* ---- Sample Json of whats expected from UI  ---
 {
-"from" : {"stream": "orders", "count/seconds/minutes/hours" : 10, "unique" : false },
+"from" : {"stream": "orders", "seconds/minutes/hours" : 10, "unique" : false },
 
 "joins" : [
     { "type":"inner/left/right/outer",  "stream":"adImpressions",  "count/seconds/minutes/hours":10,  "unique":false,
@@ -44,7 +44,7 @@ import java.util.stream.Stream;
 }
  */
 
-public class RealtimeJoinBoltFluxComponent extends AbstractFluxComponent {
+public class SLRealtimeJoinBoltFluxComponent extends AbstractFluxComponent {
 
     @Override
     protected void generateComponent()  {

--- a/streams/runners/storm/layout/src/test/java/com/hortonworks/streamline/streams/layout/storm/JoinBoltFluxComponentTest.java
+++ b/streams/runners/storm/layout/src/test/java/com/hortonworks/streamline/streams/layout/storm/JoinBoltFluxComponentTest.java
@@ -52,7 +52,7 @@ public class JoinBoltFluxComponentTest {
     }
 
 
-    private static List<Map.Entry<String, Map<String, Object>>> getYamlComponents(FluxComponent fluxComponent) throws IOException {
+    public static List<Map.Entry<String, Map<String, Object>>> getYamlComponents(FluxComponent fluxComponent) throws IOException {
         String json = "{\n" +
                 "\"from\" : {\"stream\": \"stream1\", \"key\": \"k1\"},\n" +
                 "\"joins\" :\n" +

--- a/streams/runners/storm/layout/src/test/java/com/hortonworks/streamline/streams/layout/storm/RealtimeJoinBoltFluxComponentTest.java
+++ b/streams/runners/storm/layout/src/test/java/com/hortonworks/streamline/streams/layout/storm/RealtimeJoinBoltFluxComponentTest.java
@@ -34,40 +34,25 @@ public class RealtimeJoinBoltFluxComponentTest {
     public void testFluxGen_Count() throws Exception {
         RealtimeJoinBoltFluxComponent me = new RealtimeJoinBoltFluxComponent();
         String json = "{\n" +
-                "\"from\" : {\"stream\": \"orders\"},\n" +
-                "\"join\" : {\"type\" : \"left\", \"stream\" : \"adImpressions\", \"count\" : 10, \"dropDuplicates\" : false}," +
-                "\"equal\" :\n" +
-                "  [\n" +
-                "    { \"firstKey\" : \"userID\",    \"secondKey\" : \"userid\"},\n" +
-                "    { \"firstKey\" : \"productID\", \"secondKey\" : \"productID\"}\n" +
+                "\"from\" : {\"stream\": \"orders\", \"seconds\" : 10, \"dropDuplicates\" : false },\n" +
+                "\n" +
+                "\"joins\" : [\n" +
+                "    { \"type\":\"inner\",  \"stream\":\"adImpressions\",  \"seconds\":20,  \"dropDuplicates\":false,\n" +
+                "               \"conditions\" : [\n" +
+                "                  [ \"equal\",  \"adImpressions:userID\",  \"orders:userId\" ],\n" +
+                "                  [ \"ignoreCase\", \"product\", \"orders:product\"]\n" +
+                "               ]\n" +
+                "     }\n" +
                 "  ],\n" +
-                "  \"outputKeys\" : [ \"userID\", \"orders:productID\" ,\"orderId\", \"impressionId\" ],\n" +
-                "  \"outputStream\" : \"joinedStream1\"\n" +
+                "\n" +
+                "\"outputKeys\" : [ \"userID\", \"orders:product as product\" ,\"orderId\", \"impressionId\" ],\n" +
+                "\"outputStream\" : \"joinedStream1\"\n" +
                 "}";
 
         List<Map.Entry<String, Map<String, Object>>> map = getYamlComponents(json, me);
         String yamlStr = makeYaml(map);
         System.out.println(yamlStr);
 
-    }
-
-    @Test
-    public void testFluxGen_Duration() throws Exception {
-        RealtimeJoinBoltFluxComponent me = new RealtimeJoinBoltFluxComponent();
-        String json = "{\"from\" : {\"stream\": \"orders\"},\n" +
-                "\"join\" : {\"type\" : \"left\", \"stream\" : \"adImpressions\", \"milliseconds\" : 10, \"dropDuplicates\" : false}," +
-                "\"equal\" :\n" +
-                "  [\n" +
-                "    { \"firstKey\" : \"userID\",    \"secondKey\" : \"userid\"},\n" +
-                "    { \"firstKey\" : \"productID\", \"secondKey\" : \"productID\"}\n" +
-                "  ],\n" +
-                "  \"outputKeys\" : [ \"userID\", \"orders:productID\" ,\"orderId\", \"impressionId\" ],\n" +
-                "  \"outputStream\" : \"joinedStream1\"\n" +
-                "}";
-
-        List<Map.Entry<String, Map<String, Object>>> map = getYamlComponents(json, me);
-        String yamlStr = makeYaml(map);
-        System.out.println(yamlStr);
     }
 
     public static List<Map.Entry<String, Map<String, Object>>> getYamlComponents(String json, FluxComponent fluxComponent) throws IOException {

--- a/streams/runners/storm/layout/src/test/java/com/hortonworks/streamline/streams/layout/storm/RealtimeJoinBoltFluxComponentTest.java
+++ b/streams/runners/storm/layout/src/test/java/com/hortonworks/streamline/streams/layout/storm/RealtimeJoinBoltFluxComponentTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.hortonworks.streamline.streams.layout.storm;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.snakeyaml.DumperOptions;
+import com.fasterxml.jackson.dataformat.yaml.snakeyaml.Yaml;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.*;
+
+public class RealtimeJoinBoltFluxComponentTest {
+
+    @Test
+    public void testFluxGen_Count() throws Exception {
+        RealtimeJoinBoltFluxComponent me = new RealtimeJoinBoltFluxComponent();
+        String json = "{\n" +
+                "\"from\" : {\"stream\": \"orders\"},\n" +
+                "\"join\" : {\"type\" : \"left\", \"stream\" : \"adImpressions\", \"count\" : 10, \"dropDuplicates\" : false}," +
+                "\"equal\" :\n" +
+                "  [\n" +
+                "    { \"firstKey\" : \"userID\",    \"secondKey\" : \"userid\"},\n" +
+                "    { \"firstKey\" : \"productID\", \"secondKey\" : \"productID\"}\n" +
+                "  ],\n" +
+                "  \"outputKeys\" : [ \"userID\", \"orders:productID\" ,\"orderId\", \"impressionId\" ],\n" +
+                "  \"outputStream\" : \"joinedStream1\"\n" +
+                "}";
+
+        List<Map.Entry<String, Map<String, Object>>> map = getYamlComponents(json, me);
+        String yamlStr = makeYaml(map);
+        System.out.println(yamlStr);
+
+    }
+
+    @Test
+    public void testFluxGen_Duration() throws Exception {
+        RealtimeJoinBoltFluxComponent me = new RealtimeJoinBoltFluxComponent();
+        String json = "{\"from\" : {\"stream\": \"orders\"},\n" +
+                "\"join\" : {\"type\" : \"left\", \"stream\" : \"adImpressions\", \"milliseconds\" : 10, \"dropDuplicates\" : false}," +
+                "\"equal\" :\n" +
+                "  [\n" +
+                "    { \"firstKey\" : \"userID\",    \"secondKey\" : \"userid\"},\n" +
+                "    { \"firstKey\" : \"productID\", \"secondKey\" : \"productID\"}\n" +
+                "  ],\n" +
+                "  \"outputKeys\" : [ \"userID\", \"orders:productID\" ,\"orderId\", \"impressionId\" ],\n" +
+                "  \"outputStream\" : \"joinedStream1\"\n" +
+                "}";
+
+        List<Map.Entry<String, Map<String, Object>>> map = getYamlComponents(json, me);
+        String yamlStr = makeYaml(map);
+        System.out.println(yamlStr);
+    }
+
+    public static List<Map.Entry<String, Map<String, Object>>> getYamlComponents(String json, FluxComponent fluxComponent) throws IOException {
+        Map<String, Object> props = new ObjectMapper().readValue(json, new TypeReference<HashMap<String, Object>>(){});
+
+        fluxComponent.withConfig(props);
+
+        List<Map.Entry<String, Map<String, Object>>> keysAndComponents = new ArrayList<>();
+
+        for (Map<String, Object> referencedComponent : fluxComponent.getReferencedComponents()) {
+            keysAndComponents.add(makeEntry(StormTopologyLayoutConstants.YAML_KEY_COMPONENTS, referencedComponent));
+        }
+
+        Map<String, Object> yamlComponent = fluxComponent.getComponent();
+        yamlComponent.put(StormTopologyLayoutConstants.YAML_KEY_ID, "roshan");
+
+
+        keysAndComponents.add( makeEntry(StormTopologyLayoutConstants.YAML_KEY_BOLTS,  yamlComponent) );
+
+        return keysAndComponents;
+    }
+
+
+    private static Map.Entry<String, Map<String, Object>> makeEntry(String key, Map<String, Object> component) {
+        return new AbstractMap.SimpleImmutableEntry<>(key, component);
+    }
+
+    private static String makeYaml(List<Map.Entry<String, Map<String, Object>>> keysAndComponents) {
+        Map<String, Object> yamlMap;
+        StringWriter yamlStr = new StringWriter();
+        yamlMap = new LinkedHashMap<>();
+        yamlMap.put(StormTopologyLayoutConstants.YAML_KEY_NAME, "topo1");
+
+        for (Map.Entry<String, Map<String, Object>> entry: keysAndComponents) {
+            addComponentToCollection(yamlMap, entry.getValue(), entry.getKey());
+        }
+
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setSplitLines(false);
+        Yaml yaml = new Yaml (options);
+        yaml.dump(yamlMap, yamlStr);
+        return yamlStr.toString();
+    }
+
+    private static void addComponentToCollection (Map<String, Object> yamlMap, Map<String, Object> yamlComponent, String collectionKey) {
+        if (yamlComponent == null ) {
+            return;
+        }
+
+        List<Map<String, Object>> components = (List<Map<String, Object>>) yamlMap.get(collectionKey);
+        if (components == null) {
+            components = new ArrayList<>();
+            yamlMap.put(collectionKey, components);
+        }
+        components.add(yamlComponent);
+    }
+}

--- a/streams/runners/storm/layout/src/test/java/com/hortonworks/streamline/streams/layout/storm/SLRealtimeJoinBoltFluxComponentTest.java
+++ b/streams/runners/storm/layout/src/test/java/com/hortonworks/streamline/streams/layout/storm/SLRealtimeJoinBoltFluxComponentTest.java
@@ -34,10 +34,10 @@ public class SLRealtimeJoinBoltFluxComponentTest {
     public void testFluxGen_Count() throws Exception {
         SLRealtimeJoinBoltFluxComponent me = new SLRealtimeJoinBoltFluxComponent();
         String json = "{\n" +
-                "\"from\" : {\"stream\": \"orders\", \"seconds\" : 10, \"dropDuplicates\" : false },\n" +
+                "\"from\" : {\"stream\": \"orders\", \"seconds\" : 10, \"unique\" : false },\n" +
                 "\n" +
                 "\"joins\" : [\n" +
-                "    { \"type\":\"inner\",  \"stream\":\"adImpressions\",  \"seconds\":20,  \"dropDuplicates\":false,\n" +
+                "    { \"type\":\"inner\",  \"stream\":\"adImpressions\",  \"seconds\":20,  \"unique\":true,\n" +
                 "               \"conditions\" : [\n" +
                 "                  [ \"equal\",  \"adImpressions:userID\",  \"orders:userId\" ],\n" +
                 "                  [ \"ignoreCase\", \"product\", \"orders:product\"]\n" +

--- a/streams/runners/storm/layout/src/test/java/com/hortonworks/streamline/streams/layout/storm/SLRealtimeJoinBoltFluxComponentTest.java
+++ b/streams/runners/storm/layout/src/test/java/com/hortonworks/streamline/streams/layout/storm/SLRealtimeJoinBoltFluxComponentTest.java
@@ -28,11 +28,11 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.*;
 
-public class RealtimeJoinBoltFluxComponentTest {
+public class SLRealtimeJoinBoltFluxComponentTest {
 
     @Test
     public void testFluxGen_Count() throws Exception {
-        RealtimeJoinBoltFluxComponent me = new RealtimeJoinBoltFluxComponent();
+        SLRealtimeJoinBoltFluxComponent me = new SLRealtimeJoinBoltFluxComponent();
         String json = "{\n" +
                 "\"from\" : {\"stream\": \"orders\", \"seconds\" : 10, \"dropDuplicates\" : false },\n" +
                 "\n" +

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/Cmp.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/Cmp.java
@@ -28,12 +28,12 @@ public class Cmp {
 
         @Override
         public boolean compare(Tuple t1, Tuple t2) throws InvalidTuple {
-            Object f1 = field1.findField(t1);
+            Object f1 = fromField.findField(t1);
             if (f1==null)
-                throw new InvalidTuple("Field '" + field1.canonicalFieldName() + "' not found in tuple", t1 );
-            Object f2 = field2.findField(t2);
+                throw new InvalidTuple("Field '" + fromField.canonicalFieldName() + "' not found in tuple", t1 );
+            Object f2 = joinField.findField(t2);
             if (f2==null)
-                throw new InvalidTuple("Field '" + field2.canonicalFieldName() + "' not found in tuple", t2 );
+                throw new InvalidTuple("Field '" + joinField.canonicalFieldName() + "' not found in tuple", t2 );
             return f1.equals(f2);
         }
 
@@ -51,12 +51,12 @@ public class Cmp {
 
         @Override
         public boolean compare(Tuple t1, Tuple t2) throws InvalidTuple {
-            Object f1 = field1.findField(t1);
+            Object f1 = fromField.findField(t1);
             if (f1==null)
-                throw new InvalidTuple("Field '" + field1.canonicalFieldName() + "' not found in tuple", t1 );
-            Object f2 = field2.findField(t2);
+                throw new InvalidTuple("Field '" + fromField.canonicalFieldName() + "' not found in tuple", t1 );
+            Object f2 = joinField.findField(t2);
             if (f2==null)
-                throw new InvalidTuple("Field '" + field2.canonicalFieldName() + "' not found in tuple", t2 );
+                throw new InvalidTuple("Field '" + joinField.canonicalFieldName() + "' not found in tuple", t2 );
             return f1.toString().equalsIgnoreCase(f2.toString());
         }
     }

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/Cmp.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/Cmp.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.hortonworks.streamline.streams.runtime.storm.bolt.query;
+
+import org.apache.storm.tuple.Tuple;
+
+public class Cmp {
+    static class Equal extends JoinComparator {
+        public Equal(String fieldSelector1, String fieldSelector2) {
+            super(fieldSelector1, fieldSelector2);
+        }
+
+        @Override
+        public boolean compare(Tuple t1, Tuple t2) throws InvalidTuple {
+            Object f1 = field1.findField(t1);
+            if (f1==null)
+                throw new InvalidTuple("Field '" + field1.canonicalFieldName() + "' not found in tuple", t1 );
+            Object f2 = field2.findField(t2);
+            if (f2==null)
+                throw new InvalidTuple("Field '" + field2.canonicalFieldName() + "' not found in tuple", t2 );
+            return f1.equals(f2);
+        }
+
+    }
+
+    public static Equal equal(String fieldSelector1, String fieldSelector2) {
+        return new Equal(fieldSelector1, fieldSelector2);
+    }
+
+    // Case-insensitive comparison of two String fields
+    static class IgnoreCase extends Equal {
+        public IgnoreCase(String fieldSelector1, String fieldSelector2) {
+            super(fieldSelector1, fieldSelector2);
+        }
+
+        @Override
+        public boolean compare(Tuple t1, Tuple t2) throws InvalidTuple {
+            Object f1 = field1.findField(t1);
+            if (f1==null)
+                throw new InvalidTuple("Field '" + field1.canonicalFieldName() + "' not found in tuple", t1 );
+            Object f2 = field2.findField(t2);
+            if (f2==null)
+                throw new InvalidTuple("Field '" + field2.canonicalFieldName() + "' not found in tuple", t2 );
+            return f1.toString().equalsIgnoreCase(f2.toString());
+        }
+    }
+
+    public static IgnoreCase ignoreCase(String fieldSelector1, String fieldSelector2) {
+        return new IgnoreCase(fieldSelector1, fieldSelector2);
+    }
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/Cmp.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/Cmp.java
@@ -20,8 +20,10 @@ package com.hortonworks.streamline.streams.runtime.storm.bolt.query;
 
 import org.apache.storm.tuple.Tuple;
 
+import java.io.Serializable;
+
 public class Cmp {
-    static class Equal extends JoinComparator {
+    static class Equal extends JoinComparator implements Serializable {
         public Equal(String fieldSelector1, String fieldSelector2) {
             super(fieldSelector1, fieldSelector2);
         }
@@ -44,7 +46,7 @@ public class Cmp {
     }
 
     // Case-insensitive comparison of two String fields
-    static class IgnoreCase extends Equal {
+    static class IgnoreCase extends Equal implements Serializable {
         public IgnoreCase(String fieldSelector1, String fieldSelector2) {
             super(fieldSelector1, fieldSelector2);
         }

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/FieldSelector.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/FieldSelector.java
@@ -61,20 +61,6 @@ class FieldSelector implements Serializable {
             outputName = (streamName==null) ? fieldDesc :  streamName+":"+fieldDesc ;
     }
 
-//    /**
-//     * @param stream name of stream
-//     * @param fieldDescriptor  Simple fieldDescriptor like "x.y.z" and without a stream qualifier prefix 'stream1:'.
-//     */
-//    public FieldSelector(String stream, String fieldDescriptor, RealtimeJoinBolt.StreamKind streamKind)  {
-//        this(stream + ":" + fieldDescriptor, streamKind);
-//        if(fieldDescriptor.indexOf(":")>=0) {
-//            throw new IllegalArgumentException("Not expecting stream qualifier ':' in '" + fieldDescriptor
-//                    + "'. Stream '" + stream +  "' is separately provided in this context");
-//        }
-//        this.streamName = stream;
-//    }
-
-
     // returns field name in x.y.z format (without stream name)
     public String canonicalFieldName() {
         return String.join(".", field);

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/FieldSelector.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/FieldSelector.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.hortonworks.streamline.streams.runtime.storm.bolt.query;
+
+import org.apache.storm.tuple.Tuple;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This class represents a field description used for joins. It accepts a field selector string which can include optional aliases.
+ * Fields can also be nested. Nesting of fields is assumed to be done using maps.
+ *
+ *   Examples:  "stream1:outer.inner.nestedField as field" or "outer.inner.field" or "field"
+ *
+ */
+class FieldSelector implements Serializable {
+    final static long serialVersionUID = 2L;
+    final static Pattern fieldDescrPattern = Pattern.compile("(?:([\\w-]+?):)?([\\w.-]+)(?: +as +([\\w.-]+))? *");
+    final RealtimeJoinBolt.StreamKind streamKind;
+
+    String streamName;     // can be null;. StreamKind name can have '-' & '_'
+    String[] field;        // nested field "x.y.z"  becomes => String["x","y","z"]. Field names can contain '-' & '_'
+    private String alias;  // can be null. In 'strm:x.y.z as z', here z is the alias (alias can contain '-', '_' &'.')
+    String outputName;     // either "stream1:x.y.z" or "x.y.z" (if stream unspecified) or just alias.
+
+    public FieldSelector(String fieldDescriptor, RealtimeJoinBolt.StreamKind streamKind)  {
+        this.streamKind = streamKind;
+
+        Matcher matcher = fieldDescrPattern.matcher(fieldDescriptor);
+        if (!matcher.find( ))
+            throw new IllegalArgumentException("'" +fieldDescriptor + "' is not a valid field descriptor. Correct Format: [streamid:]nested.field [as anAlias]");
+        this.streamName = matcher.group(1);     // can be null
+        String fieldDesc = matcher.group(2);
+        if (fieldDesc==null)
+            throw new IllegalArgumentException("'" +fieldDescriptor + "' is not a valid field descriptor. Correct Format: [streamid:]nested.field [as anAlias]");
+        this.field = fieldDesc.split("\\.");
+        this.alias = matcher.group(3);   // can be bykk
+
+        if (alias!=null)
+            outputName = alias;
+        else
+            outputName = (streamName==null) ? fieldDesc :  streamName+":"+fieldDesc ;
+    }
+
+//    /**
+//     * @param stream name of stream
+//     * @param fieldDescriptor  Simple fieldDescriptor like "x.y.z" and without a stream qualifier prefix 'stream1:'.
+//     */
+//    public FieldSelector(String stream, String fieldDescriptor, RealtimeJoinBolt.StreamKind streamKind)  {
+//        this(stream + ":" + fieldDescriptor, streamKind);
+//        if(fieldDescriptor.indexOf(":")>=0) {
+//            throw new IllegalArgumentException("Not expecting stream qualifier ':' in '" + fieldDescriptor
+//                    + "'. Stream '" + stream +  "' is separately provided in this context");
+//        }
+//        this.streamName = stream;
+//    }
+
+
+    // returns field name in x.y.z format (without stream name)
+    public String canonicalFieldName() {
+        return String.join(".", field);
+    }
+
+
+    @Override
+    public String toString() {
+        return outputName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        try {
+            FieldSelector that = (FieldSelector) o;
+            return outputName != null ? outputName.equals(that.outputName) : that.outputName == null;
+        } catch (ClassCastException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return outputName != null ? outputName.hashCode() : 0;
+    }
+
+    /**
+     *   Extract this field described by this FieldSelector from tuple. Can be a nested field (x.y.z)
+     * @param tuple
+     * @return  null if not found
+     */
+    public Object findField(Tuple tuple) {
+        if (tuple==null) {
+            return null;
+        }
+        // verify stream name matches, if stream name was specified
+        if ( streamName!=null &&
+                !streamName.equalsIgnoreCase( streamKind.getStreamId(tuple) ) ) {
+            return null;
+        }
+
+        Object curr = null;
+        for (int i=0; i < field.length; i++) {
+            if (i==0) {
+                if (tuple.contains(field[i]) )
+                    curr = tuple.getValueByField(field[i]);
+                else
+                    return null;
+            }  else  {
+                curr = ((Map) curr).get(field[i]);
+                if (curr==null)
+                    return null;
+            }
+        }
+        return curr;
+    }
+
+} // class FieldSelector

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/InvalidTuple.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/InvalidTuple.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.hortonworks.streamline.streams.runtime.storm.bolt.query;
+
+import org.apache.storm.tuple.Tuple;
+
+class InvalidTuple extends Exception {
+    Tuple tuple;
+
+    public InvalidTuple(String errMsg, Tuple tuple) {
+        super(errMsg);
+        this.tuple = tuple;
+    }
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/JoinComparator.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/JoinComparator.java
@@ -43,7 +43,7 @@ abstract class JoinComparator {
         // fill in missing stream name (if any) with default stream name
         if (f1.streamName==null) {
             if (f2.streamName==null) {
-                throw new IllegalArgumentException("At least one field selector must explicitly specify stream name prefix in comparator: "
+                throw new IllegalArgumentException("At least one field selector must explicitly specify streamname: prefix in comparator: "
                         + fieldStr1 + "," + fieldStr2);
             }
             f1.streamName = defaultStream;

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/JoinComparator.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/JoinComparator.java
@@ -21,7 +21,9 @@ package com.hortonworks.streamline.streams.runtime.storm.bolt.query;
 
 import org.apache.storm.tuple.Tuple;
 
-abstract class JoinComparator {
+import java.io.Serializable;
+
+public abstract class JoinComparator implements Serializable {
     private final String fieldStr1; // 1st arg
     private final String fieldStr2; // 2nd arg
 

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/JoinComparator.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/JoinComparator.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.hortonworks.streamline.streams.runtime.storm.bolt.query;
+
+
+import org.apache.storm.tuple.Tuple;
+
+abstract class JoinComparator {
+    private final String fieldStr1; // from 1st stream
+    private final String fieldStr2; // from 2nd stream
+
+    FieldSelector field1;
+    FieldSelector field2;
+
+    public JoinComparator(String fieldSelector1, String fieldSelector2) {
+        this.fieldStr1 = fieldSelector1;
+        this.fieldStr2 = fieldSelector2;
+    }
+
+    // Unfortunately we need to do some additional initialization here after construction
+    // as these two args are not available at construction time
+    public void init(RealtimeJoinBolt.StreamKind streamKind, String defaultStream) {
+        this.field1 = new FieldSelector(fieldStr1, streamKind);
+        this.field2 = new FieldSelector(fieldStr2, streamKind);
+        if (field1.streamName==null)
+            field1.streamName = defaultStream;
+        if (field2.streamName==null)
+            field2.streamName = defaultStream;
+        if (field1.streamName.equalsIgnoreCase(field2.streamName))
+            throw new IllegalArgumentException("Both field selectors in cannot refer to same stream in a comparator: "
+                    + fieldStr1 + "," + fieldStr2);
+    }
+
+    public FieldSelector getField1() {
+        return field1;
+    }
+
+    public FieldSelector getField2() {
+        return field2;
+    }
+
+    // TODO: see how to optimize this lookup as it falls in critical path
+    public FieldSelector getFieldForStream(String stream) {
+        if (field1.streamName.equalsIgnoreCase(stream))
+            return field1;
+        else if (field2.streamName.equalsIgnoreCase(stream))
+            return field2;
+        return null;
+    }
+
+    public abstract boolean compare(Tuple t1, Tuple t2) throws InvalidTuple;
+
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/RTJoinExampleTopology.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/RTJoinExampleTopology.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.hortonworks.streamline.streams.runtime.storm.bolt.query;
+
+import com.hortonworks.streamline.streams.runtime.storm.bolt.query.RealtimeJoinBolt.StreamKind;
+import org.apache.storm.Config;
+import org.apache.storm.StormSubmitter;
+import org.apache.storm.testing.FeederSpout;
+import org.apache.storm.topology.BasicOutputCollector;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.topology.TopologyBuilder;
+import org.apache.storm.topology.base.BaseBasicBolt;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.Values;
+//import org.apache.storm.utils.NimbusClient;
+
+import java.time.Duration;
+
+public class RTJoinExampleTopology {
+    public static void main(String[] args) throws Exception {
+//        if (!NimbusClient.isLocalOverride()) {
+//            throw new IllegalStateException("This example only works in local mode.  "
+//                    + "Run with storm local not storm jar");
+//        }
+        FeederSpout genderSpout = new FeederSpout(new Fields("id", "gender"));
+        FeederSpout ageSpout = new FeederSpout(new Fields("id", "age"));
+
+        TopologyBuilder builder = new TopologyBuilder();
+        builder.setSpout("genderSpout", genderSpout);
+        builder.setSpout("ageSpout", ageSpout);
+
+        // inner join of 'age' and 'gender' records on 'id' field
+        RealtimeJoinBolt joiner = new RealtimeJoinBolt(StreamKind.SOURCE)
+                .select("genderSpout:id,ageSpout:id,gender,age")
+                .from("genderSpout", 5, false)
+                .outerJoin("ageSpout", Duration.ofSeconds(5), false, Cmp.equal("genderSpout:id", "ageSpout:id") )
+                .withOutputStream("jstream");
+
+        builder.setBolt("joiner", joiner)
+                .fieldsGrouping("genderSpout", new Fields("id"))
+                .fieldsGrouping("ageSpout", new Fields("id"))         ;
+
+        builder.setBolt("printer", new PrinterBolt() ).shuffleGrouping("joiner", "jstream");
+
+        Config conf = new Config();
+        StormSubmitter.submitTopologyWithProgressBar("join-example", conf, builder.createTopology());
+
+        generateGenderData(genderSpout);
+
+        generateAgeData(ageSpout);
+    }
+
+    private static void generateAgeData(FeederSpout ageSpout) {
+        for (int i = 9; i >= 0; i--) {
+            ageSpout.feed(new Values(i, i + 20));
+        }
+    }
+
+    private static void generateGenderData(FeederSpout genderSpout) {
+        for (int i = 0; i < 10; i++) {
+            String gender;
+            if (i % 2 == 0) {
+                gender = "male";
+            }
+            else {
+                gender = "female";
+            }
+            genderSpout.feed(new Values(i, gender));
+        }
+    }
+}
+
+
+class PrinterBolt extends BaseBasicBolt {
+
+    @Override
+    public void execute(Tuple tuple, BasicOutputCollector collector) {
+        System.out.println(tuple);
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer ofd) {
+    }
+
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/RealtimeJoinBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/RealtimeJoinBolt.java
@@ -1,0 +1,638 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.hortonworks.streamline.streams.runtime.storm.bolt.query;
+
+import com.google.common.collect.LinkedListMultimap;
+import com.hortonworks.streamline.streams.StreamlineEvent;
+import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.topology.base.BaseRichBolt;
+import org.apache.storm.topology.base.BaseWindowedBolt;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Tuple;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Arrays;
+
+
+public class RealtimeJoinBolt extends BaseRichBolt  {
+    private static final Logger LOG = LoggerFactory.getLogger(RealtimeJoinBolt.class);
+    final static String EVENT_PREFIX = StreamlineEvent.STREAMLINE_EVENT + ".";
+
+    private String dataStream;
+    private String lookupStream;
+
+    protected FieldSelector[] outputFields = null;  // specified via bolt.select() ... used in declaring Output fields
+    private String outputStream;
+    private int retentionTime;
+    private int retentionCount;
+    private boolean timeBasedRetention;
+
+    private LinkedListMultimap<String, TupleInfo> lookupBuffer;
+
+    private ArrayDeque<Long> timeTracker; // for time based retention
+    private ArrayList<JoinInfo> joinCriteria = new ArrayList<>();
+
+    private OutputCollector collector;
+    private boolean dropOlderDuplicates;
+    private boolean streamLineProjection = false; // NOTE: Streamline Specific
+
+
+    protected enum JoinType {INNER, LEFT, RIGHT, OUTER}
+    private JoinType joinType;
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        String[] outputFieldNames = new String[outputFields.length];
+        for( int i=0; i<outputFields.length; ++i ) {
+            outputFieldNames[i] = outputFields[i].getOutputName() ;
+        }
+        if (outputStream !=null) {
+            declarer.declareStream(outputStream, new Fields(outputFieldNames));
+        } else {
+            declarer.declare(new Fields(outputFieldNames));
+        }
+    }
+
+    @Override
+    public void prepare(Map stormConf, TopologyContext context, OutputCollector collector) {
+        this.collector = collector;
+        if (timeBasedRetention) {
+            lookupBuffer =  LinkedListMultimap.create(50_000);
+            timeTracker = new ArrayDeque<Long>();
+        } else { // count Based Retention
+            lookupBuffer = LinkedListMultimap.create(retentionCount);
+        }
+    }
+
+    // Use streamId, source component name OR field in tuple to distinguish incoming tuple streams
+    public enum Selector { STREAM, SOURCE }
+    protected final Selector selectorType;
+
+    /**
+     * Constructor
+     * @param streamType   Specifies whether 'dataStream' refers to a stream name or source component id.
+     */
+    public RealtimeJoinBolt(Selector streamType) {
+        selectorType = streamType;
+    }
+
+
+    // NOTE: streamline specific
+    /**
+     * Calls  RealtimeJoinBolt(Selector.STREAM)
+     */
+    public RealtimeJoinBolt() {
+        this(Selector.STREAM);
+    }
+
+    /**
+     * Specify Fields to use for join. Field name can be nested x.y.z  (assumes x & y are of type Map<> )
+     * @param dataStreamField    Field to use for join on data stream.
+     * @param lookupStreamField  Field to use for join on lookup stream.
+     * @return
+     */
+    public RealtimeJoinBolt equal(String dataStreamField, String lookupStreamField) {
+        FieldSelector dataField = new FieldSelector(dataStream, dataStreamField);
+        FieldSelector lookupField = new FieldSelector(lookupStream, lookupStreamField);
+
+        if( dataField.equals(lookupField) ) {
+            throw new IllegalArgumentException("Both field selectors refer to same field: " + dataField.getOutputName());
+        }
+        joinCriteria.add(new JoinInfo(lookupField, dataField));
+        return this;
+    }
+
+    // NOTE: Streamline specific convenience method. Prefixes the key names with 'streamline-event.'
+    /**
+     * Specify Fields to use for join. Field name can be nested x.y.z  (assumes x & y are of type Map<> )
+     * @param dataStreamField    Field to use for join on data stream.
+     * @param lookupStreamField  Field to use for join on lookup stream.
+     * @return
+     */
+    public RealtimeJoinBolt streamlineEqual(String dataStreamField, String lookupStreamField) {
+        return equal(EVENT_PREFIX+dataStreamField, EVENT_PREFIX+lookupStreamField);
+    }
+
+
+    /**
+     * Introduces the buffered 'LookupStream' for inner join and retention policy
+     * @param lookupStream   Name of the stream (or source component Id) to be treated as a buffered 'LookupStream'
+     * @param retentionCount How many records to retain.
+     * @return
+     */
+    public RealtimeJoinBolt innerJoin(String lookupStream, BaseWindowedBolt.Count retentionCount, boolean dropOlderDuplicates) {
+        if(this.lookupStream!=null) {
+            throw  new IllegalArgumentException("Cannot declare a Lookup stream more than once");
+        }
+        this.lookupStream = lookupStream;
+        this.dropOlderDuplicates = dropOlderDuplicates;
+        this.retentionCount = retentionCount.value;
+        this.timeBasedRetention = false;
+        this.joinType = JoinType.INNER;
+        return this;
+    }
+
+    public RealtimeJoinBolt innerJoin(String lookupStream, BaseWindowedBolt.Duration retentionTime, boolean dropOlderDuplicates) {
+        if (this.lookupStream!=null) {
+            throw  new IllegalArgumentException("Cannot declare a Lookup stream more than once");
+        }
+        if (retentionTime.value<=0) {
+            throw  new IllegalArgumentException("Retention time must be positive number");
+        }
+
+        this.lookupStream = lookupStream;
+        this.dropOlderDuplicates = dropOlderDuplicates;
+        this.retentionTime = retentionTime.value;
+        this.timeBasedRetention = true;
+        this.joinType = JoinType.INNER;
+        return this;
+    }
+
+    public RealtimeJoinBolt leftJoin(String lookupStream, BaseWindowedBolt.Count retentionCount, boolean dropOlderDuplicates) {
+        if(this.lookupStream!=null) {
+            throw  new IllegalArgumentException("Cannot declare a Lookup stream more than once");
+        }
+        this.lookupStream = lookupStream;
+        this.dropOlderDuplicates = dropOlderDuplicates;
+        this.retentionCount = retentionCount.value;
+        this.timeBasedRetention = false;
+        this.joinType = JoinType.LEFT;
+        return this;
+    }
+
+    public RealtimeJoinBolt leftJoin(String lookupStream, BaseWindowedBolt.Duration retentionTime, boolean dropOlderDuplicates) {
+        if(this.lookupStream!=null) {
+            throw  new IllegalArgumentException("Cannot declare a Lookup stream more than once");
+        }
+        if (retentionTime.value<=0) {
+            throw  new IllegalArgumentException("Retention time must be positive number");
+        }
+        this.lookupStream = lookupStream;
+        this.dropOlderDuplicates = dropOlderDuplicates;
+        this.retentionTime = retentionTime.value;
+        this.timeBasedRetention = true;
+        this.joinType = JoinType.LEFT;
+        return this;
+    }
+
+    public RealtimeJoinBolt rightJoin(String lookupStream, BaseWindowedBolt.Count retentionCount, boolean dropOlderDuplicates) {
+        if(this.lookupStream!=null) {
+            throw  new IllegalArgumentException("Cannot declare a Lookup stream more than once");
+        }
+        this.lookupStream = lookupStream;
+        this.dropOlderDuplicates = dropOlderDuplicates;
+        this.retentionCount = retentionCount.value;
+        this.timeBasedRetention = false;
+        this.joinType = JoinType.RIGHT;
+        return this;
+    }
+
+    public RealtimeJoinBolt rightJoin(String lookupStream, BaseWindowedBolt.Duration retentionTime, boolean dropOlderDuplicates) {
+        if(this.lookupStream!=null) {
+            throw  new IllegalArgumentException("Cannot declare a Lookup stream more than once");
+        }
+        if (retentionTime.value<=0) {
+            throw  new IllegalArgumentException("Retention time must be positive number");
+        }
+        this.lookupStream = lookupStream;
+        this.dropOlderDuplicates = dropOlderDuplicates;
+        this.retentionTime = retentionTime.value;
+        this.timeBasedRetention = true;
+        this.joinType = JoinType.RIGHT;
+        return this;
+    }
+
+    public RealtimeJoinBolt outerJoin(String lookupStream, BaseWindowedBolt.Count retentionCount, boolean dropOlderDuplicates) {
+        if(this.lookupStream!=null) {
+            throw  new IllegalArgumentException("Cannot declare a Lookup stream more than once");
+        }
+        this.lookupStream = lookupStream;
+        this.dropOlderDuplicates = dropOlderDuplicates;
+        this.retentionCount = retentionCount.value;
+        this.timeBasedRetention = false;
+        this.joinType = JoinType.OUTER;
+        return this;
+    }
+
+    public RealtimeJoinBolt outerJoin(String lookupStream, BaseWindowedBolt.Duration retentionTime, boolean dropOlderDuplicates) {
+        if(this.lookupStream!=null) {
+            throw  new IllegalArgumentException("Cannot declare a Lookup stream more than once");
+        }
+        if (retentionTime.value<=0) {
+            throw  new IllegalArgumentException("Retention time must be positive number");
+        }
+        this.lookupStream = lookupStream;
+        this.dropOlderDuplicates = dropOlderDuplicates;
+        this.retentionTime = retentionTime.value;
+        this.timeBasedRetention = true;
+        this.joinType = JoinType.OUTER;
+        return this;
+    }
+
+    public RealtimeJoinBolt dataStream(String dataStream) {
+        if (this.dataStream!=null) {
+            throw  new IllegalArgumentException("Cannot declare a Data stream more than once");
+        }
+        this.dataStream = dataStream;
+        return this;
+    }
+
+    /**
+     * Specify output fields
+     *      e.g: .select("lookupField, stream2:dataField, field3")
+     * Nested Key names are supported for nested types:
+     *      e.g: .select("outerKey1.innerKey1, outerKey1.innerKey2, stream3:outerKey2.innerKey3)"
+     * Inner types (non leaf) must be Map<> in order to support nested lookup using this dot notation
+     * This selected fields implicitly declare the output fieldNames for the bolt based.
+     * @param commaSeparatedKeys
+     * @return
+     */
+    public RealtimeJoinBolt select(String commaSeparatedKeys) {
+        String[] fieldNames = commaSeparatedKeys.split(",");
+
+        outputFields = new FieldSelector[fieldNames.length];
+        for (int i = 0; i < fieldNames.length; i++) {
+            outputFields[i] = new FieldSelector(fieldNames[i]);
+        }
+        return this;
+    }
+
+    /** Convenience method for Streamline that prefixes each keyname with 'streamline-event.'
+     *
+     * @param commaSeparatedKeys
+     * @return
+     */
+    public RealtimeJoinBolt streamlineSelect(String commaSeparatedKeys) {
+        String prefixedKeys = convertToStreamLineKeys(commaSeparatedKeys);
+        streamLineProjection = true;
+        return  select(prefixedKeys);
+    }
+
+    public RealtimeJoinBolt withOutputStream(String streamName) {
+        this.outputStream = streamName;
+        return this;
+    }
+
+    @Override
+    public void execute(Tuple tuple) {
+        if (timeBasedRetention) {
+            expireAndAckTimedOutEntries(lookupBuffer);
+        }
+
+        String streamId = getStreamSelector(tuple);
+        if ( isLookupStream(streamId) ) {
+            String key = makeLookupTupleKey(tuple);
+            if(dropOlderDuplicates)
+                lookupBuffer.removeAll(key);
+            lookupBuffer.put(key, new TupleInfo(tuple) );
+
+            if(timeBasedRetention) {
+                timeTracker.add(System.currentTimeMillis());
+            } else {  // count based Rotation
+                if (lookupBuffer.size() > retentionCount) {
+                    TupleInfo expired = removeHead(lookupBuffer);
+                    if( (joinType==JoinType.RIGHT) || (joinType==JoinType.OUTER)  ) {
+                        emitUnMatchedTuples(expired);
+                    }
+                    collector.ack(expired.tuple);
+                }
+            }
+        } else if (isDataStream(streamId) ) {
+            List<TupleInfo> matches = matchWithLookupStream(tuple);
+            if (matches==null || matches.isEmpty() ) {  // no match
+                if (joinType==JoinType.LEFT ||  joinType==JoinType.OUTER ) {
+                    ArrayList<Object> outputTuple = doProjection(tuple, null);
+                    emit(outputTuple, tuple);
+                    return;
+                }
+                collector.ack(tuple);
+            }
+
+            for (TupleInfo lookupTuple : matches) { // match found
+                lookupTuple.unmatched = false;
+                ArrayList<Object> outputTuple = doProjection(lookupTuple.tuple, tuple);
+                emit(outputTuple, tuple, lookupTuple.tuple);
+            }
+            collector.ack(tuple);
+        } else {
+            LOG.warn("Received tuple from unexpected stream/source : {}. Tuple will be dropped.", streamId);
+        }
+    }
+
+    private String makeLookupTupleKey(Tuple tuple) {
+        StringBuffer key = new StringBuffer();
+        for (JoinInfo ji : joinCriteria) {
+            String partialKey = findField(ji.lookupField, tuple).toString();
+            key.append( partialKey );
+            key.append(".");
+        }
+        return key.toString();
+    }
+
+    private String makeDataTupleKey(Tuple tuple) {
+        StringBuffer key = new StringBuffer();
+        for (JoinInfo ji : joinCriteria) {
+            String partialKey = findField(ji.dataField, tuple).toString();
+            key.append( partialKey );
+            key.append(".");
+        }
+        return key.toString();
+    }
+
+    // returns null if no match
+    private List<TupleInfo> matchWithLookupStream(Tuple lookupTuple) {
+        String key = makeDataTupleKey(lookupTuple);
+        return lookupBuffer.get(key);
+    }
+
+    // Removes timedout entries from lookupBuffer & timeTracker. Acks tuples being expired.
+    private void expireAndAckTimedOutEntries(LinkedListMultimap<String, TupleInfo> lookupBuffer) {
+        Long expirationTime = System.currentTimeMillis() - retentionTime;
+        Long  insertionTime = timeTracker.peek();
+        while ( insertionTime!=null && expirationTime.compareTo(insertionTime) > 0) {
+            TupleInfo expired = removeHead(lookupBuffer);
+            timeTracker.pop();
+            if ( joinType == JoinType.RIGHT || joinType == JoinType.OUTER )
+                emitUnMatchedTuples(expired);
+            collector.ack(expired.tuple);
+            insertionTime = timeTracker.peek();
+        }
+    }
+
+    private void emitUnMatchedTuples(TupleInfo expired) {
+        if(expired.unmatched) {
+            ArrayList<Object> outputTuple = doProjection(expired.tuple, null);
+            emit(outputTuple, expired.tuple);
+        }
+    }
+
+    private static TupleInfo removeHead(LinkedListMultimap<String, TupleInfo> lookupBuffer) {
+        List<Map.Entry<String, TupleInfo>> entries = lookupBuffer.entries();
+        return entries.remove(0).getValue();
+    }
+
+
+    private void emit(ArrayList<Object> outputTuple, Tuple anchor) {
+        if ( outputStream ==null )
+            collector.emit(anchor, outputTuple);
+        else
+            collector.emit(outputStream, anchor, outputTuple);
+    }
+
+    private void emit(ArrayList<Object> outputTuple, Tuple dataTupleAnchor, Tuple lookupTupleAnchor) {
+        List<Tuple> anchors = Arrays.asList(dataTupleAnchor, lookupTupleAnchor);
+        if ( outputStream ==null )
+            collector.emit(anchors, outputTuple);
+        else
+            collector.emit(outputStream, anchors, outputTuple);
+    }
+
+    private boolean isDataStream(String streamId) {
+        return streamId.equals(dataStream);
+    }
+
+    private boolean isLookupStream(String streamId) {
+        return streamId.equals(lookupStream);
+    }
+
+    // Returns either the source component name or the stream name for the tuple
+    private String getStreamSelector(Tuple ti) {
+        switch (selectorType) {
+            case STREAM:
+                return ti.getSourceStreamId();
+            case SOURCE:
+                return ti.getSourceComponent();
+            default:
+                throw new RuntimeException(selectorType + " stream selector type not yet supported");
+        }
+    }
+
+    // Extract the field from tuple. Field may be nested field (x.y.z)
+    protected Object findField(FieldSelector fieldSelector, Tuple tuple) {
+        if (tuple==null) {
+            return null;
+        }
+        // very stream name matches, it stream name was specified
+        if ( fieldSelector.streamName!=null &&
+                !fieldSelector.streamName.equalsIgnoreCase( getStreamSelector(tuple) ) ) {
+            return null;
+        }
+
+        Object curr = null;
+        for (int i=0; i < fieldSelector.field.length; i++) {
+            if (i==0) {
+                if (tuple.contains(fieldSelector.field[i]) )
+                    curr = tuple.getValueByField(fieldSelector.field[i]);
+                else
+                    return null;
+            }  else  {
+                curr = ((Map) curr).get(fieldSelector.field[i]);
+                if (curr==null)
+                    return null;
+            }
+        }
+        return curr;
+    }
+
+    /** Performs projection on the tuples based on 'projectionFields'
+     *
+     * @param tuple1   can be null
+     * @param tuple2   can be null
+     * @return   project fields
+     */
+
+    protected ArrayList<Object> doProjection(Tuple tuple1, Tuple tuple2) {
+        if(streamLineProjection)
+            return doStreamlineProjection(tuple1, tuple2);
+
+        ArrayList<Object> result = new ArrayList<>(outputFields.length);
+        for ( int i = 0; i < outputFields.length; i++ ) {
+            FieldSelector outField = outputFields[i];
+            Object field = findField(outField, tuple1) ;
+            if (field==null)
+                field = findField(outField, tuple2);
+            result.add(field); // adds null if field is not found in both tuples
+        }
+        return result;
+    }
+
+    // NOTE: Streamline specific convenience method. Creates output tuple as a StreamlineEvent
+    protected ArrayList<Object> doStreamlineProjection(Tuple tuple1, Tuple tuple2) {
+//        String flattenedKey = projectionKeys[i].getOutputName();
+//        String outputKeyName = dropStreamLineEventPrefix(flattenedKey); // drops the "streamline-event." prefix
+        StreamlineEventImpl.Builder eventBuilder = StreamlineEventImpl.builder();
+
+        ArrayList<Object> result = new ArrayList<>(outputFields.length);
+        for ( int i = 0; i < outputFields.length; i++ ) {
+            FieldSelector outField = outputFields[i];
+
+            Object field = findField(outField, tuple1) ;
+            if (field==null)
+                field = findField(outField, tuple2);
+            String outputKeyName = dropStreamLineEventPrefix(outField.getOutputName() );
+            eventBuilder.put(outputKeyName, field); // adds null if field is not found in both tuples
+        }
+
+        ArrayList<Object> resultRow = new ArrayList<>();
+        StreamlineEventImpl slEvent = eventBuilder.dataSourceId("multiple sources").build();
+        resultRow.add(slEvent);
+        return resultRow;
+
+    }
+
+
+    // Prefixes each key with 'streamline-event.' Example:
+    //   arg = "stream1:key1, key2, stream2:key3.key4, key5"
+    //   result  = "stream1:streamline-event.key1, streamline-event.key2, stream2:streamline-event.key3.key4, streamline-event.key5"
+    private static String convertToStreamLineKeys(String commaSeparatedKeys) {
+        String[] keyNames = commaSeparatedKeys.replaceAll("\\s+","").split(",");
+
+        String[] prefixedKeys = new String[keyNames.length];
+
+        for (int i = 0; i < keyNames.length; i++) {
+            FieldSelector fs = new FieldSelector(keyNames[i]);
+            if (fs.streamName==null)
+                prefixedKeys[i] =  EVENT_PREFIX + String.join(".", fs.getField());
+            else
+                prefixedKeys[i] =  fs.streamName + ":" + EVENT_PREFIX + String.join(".", fs.getField());
+        }
+
+        return String.join(", ", prefixedKeys);
+    }
+
+    private static String dropStreamLineEventPrefix(String flattenedKey) {
+        int pos = flattenedKey.indexOf(EVENT_PREFIX);
+        if(pos==0)
+            return flattenedKey.substring(EVENT_PREFIX.length());
+        return flattenedKey.substring(0,pos) + flattenedKey.substring(pos+EVENT_PREFIX.length());
+    }
+
+}
+
+
+class FieldSelector implements Serializable {
+    final static long serialVersionUID = 2L;
+
+    String streamName;    // can be null;
+    String[] field;       // nested field "x.y.z"  becomes => String["x","y","z"]
+    String outputName;    // either "stream1:x.y.z" or "x.y.z" depending on whether stream name is present.
+
+    public FieldSelector(String fieldDescriptor)  {  // sample fieldDescriptor = "stream1:x.y.z"
+        int pos = fieldDescriptor.indexOf(':');
+
+        if (pos>0) {  // stream name is specified
+            streamName = fieldDescriptor.substring(0,pos).trim();
+            outputName = fieldDescriptor.trim();
+            field =  fieldDescriptor.substring(pos+1, fieldDescriptor.length()).split("\\.");
+            return;
+        }
+
+        // stream name unspecified
+        streamName = null;
+        if(pos==0) {
+            outputName = fieldDescriptor.substring(1, fieldDescriptor.length() ).trim();
+
+        } else if (pos<0) {
+            outputName = fieldDescriptor.trim();
+        }
+        field =  outputName.split("\\.");
+    }
+
+    /**
+     * @param stream name of stream
+     * @param fieldDescriptor  Simple fieldDescriptor like "x.y.z" and w/o a 'stream1:' stream qualifier.
+     */
+    public FieldSelector(String stream, String fieldDescriptor)  {
+        this(stream + ":" + fieldDescriptor);
+        if(fieldDescriptor.indexOf(":")>=0) {
+            throw new IllegalArgumentException("Not expecting stream qualifier ':' in '" + fieldDescriptor
+                    + "'. Stream name '" + stream +  "' is implicit in this context");
+        }
+        this.streamName = stream;
+    }
+
+    public String[] getField() {
+        return field;
+    }
+
+    public String getFieldName() {
+        if(streamName!=null)
+            return streamName + ":" + field;
+        return getOutputName();
+    }
+
+
+    public String getOutputName() {
+        return outputName;
+    }
+
+    @Override
+    public String toString() {
+        return outputName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        try {
+            FieldSelector that = (FieldSelector) o;
+            return outputName != null ? outputName.equals(that.outputName) : that.outputName == null;
+        } catch (ClassCastException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return outputName != null ? outputName.hashCode() : 0;
+    }
+}
+
+
+class JoinInfo implements Serializable {
+    final static long serialVersionUID = 1L;
+
+    FieldSelector lookupField;           // field for the current stream
+    FieldSelector dataField;      // field for the other (2nd) stream
+
+
+    public JoinInfo(FieldSelector lookupField, FieldSelector dataField) {
+        this.lookupField = lookupField;
+        this.dataField = dataField;
+    }
+
+} // class JoinInfo
+
+class TupleInfo {
+    boolean unmatched = true; // indicates if 'tuple' has been matched with at least one tuple from other stream
+    Tuple tuple;
+
+    public TupleInfo(Tuple tuple) {
+        this.tuple = tuple;
+    }
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/SLCmp.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/SLCmp.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.hortonworks.streamline.streams.runtime.storm.bolt.query;
+
+// Streamline specific join comparators
+public class SLCmp {
+
+    public static class Equal extends Cmp.Equal {
+        public Equal(String fieldSelector1, String fieldSelector2) {
+            super(   SLRealtimeJoinBolt.insertStreamlinePrefix(fieldSelector1)
+                    , SLRealtimeJoinBolt.insertStreamlinePrefix(fieldSelector2) );
+        }
+
+    }
+
+    public static Equal equal(String fieldSelector1, String fieldSelector2) {
+        return new Equal(fieldSelector1, fieldSelector2);
+    }
+
+
+    public static class IgnoreCase extends Cmp.IgnoreCase {
+        public IgnoreCase(String fieldSelector1, String fieldSelector2) {
+            super(  SLRealtimeJoinBolt.insertStreamlinePrefix(fieldSelector1)
+                   , SLRealtimeJoinBolt.insertStreamlinePrefix(fieldSelector2) );
+        }
+    }
+
+    public static IgnoreCase ignoreCase(String fieldSelector1, String fieldSelector2) {
+        return new IgnoreCase(fieldSelector1, fieldSelector2);
+    }
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/SLCmp.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/SLCmp.java
@@ -18,13 +18,15 @@
 
 package com.hortonworks.streamline.streams.runtime.storm.bolt.query;
 
+import java.io.Serializable;
+
 // Streamline specific join comparators
 public class SLCmp {
 
     // TODO: once Flux can call static method SLCmp.equal(), we dont need this class
     //   the streamline prefix insertion can be handled in the static method before instantiating
     //   Cmp.Equal
-    public static class Equal extends Cmp.Equal {
+    public static class Equal extends Cmp.Equal  implements Serializable {
         public Equal(String fieldSelector1, String fieldSelector2) {
             super(   SLRealtimeJoinBolt.insertStreamlinePrefix(fieldSelector1)
                     , SLRealtimeJoinBolt.insertStreamlinePrefix(fieldSelector2) );
@@ -37,7 +39,7 @@ public class SLCmp {
     }
 
 
-    public static class IgnoreCase extends Cmp.IgnoreCase {
+    public static class IgnoreCase extends Cmp.IgnoreCase implements Serializable {
         public IgnoreCase(String fieldSelector1, String fieldSelector2) {
             super(  SLRealtimeJoinBolt.insertStreamlinePrefix(fieldSelector1)
                    , SLRealtimeJoinBolt.insertStreamlinePrefix(fieldSelector2) );

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/SLCmp.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/SLCmp.java
@@ -21,6 +21,9 @@ package com.hortonworks.streamline.streams.runtime.storm.bolt.query;
 // Streamline specific join comparators
 public class SLCmp {
 
+    // TODO: once Flux can call static method SLCmp.equal(), we dont need this class
+    //   the streamline prefix insertion can be handled in the static method before instantiating
+    //   Cmp.Equal
     public static class Equal extends Cmp.Equal {
         public Equal(String fieldSelector1, String fieldSelector2) {
             super(   SLRealtimeJoinBolt.insertStreamlinePrefix(fieldSelector1)

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/SLRealtimeJoinBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/SLRealtimeJoinBolt.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.hortonworks.streamline.streams.runtime.storm.bolt.query;
+
+import com.hortonworks.streamline.streams.StreamlineEvent;
+import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.topology.base.BaseWindowedBolt;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Tuple;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This class derives from RealtimeBolt to customize the handling of 'streamline-event' prefix
+ *
+ *
+ **** Examples: ****
+ *
+ *  NOTE:  We use the streamline specific comparators from  SLCmp.* instead of Cmp.*
+ *
+ *  1) -- Count based retention window ---
+ *    new SLRealtimeJoinBolt(RealtimeJoinBolt.StreamKind.STREAM)
+ *            .from("purchases", 10, false )
+ *            .leftJoin("ads"  , 10, false, SLCmp.ignoreCase("ads:product","purchases:product")
+ *                                        , SLCmp.equal("userId", "purchases:userId") )
+ *            .select("orders:id , ads:userId, ads:product, orders:product, price")
+ *            .withOutputStream("outStreamName");
+ *
+ *
+ *   2) -- Time based retention window ---
+ *    new SLRealtimeJoinBolt(RealtimeJoinBolt.StreamKind.STREAM)
+ *            .from("purchases", Duration.ofSeconds(10), false )
+ *            .leftJoin("ads",   Duration.ofSeconds(20), false, SLCmp.ignoreCase("ads:product","purchases:product")
+ *                                                            , SLCmp.equal("userId", "purchases:userId") )
+ *            .select("orders:id , ads:userId, ads:product, orders:product, price")
+ *            .withOutputStream("outStreamName");
+ *
+ */
+public class SLRealtimeJoinBolt extends RealtimeJoinBolt {
+    final static String EVENT_PREFIX = StreamlineEvent.STREAMLINE_EVENT + ".";
+
+    /**
+     * Calls  RealtimeJoinBolt(StreamKind.STREAM)
+     */
+    public SLRealtimeJoinBolt() {
+        super(StreamKind.STREAM);
+    }
+
+    @Override
+    public SLRealtimeJoinBolt withOutputStream(String streamName) {
+        return (SLRealtimeJoinBolt) super.withOutputStream(streamName);
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        declarer.declareStream(this.outputStream, new Fields(StreamlineEvent.STREAMLINE_EVENT));
+    }
+
+    @Override
+    public SLRealtimeJoinBolt from(String stream, int retentionCount, boolean unique) {
+        return (SLRealtimeJoinBolt) super.from(stream, retentionCount, unique);
+    }
+
+    public SLRealtimeJoinBolt from(String stream, BaseWindowedBolt.Duration retentionTime, boolean unique) {
+        return (SLRealtimeJoinBolt) super.from(stream, Duration.ofMillis(retentionTime.value), unique);
+    }
+
+    @Override
+    public SLRealtimeJoinBolt innerJoin(String stream, int retentionCount, boolean unique, JoinComparator... comparators) {
+        return (SLRealtimeJoinBolt) super.innerJoin(stream, retentionCount, unique, comparators);
+    }
+
+    public SLRealtimeJoinBolt innerJoin(String stream, BaseWindowedBolt.Duration retentionTime, boolean unique, JoinComparator... comparators) {
+        return (SLRealtimeJoinBolt) super.innerJoin(stream, Duration.ofMillis(retentionTime.value), unique, comparators);
+    }
+
+    @Override
+    public SLRealtimeJoinBolt leftJoin(String stream, int retentionCount, boolean unique, JoinComparator... comparators) {
+        return (SLRealtimeJoinBolt) super.leftJoin(stream, retentionCount, unique, comparators);
+    }
+
+    public SLRealtimeJoinBolt leftJoin(String stream, BaseWindowedBolt.Duration retentionTime, boolean unique, JoinComparator... comparators) {
+        return (SLRealtimeJoinBolt) super.leftJoin(stream, Duration.ofMillis(retentionTime.value), unique, comparators);
+    }
+
+    @Override
+    public SLRealtimeJoinBolt rightJoin(String stream, int retentionCount, boolean unique, JoinComparator... comparators) {
+        return (SLRealtimeJoinBolt) super.rightJoin(stream, retentionCount, unique, comparators);
+    }
+
+    public SLRealtimeJoinBolt rightJoin(String stream, BaseWindowedBolt.Duration retentionTime, boolean unique, JoinComparator... comparators) {
+        return (SLRealtimeJoinBolt) super.rightJoin(stream, Duration.ofMillis(retentionTime.value), unique, comparators);
+    }
+
+    @Override
+    public SLRealtimeJoinBolt outerJoin(String stream, int retentionCount, boolean unique, JoinComparator... comparators) {
+        return (SLRealtimeJoinBolt) super.outerJoin(stream, retentionCount, unique, comparators);
+    }
+
+    public SLRealtimeJoinBolt outerJoin(String stream, BaseWindowedBolt.Duration retentionTime, boolean unique, JoinComparator... comparators) {
+        return (SLRealtimeJoinBolt) super.outerJoin(stream, Duration.ofMillis(retentionTime.value), unique, comparators);
+    }
+
+    /** Convenience method for Streamline that prefixes each keyname with 'streamline-event.'
+     *
+     * @param commaSeparatedKeys
+     * @return
+     */
+    public SLRealtimeJoinBolt select(String commaSeparatedKeys) {
+        String prefixedKeys = convertToStreamLineKeys(commaSeparatedKeys);
+        return (SLRealtimeJoinBolt) super.select(prefixedKeys);
+    }
+
+    /**
+     *  NOTE: Streamline specific convenience method. Creates output tuple as a StreamlineEvent
+     * @param tuple1  can be null
+     * @param tuple2  can be null
+     * @return
+     */
+    @Override
+    protected List<Object> doProjection(Tuple tuple1, Tuple tuple2) {
+        StreamlineEventImpl.Builder eventBuilder = StreamlineEventImpl.builder();
+
+        for ( int i = 0; i < outputFields.length; i++ ) {
+            FieldSelector outField = outputFields[i];
+
+            Object field = outField.findField(tuple1) ;
+            if (field==null)
+                field = outField.findField(tuple2);
+            String outputKeyName = dropStreamLineEventPrefix(outField.outputName );
+            eventBuilder.put(outputKeyName, field); // adds null if field is not found in both tuples
+        }
+
+        StreamlineEventImpl slEvent = eventBuilder.dataSourceId("multiple sources").build();
+        return Collections.singletonList(slEvent);
+    }
+
+    // Prefixes each key with 'streamline-event.' Example:
+    //   arg = "stream1:key1, key2, stream2:key3.key4, key5"
+    //   result  = "stream1:streamline-event.key1, streamline-event.key2, stream2:streamline-event.key3.key4, streamline-event.key5"
+    static String convertToStreamLineKeys(String commaSeparatedKeys) {
+        String[] keyNames = commaSeparatedKeys.replaceAll("\\s+","").split(",");
+
+        String[] prefixedKeys = new String[keyNames.length];
+        for (int i = 0; i < keyNames.length; i++) {
+            prefixedKeys[i] = insertStreamlinePrefix(keyNames[i]);
+        }
+
+        return String.join(", ", prefixedKeys);
+    }
+
+    public static String insertStreamlinePrefix(String keyName) {
+        FieldSelector fs = new FieldSelector(keyName, null); // 2nd arg here is null as we don't care about it. FieldSelector used only for parsing and not calling findField()
+        if (fs.streamName==null)
+            return   EVENT_PREFIX +  fs.canonicalFieldName();
+        else
+            return   fs.streamName + ":" + EVENT_PREFIX + fs.canonicalFieldName();
+    }
+
+    private static String dropStreamLineEventPrefix(String flattenedKey) {
+        int pos = flattenedKey.indexOf(EVENT_PREFIX);
+        if(pos==0)
+            return flattenedKey.substring(EVENT_PREFIX.length());
+        return flattenedKey.substring(0,pos) + flattenedKey.substring(pos+EVENT_PREFIX.length());
+    }
+}
+

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/SLRealtimeJoinBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/SLRealtimeJoinBolt.java
@@ -80,6 +80,12 @@ public class SLRealtimeJoinBolt extends RealtimeJoinBolt {
         return (SLRealtimeJoinBolt) super.from(stream, retentionCount, unique);
     }
 
+    @Override
+    public SLRealtimeJoinBolt from(String stream, Duration retentionTime, boolean unique) {
+        return (SLRealtimeJoinBolt) super.from(stream, retentionTime, unique);
+    }
+
+    // TODO: Eliminate this overload once Taylor fixes Flux to support static method calls like Duration.ofSeconds()
     public SLRealtimeJoinBolt from(String stream, BaseWindowedBolt.Duration retentionTime, boolean unique) {
         return (SLRealtimeJoinBolt) super.from(stream, Duration.ofMillis(retentionTime.value), unique);
     }
@@ -89,6 +95,12 @@ public class SLRealtimeJoinBolt extends RealtimeJoinBolt {
         return (SLRealtimeJoinBolt) super.innerJoin(stream, retentionCount, unique, comparators);
     }
 
+    @Override
+    public SLRealtimeJoinBolt innerJoin(String stream, Duration retentionTime, boolean unique, JoinComparator... comparators) {
+        return (SLRealtimeJoinBolt) super.innerJoin(stream, retentionTime, unique, comparators);
+    }
+
+    // TODO: Eliminate this overload once Taylor fixes Flux to support static method calls like Duration.ofSeconds()
     public SLRealtimeJoinBolt innerJoin(String stream, BaseWindowedBolt.Duration retentionTime, boolean unique, JoinComparator... comparators) {
         return (SLRealtimeJoinBolt) super.innerJoin(stream, Duration.ofMillis(retentionTime.value), unique, comparators);
     }
@@ -98,6 +110,12 @@ public class SLRealtimeJoinBolt extends RealtimeJoinBolt {
         return (SLRealtimeJoinBolt) super.leftJoin(stream, retentionCount, unique, comparators);
     }
 
+    @Override
+    public SLRealtimeJoinBolt leftJoin(String stream, Duration retentionTime, boolean unique, JoinComparator... comparators) {
+        return (SLRealtimeJoinBolt) super.leftJoin(stream, retentionTime, unique, comparators);
+    }
+
+    // TODO: Eliminate this overload once Taylor fixes Flux to support static method calls like Duration.ofSeconds()
     public SLRealtimeJoinBolt leftJoin(String stream, BaseWindowedBolt.Duration retentionTime, boolean unique, JoinComparator... comparators) {
         return (SLRealtimeJoinBolt) super.leftJoin(stream, Duration.ofMillis(retentionTime.value), unique, comparators);
     }
@@ -107,6 +125,12 @@ public class SLRealtimeJoinBolt extends RealtimeJoinBolt {
         return (SLRealtimeJoinBolt) super.rightJoin(stream, retentionCount, unique, comparators);
     }
 
+    @Override
+    public SLRealtimeJoinBolt rightJoin(String stream, Duration retentionTime, boolean unique, JoinComparator... comparators) {
+        return (SLRealtimeJoinBolt) super.rightJoin(stream, retentionTime, unique, comparators);
+    }
+
+    // TODO: Eliminate this overload once Taylor fixes Flux to support static method calls like Duration.ofSeconds()
     public SLRealtimeJoinBolt rightJoin(String stream, BaseWindowedBolt.Duration retentionTime, boolean unique, JoinComparator... comparators) {
         return (SLRealtimeJoinBolt) super.rightJoin(stream, Duration.ofMillis(retentionTime.value), unique, comparators);
     }
@@ -116,6 +140,12 @@ public class SLRealtimeJoinBolt extends RealtimeJoinBolt {
         return (SLRealtimeJoinBolt) super.outerJoin(stream, retentionCount, unique, comparators);
     }
 
+    @Override
+    public SLRealtimeJoinBolt outerJoin(String stream, Duration retentionTime, boolean unique, JoinComparator... comparators) {
+        return (SLRealtimeJoinBolt) super.outerJoin(stream, retentionTime, unique, comparators);
+    }
+
+    // TODO: Eliminate this overload once Taylor fixes Flux to support static method calls like Duration.ofSeconds()
     public SLRealtimeJoinBolt outerJoin(String stream, BaseWindowedBolt.Duration retentionTime, boolean unique, JoinComparator... comparators) {
         return (SLRealtimeJoinBolt) super.outerJoin(stream, Duration.ofMillis(retentionTime.value), unique, comparators);
     }

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/WindowedQueryBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/WindowedQueryBolt.java
@@ -136,11 +136,19 @@ public class WindowedQueryBolt extends JoinBolt {
         return resultRow;
     }
 
-    // Return the alias if any, or else the unaliased keyname
-    // Examples:
-    //      "stream1:key1.innerkey as  inner"  => "inner"
-    //      "stream1:key1 "  => "stream1:key1"
-    //      "key1 "  => "key1"
+    /** Return the alias if any, or else the unaliased keyname
+     *** Examples: ***
+     *      -  "stream1:key1.innerkey as  inner"  => "inner"
+     *      -  "stream1:key1 "  => "stream1:key1"
+     *      -  "key1 "  => "key1"
+     *
+     * @param keySpec  a field selector
+     * @return
+     */
+
+
+
+
     private static String getAliasOrKeyName(String keySpec) {
         Pattern pattern =  Pattern.compile(" +as +(\\w+)");
         Matcher result = pattern.matcher(keySpec);

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/TestRealtimeJoinBolt.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/TestRealtimeJoinBolt.java
@@ -1,0 +1,361 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.hortonworks.streamline.streams.runtime.storm.bolt.query;
+
+import com.hortonworks.streamline.streams.StreamlineEvent;
+import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
+import org.apache.storm.task.GeneralTopologyContext;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.topology.base.BaseWindowedBolt;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.TupleImpl;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class TestRealtimeJoinBolt {
+
+    String[] adImpressionFields = {"id", "userId", "product"};
+
+    Object[][] adImpressions = {
+            {1, 21, "book" },
+            {2, 22, "watch" },
+            {3, 23, "chair" },
+            {4, 24, "tv" },
+            {5, 25, "watch" },
+            {6, 26, "camera" },
+            {7, 27, "book" },
+            {8, 28, "tv" },
+            {9, 29, "camera" },
+            {10,30, "tv" } };
+
+    String[] orderFields = {"id", "userId", "product", "price"};
+
+    Object[][] orders = {
+            {11, 21, "book"  , 71},
+            {12, 22, "watch" , 330},
+            {13, 23, "chair" , 500},
+            {14, 29, "tv"    , 2000},    //  matches adImpression on [product] but not on [userId & product]
+            {15, 30, "watch" , 400},     //  matches adImpression on [userID] but not on [userId & product]
+            {16, 31, "mattress" , 900},  //  this has no match whatsoever in adImpressions
+    };
+
+
+
+    @Test
+    public void testSingleKey_InnerJoin_CountRetention() throws Exception {
+        ArrayList<Tuple> orderStream = makeStream("orders", orderFields, orders);
+        ArrayList<Tuple> adImpressionStream = makeStream("ads", adImpressionFields, adImpressions);
+
+        RealtimeJoinBolt bolt = new RealtimeJoinBolt(RealtimeJoinBolt.Selector.STREAM)
+                .dataStream("orders")
+                .innerJoin("ads", new BaseWindowedBolt.Count(10), false)
+                .equal(orderFields[1], adImpressionFields[1] )
+                .select("orders:id,ads:userId,ads:product,orders:product,price");
+
+        MockCollector collector = new MockCollector();
+        bolt.prepare(null, null, collector);
+
+        for (Tuple tuple : adImpressionStream) {
+            bolt.execute(tuple);
+        }
+        for (Tuple tuple : orderStream) {
+            bolt.execute(tuple);
+        }
+
+        printResults(collector);
+        Assert.assertEquals( 5, collector.actualResults.size() );
+    }
+
+    @Test
+    public void testSingleKey_InnerJoin_TimeRetention() throws Exception {
+        ArrayList<Tuple> orderStream = makeStream("orders", orderFields, orders);
+        ArrayList<Tuple> adImpressionStream = makeStream("ads", adImpressionFields, adImpressions);
+
+        RealtimeJoinBolt bolt = new RealtimeJoinBolt(RealtimeJoinBolt.Selector.STREAM)
+                .dataStream("orders")
+                .innerJoin("ads", new BaseWindowedBolt.Duration(2, TimeUnit.SECONDS), false)
+                .equal(orderFields[1], adImpressionFields[1] )
+                .select("orders:id,ads:userId,product,price");
+
+        MockCollector collector = new MockCollector();
+        bolt.prepare(null, null, collector);
+
+        for (Tuple tuple : adImpressionStream) {
+            bolt.execute(tuple);
+        }
+        for (Tuple tuple : orderStream) {
+            bolt.execute(tuple);
+        }
+
+        printResults(collector);
+        Assert.assertEquals( 5, collector.actualResults.size() );
+    }
+
+    @Test
+    public void testSingleKey_LeftJoin() throws Exception {
+        ArrayList<Tuple> orderStream = makeStream("orders", orderFields, orders);
+        ArrayList<Tuple> adImpressionStream = makeStream("ads", adImpressionFields, adImpressions);
+
+        RealtimeJoinBolt bolt = new RealtimeJoinBolt(RealtimeJoinBolt.Selector.STREAM)
+                .dataStream("ads")
+                .leftJoin("orders", new BaseWindowedBolt.Count(10), false)
+                .equal(adImpressionFields[1],orderFields[1] )
+                .select("orders:id,ads:userId,ads:product,orders:product,price");
+
+        MockCollector collector = new MockCollector();
+        bolt.prepare(null, null, collector);
+
+        for (Tuple tuple : orderStream) {
+            bolt.execute(tuple);
+        }
+
+        for (Tuple tuple : adImpressionStream) {
+            bolt.execute(tuple);
+        }
+
+        printResults(collector);
+        Assert.assertEquals( adImpressionStream.size(), collector.actualResults.size() );
+    }
+
+    @Test
+    public void testSingleKey_RightJoin() throws Exception {
+        ArrayList<Tuple> orderStream = makeStream("orders", orderFields, orders);
+        ArrayList<Tuple> adImpressionStream = makeStream("ads", adImpressionFields, adImpressions);
+
+        RealtimeJoinBolt bolt = new RealtimeJoinBolt(RealtimeJoinBolt.Selector.STREAM)
+                .dataStream("ads")
+                .rightJoin("orders", new BaseWindowedBolt.Duration(1, TimeUnit.SECONDS), false)
+                .equal(adImpressionFields[1], orderFields[1])
+                .select("orders:id,ads:userId,ads:product,orders:product,price");
+
+        MockCollector collector = new MockCollector();
+        bolt.prepare(null, null, collector);
+
+        for (Tuple tuple : orderStream) {
+            bolt.execute(tuple);
+        }
+
+        // emit all ads but last one
+        for (int i = 0; i < adImpressionStream.size()-1; i++) {
+            bolt.execute( adImpressionStream.get(i) );
+        }
+
+        // sleep to allow expiration of all buffered orders and trigger an emit of unmatched orders on next execute()
+        Thread.sleep(1_100);
+        bolt.execute( adImpressionStream.get(adImpressionStream.size()-1) );
+
+        printResults(collector);
+        Assert.assertEquals( orderStream.size(), collector.actualResults.size() );
+    }
+
+
+    @Test
+    public void testSingleKey_OuterJoin() throws Exception {
+        ArrayList<Tuple> orderStream = makeStream("orders", orderFields, orders);
+        ArrayList<Tuple> adImpressionStream = makeStream("ads", adImpressionFields, adImpressions);
+
+        RealtimeJoinBolt bolt = new RealtimeJoinBolt(RealtimeJoinBolt.Selector.STREAM)
+                .dataStream("ads")
+                .outerJoin("orders", new BaseWindowedBolt.Duration(1, TimeUnit.SECONDS), false)
+                .equal(adImpressionFields[1], orderFields[1])
+                .select("orders:id,ads:userId,ads:product,orders:product,price");
+
+        MockCollector collector = new MockCollector();
+        bolt.prepare(null, null, collector);
+
+        for (Tuple tuple : orderStream) {
+            bolt.execute(tuple);
+        }
+
+        // emit all ads but last one
+        for (int i = 0; i < adImpressionStream.size()-1; i++) {
+            bolt.execute( adImpressionStream.get(i) );
+        }
+
+        // sleep to allow expiration of all buffered orders and trigger an emit of unmatched orders on next execute()
+        Thread.sleep(1_100);
+        bolt.execute( adImpressionStream.get(adImpressionStream.size()-1) );
+
+        printResults(collector);
+        Assert.assertEquals( adImpressionStream.size()+2, collector.actualResults.size() );
+    }
+
+    @Test
+    public void testMultiKey_InnerJoin_CountRetention() throws Exception {
+        ArrayList<Tuple> orderStream = makeStream("orders", orderFields, orders);
+        ArrayList<Tuple> adImpressionStream = makeStream("ads", adImpressionFields, adImpressions);
+
+        RealtimeJoinBolt bolt = new RealtimeJoinBolt(RealtimeJoinBolt.Selector.STREAM)
+                .dataStream("orders")
+                .innerJoin("ads", new BaseWindowedBolt.Count(10), false)
+                .equal(orderFields[1], adImpressionFields[1] )
+                .equal(orderFields[2], adImpressionFields[2] )
+                .select("orders:id,ads:userId,ads:product,orders:product,price");
+
+        MockCollector collector = new MockCollector();
+        bolt.prepare(null, null, collector);
+
+        for (Tuple tuple : adImpressionStream) {
+            bolt.execute(tuple);
+        }
+        for (Tuple tuple : orderStream) {
+            bolt.execute(tuple);
+        }
+
+        printResults(collector);
+        Assert.assertEquals( 3, collector.actualResults.size() );
+    }
+
+
+    @Test
+    public void testStreamline_InnerJoin_TimeRetention() throws Exception {
+        ArrayList<Tuple> orderStream = makeStreamLineEventStream("orders", orderFields, orders);
+        ArrayList<Tuple> adImpressionStream = makeStreamLineEventStream("ads", adImpressionFields, adImpressions);
+
+        RealtimeJoinBolt bolt = new RealtimeJoinBolt(RealtimeJoinBolt.Selector.STREAM)
+                .dataStream("orders")
+                .innerJoin("ads", new BaseWindowedBolt.Duration(2, TimeUnit.SECONDS), false)
+                .streamlineEqual(orderFields[1], adImpressionFields[1] )
+                .streamlineEqual(orderFields[2], adImpressionFields[2] )
+                .streamlineSelect("orders:id,ads:userId,product,price");
+
+        MockCollector collector = new MockCollector();
+        bolt.prepare(null, null, collector);
+
+        for (Tuple tuple : adImpressionStream) {
+            bolt.execute(tuple);
+        }
+        for (Tuple tuple : orderStream) {
+            bolt.execute(tuple);
+        }
+
+        printResults_StreamLine(collector);
+        Assert.assertEquals( 3, collector.actualResults.size() );
+    }
+
+
+    private static ArrayList<Tuple> makeStream(String streamName, String[] fieldNames, Object[][] data) {
+        ArrayList<Tuple> result = new ArrayList<>();
+        MockContext mockContext = new MockContext(fieldNames);
+
+        for (Object[] record : data) {
+            TupleImpl rec = new TupleImpl(mockContext, Arrays.asList(record), 0, streamName);
+            result.add( rec );
+        }
+
+        return result;
+    }
+
+    // NOTE: Streamline Specific
+    private static ArrayList<Tuple> makeStreamLineEventStream (String streamName, String[] fieldNames, Object[][] records) {
+
+        MockContext mockContext = new MockContext(new String[]{StreamlineEvent.STREAMLINE_EVENT} );
+        ArrayList<Tuple> result = new ArrayList<>(records.length);
+
+        // convert each record into a HashMap using fieldNames as keys
+        for (Object[] record : records) {
+            HashMap<String,Object> recordMap = new HashMap<>( fieldNames.length );
+            for (int i = 0; i < fieldNames.length; i++) {
+                recordMap.put(fieldNames[i], record[i]);
+            }
+            StreamlineEvent streamLineEvent = new StreamlineEventImpl(recordMap, "multiple sources");
+            ArrayList<Object> tupleValues = new ArrayList<>(1);
+            tupleValues.add(streamLineEvent);
+            TupleImpl tuple = new TupleImpl(mockContext, tupleValues, 0, streamName);
+            result.add( tuple );
+        }
+
+        return result;
+    }
+
+
+    private static void printResults(MockCollector collector) {
+        int counter=0;
+        for (List<Object> rec : collector.actualResults) {
+            System.out.print(++counter +  ") ");
+            for (Object field : rec) {
+                System.out.print(field + ", ");
+            }
+            System.out.println("");
+        }
+    }
+
+    private static void printResults_StreamLine(MockCollector collector) {
+        int counter=0;
+        for (List<Object> rec : collector.actualResults) {
+            System.out.print(++counter +  ") ");
+            for (Object field : rec) {
+                Map<String, Object> data = ((StreamlineEvent)field);
+                data.forEach((k,v)-> {
+                    System.out.print(k + ":" + v + ", ");
+                } );
+                System.out.println();
+            }
+            System.out.println("");
+        }
+    }
+
+    static class MockCollector extends OutputCollector {
+        public ArrayList<List<Object>> actualResults = new ArrayList<>();
+
+        public MockCollector() {
+            super(null);
+        }
+
+        @Override
+        public List<Integer> emit(Collection<Tuple> anchors, List<Object> tuple) {
+            actualResults.add(tuple);
+            return null;
+        }
+
+        @Override
+        public List<Integer> emit(Tuple anchor, List<Object> tuple) {
+            actualResults.add(tuple);
+            return null;
+        }
+
+        @Override
+        public void ack(Tuple input) {
+            // no-op
+        }
+    } // class MockCollector
+
+    static class MockContext extends GeneralTopologyContext {
+
+        private final Fields fields;
+
+        public MockContext(String[] fieldNames) {
+            super(null, null, null, null, null, null);
+            this.fields = new Fields(fieldNames);
+        }
+
+        public String getComponentId(int taskId) {
+            return "component";
+        }
+
+        public Fields getComponentOutputFields(String componentId, String streamId) {
+            return fields;
+        }
+
+    }
+}

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/TestRealtimeJoinBolt.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/TestRealtimeJoinBolt.java
@@ -72,7 +72,7 @@ public class TestRealtimeJoinBolt {
                 .equal(orderFields[1], adImpressionFields[1] )
                 .select("orders:id,ads:userId,ads:product,orders:product,price");
 
-        MockCollector collector = new MockCollector();
+        MockCollector collector = new MockCollector(bolt.getOutputFields());
         bolt.prepare(null, null, collector);
 
         for (Tuple tuple : adImpressionStream) {
@@ -97,7 +97,7 @@ public class TestRealtimeJoinBolt {
                 .equal(orderFields[1], adImpressionFields[1] )
                 .select("orders:id,ads:userId,product,price");
 
-        MockCollector collector = new MockCollector();
+        MockCollector collector = new MockCollector(bolt.getOutputFields());
         bolt.prepare(null, null, collector);
 
         for (Tuple tuple : adImpressionStream) {
@@ -122,7 +122,7 @@ public class TestRealtimeJoinBolt {
                 .equal(adImpressionFields[1],orderFields[1] )
                 .select("orders:id,ads:userId,ads:product,orders:product,price");
 
-        MockCollector collector = new MockCollector();
+        MockCollector collector = new MockCollector(bolt.getOutputFields());
         bolt.prepare(null, null, collector);
 
         for (Tuple tuple : orderStream) {
@@ -148,7 +148,7 @@ public class TestRealtimeJoinBolt {
                 .equal(adImpressionFields[1], orderFields[1])
                 .select("orders:id,ads:userId,ads:product,orders:product,price");
 
-        MockCollector collector = new MockCollector();
+        MockCollector collector = new MockCollector(bolt.getOutputFields());
         bolt.prepare(null, null, collector);
 
         for (Tuple tuple : orderStream) {
@@ -178,9 +178,9 @@ public class TestRealtimeJoinBolt {
                 .dataStream("ads")
                 .outerJoin("orders", new BaseWindowedBolt.Duration(1, TimeUnit.SECONDS), false)
                 .equal(adImpressionFields[1], orderFields[1])
-                .select("orders:id,ads:userId,ads:product,orders:product,price");
+                .select(" orders:id as orderId, ads:userId  as  userId ,ads:product, orders:product, price"); // extra spaces are to test FieldDescriptor
 
-        MockCollector collector = new MockCollector();
+        MockCollector collector = new MockCollector(bolt.getOutputFields());
         bolt.prepare(null, null, collector);
 
         for (Tuple tuple : orderStream) {
@@ -212,7 +212,7 @@ public class TestRealtimeJoinBolt {
                 .equal(orderFields[2], adImpressionFields[2] )
                 .select("orders:id,ads:userId,ads:product,orders:product,price");
 
-        MockCollector collector = new MockCollector();
+        MockCollector collector = new MockCollector(bolt.getOutputFields());
         bolt.prepare(null, null, collector);
 
         for (Tuple tuple : adImpressionStream) {
@@ -239,7 +239,7 @@ public class TestRealtimeJoinBolt {
                 .streamlineEqual(orderFields[2], adImpressionFields[2] )
                 .streamlineSelect("orders:id,ads:userId,product,price");
 
-        MockCollector collector = new MockCollector();
+        MockCollector collector = new MockCollector(bolt.getOutputFields());
         bolt.prepare(null, null, collector);
 
         for (Tuple tuple : adImpressionStream) {
@@ -290,6 +290,8 @@ public class TestRealtimeJoinBolt {
 
 
     private static void printResults(MockCollector collector) {
+        System.out.println( String.join(",", collector.outputFields) );
+        System.out.println("--------------------------------------------------");
         int counter=0;
         for (List<Object> rec : collector.actualResults) {
             System.out.print(++counter +  ") ");
@@ -302,6 +304,8 @@ public class TestRealtimeJoinBolt {
 
     private static void printResults_StreamLine(MockCollector collector) {
         int counter=0;
+        System.out.println( String.join(",", collector.outputFields) );
+        System.out.println("--------------------------------------------------");
         for (List<Object> rec : collector.actualResults) {
             System.out.print(++counter +  ") ");
             for (Object field : rec) {
@@ -316,11 +320,15 @@ public class TestRealtimeJoinBolt {
     }
 
     static class MockCollector extends OutputCollector {
+        private final String[] outputFields;
+
         public ArrayList<List<Object>> actualResults = new ArrayList<>();
 
-        public MockCollector() {
+        public MockCollector(String[] outputFields) {
             super(null);
+            this.outputFields = outputFields;
         }
+
 
         @Override
         public List<Integer> emit(Collection<Tuple> anchors, List<Object> tuple) {

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/TestRealtimeJoinBolt.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/TestRealtimeJoinBolt.java
@@ -62,7 +62,7 @@ public class TestRealtimeJoinBolt {
 
 
     @Test
-    public void testSingleKey_InnerJoin_CountRetention_good() throws Exception {
+    public void testSingleKey_InnerJoin_CountRetention() throws Exception {
         ArrayList<Tuple> orderStream = makeStream("orders", orderFields, orders);
         ArrayList<Tuple> adImpressionStream = makeStream("ads", adImpressionFields, adImpressions);
 
@@ -117,8 +117,8 @@ public class TestRealtimeJoinBolt {
         ArrayList<Tuple> adImpressionStream = makeStream("ads", adImpressionFields, adImpressions);
 
         RealtimeJoinBolt bolt = new RealtimeJoinBolt(RealtimeJoinBolt.StreamKind.STREAM)
-                .from("ads", 10, false)
-                .leftJoin("orders", 10, false,  Cmp.equal("userId", "ads:userId"))
+                .from("ads", 1, false)
+                .leftJoin("orders", 12, false,  Cmp.equal("userId", "ads:userId"))
                 .select("ads:id, orders:id , ads:userId , ads:product , orders:product , price");
 
         MockCollector collector = new MockCollector(bolt.getOutputFields());
@@ -127,12 +127,9 @@ public class TestRealtimeJoinBolt {
         for (Tuple tuple : orderStream) {
             bolt.execute(tuple);
         }
-
         for (Tuple tuple : adImpressionStream) {
             bolt.execute(tuple);
         }
-        Thread.sleep( Duration.ofSeconds(2).toMillis() );
-        bolt.execute(makeTickTuple());
 
         printResults(collector);
         Assert.assertEquals( adImpressionStream.size(), collector.actualResults.size() );
@@ -229,7 +226,7 @@ public class TestRealtimeJoinBolt {
     }
 
     @Test
-    public void testMultiKey_InnerJoin_CountRetention_good() throws Exception {
+    public void testMultiKey_InnerJoin_CountRetention() throws Exception {
         ArrayList<Tuple> orderStream = makeStream("orders", orderFields, orders);
         ArrayList<Tuple> adImpressionStream = makeStream("ads", adImpressionFields, adImpressions);
 
@@ -255,7 +252,7 @@ public class TestRealtimeJoinBolt {
 
 
     @Test
-    public void testStreamline_InnerJoin_TimeRetention() throws Exception {
+    public void testStreamlineMultiKey_InnerJoin_TimeRetention() throws Exception {
         ArrayList<Tuple> orderStream = makeStreamLineEventStream("orders", orderFields, orders);
         ArrayList<Tuple> adImpressionStream = makeStreamLineEventStream("ads", adImpressionFields, adImpressions);
 

--- a/webservice/src/main/resources/app/scripts/components/StreamSidebar.jsx
+++ b/webservice/src/main/resources/app/scripts/components/StreamSidebar.jsx
@@ -20,7 +20,7 @@ import _ from 'lodash';
 export default class StreamSidebar extends Component {
   static propTypes = {
     // streamObj: PropTypes.object.isRequired,
-    streamType: PropTypes.string.isRequired, //input or output,
+    streamKind: PropTypes.string.isRequired, //input or output,
     inputStreamOptions: PropTypes.array
   };
 
@@ -61,16 +61,16 @@ export default class StreamSidebar extends Component {
   }
 
   render() {
-    const {streamType, streamObj} = this.props;
+    const {streamKind, streamObj} = this.props;
     this.fieldsArr = [];
     if (streamObj.fields) {
       this.getSchemaFields(streamObj.fields, 0);
     }
     return (
-      <div className={streamType === 'input'
+      <div className={streamKind === 'input'
         ? "modal-sidebar-left sidebar-overflow"
         : "modal-sidebar-right sidebar-overflow"}>
-        <h4>{streamType === 'input'
+        <h4>{streamKind === 'input'
             ? 'Input'
             : 'Output'}</h4>
         {this.state.showDropdown && this.props.inputStreamOptions.length > 1
@@ -94,7 +94,7 @@ export default class StreamSidebar extends Component {
               return (
                 <li key={i} style={styleObj}>
                   {
-                    streamType === "output"
+                    streamKind === "output"
                     ? <span title={field.keyPath}>{field.name}</span>
                     : field.name
                   }

--- a/webservice/src/main/resources/app/scripts/containers/Streams/TopologyEditor/ProcessorNodeForm.jsx
+++ b/webservice/src/main/resources/app/scripts/containers/Streams/TopologyEditor/ProcessorNodeForm.jsx
@@ -112,8 +112,8 @@ export default class ProcessorNodeForm extends Component {
     return (
       <Tabs id="ProcessorForm" defaultActiveKey={1} className="modal-tabs">
         <Tab eventKey={1} title="CONFIGURATION">
-          <StreamsSidebar ref="StreamSidebarInput" streamObj={streamObj} inputStreamOptions={this.state.inputStreamOptions} streamType="input"/> {childElement}
-          <StreamsSidebar ref="StreamSidebarOutput" streamObj={this.state.outputStreamObj} streamType="output"/>
+          <StreamsSidebar ref="StreamSidebarInput" streamObj={streamObj} inputStreamOptions={this.state.inputStreamOptions} streamKind="input"/> {childElement}
+          <StreamsSidebar ref="StreamSidebarOutput" streamObj={this.state.outputStreamObj} streamKind="output"/>
         </Tab>
         <Tab eventKey={2} title="NOTES">
           <NotesForm ref="NotesForm" testRunActivated={this.props.testRunActivated} description={this.state.description} onChangeDescription={this.handleNotesChange.bind(this)}/>

--- a/webservice/src/main/resources/app/scripts/containers/Streams/TopologyEditor/SinkNodeForm.jsx
+++ b/webservice/src/main/resources/app/scripts/containers/Streams/TopologyEditor/SinkNodeForm.jsx
@@ -477,7 +477,7 @@ export default class SinkNodeForm extends Component {
           </Form>
         </Scrollbars>
       </div>;
-    const inputSidebar = <StreamsSidebar ref="StreamSidebar" streamObj={streamObj} inputStreamOptions={streamObjArr} streamType="input"/>;
+    const inputSidebar = <StreamsSidebar ref="StreamSidebar" streamObj={streamObj} inputStreamOptions={streamObjArr} streamKind="input"/>;
     return (
       <Tabs id="SinkForm" activeKey={this.state.activeTabKey} className="modal-tabs" onSelect={this.onSelectTab}>
         <Tab eventKey={1} title="REQUIRED">

--- a/webservice/src/main/resources/app/scripts/containers/Streams/TopologyEditor/SourceNodeForm.jsx
+++ b/webservice/src/main/resources/app/scripts/containers/Streams/TopologyEditor/SourceNodeForm.jsx
@@ -338,7 +338,7 @@ export default class SourceNodeForm extends Component {
           </Form>
         </Scrollbars>
       </div>;
-    const outputSidebar = <StreamsSidebar ref="StreamSidebar" streamObj={this.state.streamObj} streamType="output"/>;
+    const outputSidebar = <StreamsSidebar ref="StreamSidebar" streamObj={this.state.streamObj} streamKind="output"/>;
     return (
       <Tabs id="SinkForm" activeKey={this.state.activeTabKey} className="modal-tabs" onSelect={this.onSelectTab}>
         <Tab eventKey={1} title="REQUIRED">


### PR DESCRIPTION
Sample usage:

        RealtimeJoinBolt bolt = new RealtimeJoinBolt(Selector.STREAM)
                .dataStream("orders")
                .innerJoin("ads", new BaseWindowedBolt.Duration(10, TimeUnit.SECONDS), false) // buffer each event for 10 seconds
                .equal("userId", "userID" )    // join keys corresponding to the above two streams
                .equal("productId", "productId" )
                .select("orders:id, ads:userId, orders:product, price");


**Features:**
 -  Join Types:  inner, left, right, outer
 -  MultKey joins
 -  Currently allows joining only two streams at a time. Can use cascaded joins for joining additional streams.
- Realtime joins and not windowed joins. Does not wait for Window expiration to occur before emitting. It buffers one of the streams and the other stream is joined with it in realtime. 

