### PR TITLE
STREAMLINE-787: Populate the user principal into jax-rs SecurityContext from HttpServletRequest

### DIFF
--- a/streams/authorizer/src/main/java/com/hortonworks/streamline/streams/security/SecurityUtil.java
+++ b/streams/authorizer/src/main/java/com/hortonworks/streamline/streams/security/SecurityUtil.java
@@ -79,6 +79,14 @@ public final class SecurityUtil {
                 .collect(Collectors.toList());
     }
 
+    public static String getUserName(String principalName) {
+        return principalName == null ? null : principalName.split("[/@]")[0];
+    }
+
+    public static String getUserName(AuthenticationContext context) {
+        return context.getPrincipal() == null ? null : getUserName(context.getPrincipal().getName());
+    }
+
     private static boolean doCheckPermissions(StreamlineAuthorizer authorizer, Principal principal,
                                               String targetEntityNamespace, Long targetEntityId,
                                               EnumSet<Permission> permissions) {

--- a/streams/authorizer/src/main/java/com/hortonworks/streamline/streams/security/authentication/StreamlineKerberosRequestFilter.java
+++ b/streams/authorizer/src/main/java/com/hortonworks/streamline/streams/security/authentication/StreamlineKerberosRequestFilter.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.security.authentication;
+
+import com.hortonworks.streamline.common.exception.service.exception.request.WebserviceAuthorizationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.security.Principal;
+
+import static com.hortonworks.streamline.streams.security.authentication.StreamlineSecurityContext.KERBEROS_AUTH;
+
+@Provider
+public class StreamlineKerberosRequestFilter implements ContainerRequestFilter {
+    private static final Logger LOG = LoggerFactory.getLogger(StreamlineKerberosRequestFilter.class);
+
+    @Context
+    private HttpServletRequest httpRequest;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        Principal principal = httpRequest.getUserPrincipal();
+        String scheme = requestContext.getUriInfo().getRequestUri().getScheme();
+
+        LOG.debug("Method: {}, AuthType: {}, RemoteUser: {}, UserPrincipal: {}, Scheme: {}",
+                httpRequest.getMethod(), httpRequest.getAuthType(),
+                httpRequest.getRemoteUser(), principal, scheme);
+
+        if (principal == null || !httpRequest.getAuthType().equalsIgnoreCase(KERBEROS_AUTH)) {
+            throw new WebserviceAuthorizationException("Not authorized");
+        }
+
+        SecurityContext securityContext = new StreamlineSecurityContext(principal, scheme, KERBEROS_AUTH);
+        LOG.debug("SecurityContext {}", securityContext);
+        requestContext.setSecurityContext(securityContext);
+    }
+}

--- a/streams/authorizer/src/main/java/com/hortonworks/streamline/streams/security/authentication/StreamlineSecurityContext.java
+++ b/streams/authorizer/src/main/java/com/hortonworks/streamline/streams/security/authentication/StreamlineSecurityContext.java
@@ -15,7 +15,6 @@
  **/
 package com.hortonworks.streamline.streams.security.authentication;
 
-import com.hortonworks.streamline.streams.security.StreamlinePrincipal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,22 +26,31 @@ import java.security.Principal;
  */
 public class StreamlineSecurityContext implements SecurityContext {
     private static final Logger LOG = LoggerFactory.getLogger(StreamlineSecurityContext.class);
-    private final StreamlinePrincipal user;
-    private final String scheme;
 
-    public StreamlineSecurityContext(StreamlinePrincipal user, String scheme) {
-        this.user = user;
+    public static final String KERBEROS_AUTH = "KERBEROS";
+
+    private final Principal principal;
+    private final String scheme;
+    private final String authenticationScheme;
+
+    public StreamlineSecurityContext(Principal principal, String scheme) {
+        this(principal, scheme, SecurityContext.BASIC_AUTH);
+    }
+
+    public StreamlineSecurityContext(Principal principal, String scheme, String authenticationScheme) {
+        this.principal = principal;
         this.scheme = scheme;
+        this.authenticationScheme = authenticationScheme;
     }
 
     @Override
     public Principal getUserPrincipal() {
-        return user;
+        return principal;
     }
 
     @Override
     public boolean isUserInRole(String role) {
-        LOG.debug("isUserInRole user: {}, role: {}", user, role);
+        LOG.debug("isUserInRole user: {}, role: {}", principal, role);
         return false;
     }
 
@@ -53,7 +61,15 @@ public class StreamlineSecurityContext implements SecurityContext {
 
     @Override
     public String getAuthenticationScheme() {
-        return SecurityContext.BASIC_AUTH;
+        return authenticationScheme;
     }
 
+    @Override
+    public String toString() {
+        return "StreamlineSecurityContext{" +
+                "principal=" + principal +
+                ", scheme='" + scheme + '\'' +
+                ", authenticationScheme='" + authenticationScheme + '\'' +
+                '}';
+    }
 }

--- a/streams/authorizer/src/main/java/com/hortonworks/streamline/streams/security/impl/DefaultStreamlineAuthorizer.java
+++ b/streams/authorizer/src/main/java/com/hortonworks/streamline/streams/security/impl/DefaultStreamlineAuthorizer.java
@@ -18,6 +18,7 @@ package com.hortonworks.streamline.streams.security.impl;
 import com.hortonworks.streamline.streams.security.AuthenticationContext;
 import com.hortonworks.streamline.streams.security.AuthorizationException;
 import com.hortonworks.streamline.streams.security.Permission;
+import com.hortonworks.streamline.streams.security.SecurityUtil;
 import com.hortonworks.streamline.streams.security.StreamlineAuthorizer;
 import com.hortonworks.streamline.streams.security.catalog.AclEntry;
 import com.hortonworks.streamline.streams.security.catalog.Role;
@@ -30,6 +31,7 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class DefaultStreamlineAuthorizer implements StreamlineAuthorizer {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultStreamlineAuthorizer.class);
@@ -38,14 +40,39 @@ public class DefaultStreamlineAuthorizer implements StreamlineAuthorizer {
     public static final String CONF_ADMIN_PRINCIPALS = "adminPrincipals";
 
     private SecurityCatalogService catalogService;
-    private Set<String> adminPrincipals;
+    private Set<String> adminUsers;
 
     @SuppressWarnings("unchecked")
     @Override
     public void init(Map<String, Object> config) {
         LOG.info("Initializing DefaultStreamlineAuthorizer with config {}", config);
         catalogService = (SecurityCatalogService) config.get(CONF_CATALOG_SERVICE);
-        adminPrincipals = (Set<String>) config.get(CONF_ADMIN_PRINCIPALS);
+        adminUsers = ((Set<String>) config.get(CONF_ADMIN_PRINCIPALS)).stream()
+                .map(SecurityUtil::getUserName)
+                .collect(Collectors.toSet());
+        LOG.info("Admin users: {}", adminUsers);
+        mayBeAddAdminUsers();
+    }
+
+    private void mayBeAddAdminUsers() {
+        LOG.info("Checking user entries for admin users");
+        adminUsers.stream()
+                .filter(name -> {
+                    User user = catalogService.getUser(name);
+                    if (user != null) {
+                        LOG.info("Entry for user '{}' already exists", name);
+                        return false;
+                    } else {
+                        return true;
+                    }
+                })
+                .forEach(name -> {
+                    User user = new User();
+                    user.setName(name);
+                    user.setEmail(name + "@auto-generated");
+                    User addedUser = catalogService.addUser(user);
+                    LOG.info("Added admin user entry: {}", addedUser);
+                });
     }
 
     @Override
@@ -66,7 +93,7 @@ public class DefaultStreamlineAuthorizer implements StreamlineAuthorizer {
     @Override
     public void addAcl(AuthenticationContext ctx, String targetEntityNamespace, Long targetEntityId, EnumSet<Permission> permissions) {
         validateAuthenticationContext(ctx);
-        String userName = ctx.getPrincipal().getName();
+        String userName = SecurityUtil.getUserName(ctx);
         User user = catalogService.getUser(userName);
         if (user == null || user.getId() == null) {
             LOG.warn("No such user '{}'", userName);
@@ -84,7 +111,7 @@ public class DefaultStreamlineAuthorizer implements StreamlineAuthorizer {
     @Override
     public void removeAcl(AuthenticationContext ctx, String targetEntityNamespace, Long targetEntityId) {
         validateAuthenticationContext(ctx);
-        String userName = ctx.getPrincipal().getName();
+        String userName = SecurityUtil.getUserName(ctx);
         User user = catalogService.getUser(userName);
         if (user == null || user.getId() == null) {
             LOG.warn("No such user '{}'", userName);
@@ -98,8 +125,8 @@ public class DefaultStreamlineAuthorizer implements StreamlineAuthorizer {
 
     private boolean checkPermissions(AuthenticationContext ctx, String targetEntityNamespace, Long targetEntityId, EnumSet<Permission> permissions) {
         validateAuthenticationContext(ctx);
-        String userName = ctx.getPrincipal().getName();
-        if (adminPrincipals.contains(userName)) {
+        String userName = SecurityUtil.getUserName(ctx);
+        if (adminUsers.contains(userName)) {
             return true;
         }
         User user = catalogService.getUser(userName);
@@ -111,15 +138,15 @@ public class DefaultStreamlineAuthorizer implements StreamlineAuthorizer {
     }
 
     private void validateAuthenticationContext(AuthenticationContext ctx) {
-        if (ctx.getPrincipal() == null) {
+        if (ctx == null || ctx.getPrincipal() == null) {
             throw new AuthorizationException("No principal in AuthenticationContext");
         }
     }
 
     private boolean checkRole(AuthenticationContext ctx, String role) {
         validateAuthenticationContext(ctx);
-        String userName = ctx.getPrincipal().getName();
-        if (adminPrincipals.contains(userName)) {
+        String userName = SecurityUtil.getUserName(ctx);
+        if (adminUsers.contains(userName)) {
             return true;
         }
         User user = catalogService.getUser(userName);

--- a/streams/sdk/src/main/java/com/hortonworks/streamline/streams/security/AuthenticationContext.java
+++ b/streams/sdk/src/main/java/com/hortonworks/streamline/streams/security/AuthenticationContext.java
@@ -22,7 +22,6 @@ import java.security.Principal;
  * for authorization.
  */
 public final class AuthenticationContext {
-    private String remoteAddress;
     private Principal principal;
 
     public Principal getPrincipal() {
@@ -33,18 +32,9 @@ public final class AuthenticationContext {
         this.principal = principal;
     }
 
-    public String getRemoteAddress() {
-        return remoteAddress;
-    }
-
-    public void setRemoteAddress(String remoteAddress) {
-        this.remoteAddress = remoteAddress;
-    }
-
     @Override
     public String toString() {
         return "AuthenticationContext{" +
-                "remoteAddress='" + remoteAddress + '\'' +
                 ", principal=" + principal +
                 '}';
     }

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyEditorToolbarResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyEditorToolbarResource.java
@@ -132,7 +132,8 @@ public class TopologyEditorToolbarResource {
 
     private long getUserId(SecurityContext securityContext) {
         Principal principal = securityContext.getUserPrincipal();
-        String userName = principal != null ? principal.getName() : User.USER_ANONYMOUS;
+        String principalName = principal != null ? SecurityUtil.getUserName(principal.getName()) : null;
+        String userName = principalName != null ? principalName : User.USER_ANONYMOUS;
         User user = securityCatalogService.getUser(userName);
         if (user != null && user.getId() != null) {
             return user.getId();

--- a/webservice/src/main/java/com/hortonworks/streamline/webservice/StreamlineApplication.java
+++ b/webservice/src/main/java/com/hortonworks/streamline/webservice/StreamlineApplication.java
@@ -37,6 +37,7 @@ import com.hortonworks.streamline.storage.cache.writer.StorageWriter;
 import com.hortonworks.streamline.streams.exception.ConfigException;
 import com.hortonworks.streamline.streams.security.StreamlineAuthorizer;
 import com.hortonworks.streamline.streams.security.authentication.StreamlineBasicAuthorizationRequestFilter;
+import com.hortonworks.streamline.streams.security.authentication.StreamlineKerberosRequestFilter;
 import com.hortonworks.streamline.streams.security.impl.DefaultStreamlineAuthorizer;
 import com.hortonworks.streamline.streams.security.service.SecurityCatalogService;
 import com.hortonworks.streamline.streams.service.GenericExceptionMapper;
@@ -252,7 +253,7 @@ public class StreamlineApplication extends Application<StreamlineConfiguration> 
             authorizerConfig.put(DefaultStreamlineAuthorizer.CONF_CATALOG_SERVICE, securityCatalogService);
             authorizerConfig.put(DefaultStreamlineAuthorizer.CONF_ADMIN_PRINCIPALS, authorizerConf.getAdminPrincipals());
             authorizer.init(authorizerConfig);
-            environment.jersey().register(new StreamlineBasicAuthorizationRequestFilter());
+            environment.jersey().register(new StreamlineKerberosRequestFilter());
         } else {
             LOG.info("Authorizer config not set, setting noop authorizer");
             String noopAuthorizerClassName = "com.hortonworks.streamline.streams.security.impl.NoopAuthorizer";


### PR DESCRIPTION
I did some basic testing with the secure cluster and it appears to work. Need to do more testing.

When the user is not authorized, we return a 401 NotAuthorized response but UI seems to be hanging. Observed this while adding service pool.

Corresponding users for the admin principals listed in the streamline.yaml should be added via the user api before they can create entities. (E.g streamline-hdf user needs to be added in the streamline db before streamline-hdf@EXAMPLE.COM). This can be done by the same admin user.