### PR TITLE
Quick Fix: Force using kafka-clients to 0.10.2.1 to use dynamic SASL jaas config

### DIFF
--- a/bootstrap/components/sinks/kafka-sink-topology-component.json
+++ b/bootstrap/components/sinks/kafka-sink-topology-component.json
@@ -6,7 +6,7 @@
   "builtin": true,
   "fieldHintProviderClass": "com.hortonworks.streamline.streams.cluster.bundle.impl.KafkaSinkBundleHintProvider",
   "transformationClass": "com.hortonworks.streamline.streams.layout.storm.KafkaBoltFluxComponent",
-  "mavenDeps": "org.apache.storm:storm-kafka-client:STORM_VERSION^org.slf4j:slf4j-log4j12^log4j:log4j^org.apache.zookeeper:zookeeper",
+  "mavenDeps": "org.apache.kafka:kafka-clients:0.10.2.1,org.apache.storm:storm-kafka-client:STORM_VERSION^org.slf4j:slf4j-log4j12^log4j:log4j^org.apache.zookeeper:zookeeper^org.apache.kafka:kafka-clients",
   "topologyComponentUISpecification": {
     "fields": [
       {

--- a/bootstrap/components/sources/kafka-source-topology-component.json
+++ b/bootstrap/components/sources/kafka-source-topology-component.json
@@ -6,7 +6,7 @@
   "builtin": true,
   "fieldHintProviderClass": "com.hortonworks.streamline.streams.cluster.bundle.impl.KafkaBundleHintProvider",
   "transformationClass": "com.hortonworks.streamline.streams.layout.storm.KafkaSpoutFluxComponent",
-  "mavenDeps": "org.apache.storm:storm-kafka-client:STORM_VERSION^org.slf4j:slf4j-log4j12^log4j:log4j^org.apache.zookeeper:zookeeper",
+  "mavenDeps": "org.apache.kafka:kafka-clients:0.10.2.1,org.apache.storm:storm-kafka-client:STORM_VERSION^org.slf4j:slf4j-log4j12^log4j:log4j^org.apache.zookeeper:zookeeper^org.apache.kafka:kafka-clients",
   "topologyComponentUISpecification": {
     "fields": [
       {


### PR DESCRIPTION
We're using dynamic SASL jaas config which is introduced at 0.10.2.0 for Kafka sources and sinks, but storm-kafka-client pulls kafka-clients 0.10.0.0 so the configuration is ignored in runtime.

This patch will fix the issue.