### PR TITLE
STREAMLINE-781  Support aliasing of output field names in WindowedQuery.selectStreamline()

### DIFF
--- a/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/JoinBoltFluxComponent.java
+++ b/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/JoinBoltFluxComponent.java
@@ -43,7 +43,7 @@ import java.util.Map;
     {"type" : "left",  "stream": "s3", "key":"k3", "with": "s1"},
     {"type" : "inner", "stream": "s4", "key":"k4", "with": "s2"}
   ],
-  "outputKeys" : [ "k1", "k2" ],
+  "outputKeys" : [ "k1", "k2 as key2" ],
   "window" : {"windowLength" : {"class":".Window$Count", "count":100}, "slidingInterval":{"class":".Window$Count", "count":100}, "tsField":null, "lagMs":0},
   "outputStream" : "joinedStream1"
 }

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/TestWindowedQueryBolt.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/TestWindowedQueryBolt.java
@@ -66,7 +66,7 @@ public class TestWindowedQueryBolt {
         ArrayList<Tuple> userStream = makeStreamLineEventStream("users", userFields, users);
         TupleWindow window = makeTupleWindow(userStream);
         WindowedQueryBolt bolt = new WindowedQueryBolt("users", SL_PREFIX + "userId")
-                .selectStreamLine("name,users:city");
+                .selectStreamLine("name,users:city, users:city as cityagain");
         MockCollector collector = new MockCollector();
         bolt.prepare(null, null, collector);
         bolt.execute(window);
@@ -78,11 +78,11 @@ public class TestWindowedQueryBolt {
     @Test
     public void testNestedKeys_StreamLine() throws Exception {
         ArrayList<Tuple> userStream = makeStreamLineEventStream("users", userFields, users);
-        ArrayList<Tuple> cityStream = makeStreamLineEventStream("city", cityFields, cities);
+        ArrayList<Tuple> cityStream = makeStreamLineEventStream("cities", cityFields, cities);
         TupleWindow window = makeTupleWindow(userStream, cityStream);
         WindowedQueryBolt bolt = new WindowedQueryBolt("users", "city")
-                .join("city", "cityName", "users")
-                .selectStreamLine("name,users:city,cities:country");
+                .join("cities", "cityName", "users")
+                .selectStreamLine("name, users:city as city, cities:country");
         MockCollector collector = new MockCollector();
         bolt.prepare(null, null, collector);
         bolt.execute(window);
@@ -97,7 +97,7 @@ public class TestWindowedQueryBolt {
             for (Object field : rec) {
                 Map<String, Object> data = ((StreamlineEvent)field);
                 data.forEach((k,v)-> {
-                    System.out.print(k + ":" + v + ", ");
+                    System.out.print(k + "=" + v + ", ");
                 } );
                 System.out.println();
             }


### PR DESCRIPTION
Note to UI devs:
Sample of JSON coming from UI to perform aliasing: See the 'as' clause in the 'outputKeys' section below:

{
"from" : {"stream": "s1", "key": "k1"},
"joins" :
  [
    {"type" : "left",  "stream": "s2", "key":"k2", "with": "s1"},
  ],
  "outputKeys" : [ "k1", "s2:k2 as key2" ],
  "window" : { ...... },
  "outputStream" : "joinedStream1"
}


 