### PR TITLE
Quick Fix: exclude slf4j-log4j12 from HBase maven artifacts

### DIFF
--- a/bootstrap/components/sinks/hbase-sink-topology-component.json
+++ b/bootstrap/components/sinks/hbase-sink-topology-component.json
@@ -6,7 +6,7 @@
   "streamingEngine": "STORM",
   "fieldHintProviderClass": "com.hortonworks.streamline.streams.cluster.bundle.impl.HBaseBundleHintProvider",
   "transformationClass": "com.hortonworks.streamline.streams.layout.storm.HbaseBoltFluxComponent",
-  "mavenDeps": "org.apache.storm:storm-hbase:STORM_VERSION^org.slf4j:slf4j-log4j12,org.apache.hadoop:hadoop-hdfs:2.7.3.2.5.0.9-6,org.apache.hbase:hbase-server:1.1.2.2.5.0.9-6,org.apache.hbase:hbase-client:1.1.2.2.5.0.9-6",
+  "mavenDeps": "org.apache.storm:storm-hbase:STORM_VERSION^org.slf4j:slf4j-log4j12,org.apache.hadoop:hadoop-hdfs:2.7.3.2.5.0.9-6^org.slf4j:slf4j-log4j12,org.apache.hbase:hbase-server:1.1.2.2.5.0.9-6^org.slf4j:slf4j-log4j12,org.apache.hbase:hbase-client:1.1.2.2.5.0.9-6^org.slf4j:slf4j-log4j12",
   "topologyComponentUISpecification": {
     "fields": [
       {


### PR DESCRIPTION
* both log4j-over-slf4j and slf4j-log4j12 are in classpath

Change-Id: Id00d87d8a20c78ce208fa6be266ab0a214ca157f