### PR TITLE
Update Storm version to 1.0.2.3.0.0.0-310 to apply recent changes

### DIFF
--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -90,7 +90,7 @@ while getopts 'hvd:s:p:' flag; do
 done
 
 #Below command to update storm version will be called by RE script. Need to remove later. Adding now for convenience
-update_storm_version_command="$bootstrap_dir/update-storm-version.sh 1.0.2.2.1.0.0-165"
+update_storm_version_command="$bootstrap_dir/update-storm-version.sh 1.0.2.3.0.0.0-310"
 run_cmd $update_storm_version_command
 
 #---------------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <scala.version>2.10.5</scala.version>
         <schema-registry.version>0.2.0</schema-registry.version>
         <slf4j.version>1.7.12</slf4j.version>
-        <storm.version>1.0.2.3.0.0.0-304</storm.version>
+        <storm.version>1.0.2.3.0.0.0-310</storm.version>
         <woodstox-core-asl.version>4.4.1</woodstox-core-asl.version>
         <druid.tranquility.version>0.8.2</druid.tranquility.version>
         <spring.version>4.3.6.RELEASE</spring.version>


### PR DESCRIPTION
This patch is needed for pulling the change from STORM-2512: Make constructor public and add one more builder constructor.

The codebase of Streamline is already changed to apply STORM-2512, and without this patch, topology submission fails.