### PR TITLE
Let hint provider handles SecurityContext and Subject

### DIFF
--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/AbstractBundleHintProvider.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/AbstractBundleHintProvider.java
@@ -21,6 +21,8 @@ import com.hortonworks.streamline.streams.catalog.NamespaceServiceClusterMapping
 import com.hortonworks.streamline.streams.catalog.exception.ClusterNotFoundException;
 import com.hortonworks.streamline.streams.cluster.service.EnvironmentService;
 
+import javax.security.auth.Subject;
+import javax.ws.rs.core.SecurityContext;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -36,7 +38,7 @@ public abstract class AbstractBundleHintProvider implements ComponentBundleHintP
     }
 
     @Override
-    public Map<Long, BundleHintsResponse> provide(Namespace namespace) {
+    public Map<Long, BundleHintsResponse> provide(Namespace namespace, SecurityContext securityContext, Subject subject) {
         Map<Long, BundleHintsResponse> hintMap = new HashMap<>();
 
         Collection<NamespaceServiceClusterMapping> serviceMappings = environmentService.listServiceClusterMapping(
@@ -48,14 +50,14 @@ public abstract class AbstractBundleHintProvider implements ComponentBundleHintP
                 throw new RuntimeException(new ClusterNotFoundException(clusterId));
             }
 
-            BundleHintsResponse response = new BundleHintsResponse(cluster, getHintsOnCluster(cluster));
+            BundleHintsResponse response = new BundleHintsResponse(cluster, getHintsOnCluster(cluster, securityContext, subject));
             hintMap.put(clusterId, response);
         }
 
         return hintMap;
     }
 
-    public abstract Map<String, Object> getHintsOnCluster(Cluster cluster);
+    public abstract Map<String, Object> getHintsOnCluster(Cluster cluster, SecurityContext securityContext, Subject subject);
 
     public abstract String getServiceName();
 }

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/ComponentBundleHintProvider.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/ComponentBundleHintProvider.java
@@ -19,6 +19,8 @@ import com.hortonworks.streamline.streams.catalog.Cluster;
 import com.hortonworks.streamline.streams.catalog.Namespace;
 import com.hortonworks.streamline.streams.cluster.service.EnvironmentService;
 
+import javax.security.auth.Subject;
+import javax.ws.rs.core.SecurityContext;
 import java.util.Map;
 
 /**
@@ -58,7 +60,9 @@ public interface ComponentBundleHintProvider {
      * Provide hints on specific component bundle with selected namespace.
      *
      * @param namespace selected namespace
+     * @param securityContext
+     * @param subject
      * @return Hint structures. The structure of map should be cluster id -> (cluster, hints).
      */
-    Map<Long, BundleHintsResponse> provide(Namespace namespace);
+    Map<Long, BundleHintsResponse> provide(Namespace namespace, SecurityContext securityContext, Subject subject);
 }

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/AbstractHDFSBundleHintProvider.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/AbstractHDFSBundleHintProvider.java
@@ -22,12 +22,14 @@ import com.hortonworks.streamline.streams.cluster.Constants;
 import com.hortonworks.streamline.streams.cluster.service.metadata.HDFSMetadataService;
 import com.hortonworks.streamline.streams.cluster.bundle.AbstractBundleHintProvider;
 
+import javax.security.auth.Subject;
+import javax.ws.rs.core.SecurityContext;
 import java.util.HashMap;
 import java.util.Map;
 
 public abstract class AbstractHDFSBundleHintProvider extends AbstractBundleHintProvider {
     @Override
-    public Map<String, Object> getHintsOnCluster(Cluster cluster) {
+    public Map<String, Object> getHintsOnCluster(Cluster cluster, SecurityContext securityContext, Subject subject) {
         Map<String, Object> hintMap = new HashMap<>();
 
         try {

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/DruidSinkBundleHintProvider.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/DruidSinkBundleHintProvider.java
@@ -8,6 +8,8 @@ import com.hortonworks.streamline.streams.catalog.exception.ServiceNotFoundExcep
 import com.hortonworks.streamline.streams.cluster.Constants;
 import com.hortonworks.streamline.streams.cluster.bundle.AbstractBundleHintProvider;
 
+import javax.security.auth.Subject;
+import javax.ws.rs.core.SecurityContext;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,7 +24,7 @@ public class DruidSinkBundleHintProvider extends AbstractBundleHintProvider {
     }
 
     @Override
-    public Map<String, Object> getHintsOnCluster(Cluster cluster) {
+    public Map<String, Object> getHintsOnCluster(Cluster cluster, SecurityContext securityContext, Subject subject) {
         Map<String, Object> hintMap = new HashMap<>();
 
         try {

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/EventHubsSourceHintProvider.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/EventHubsSourceHintProvider.java
@@ -4,12 +4,14 @@ import com.hortonworks.streamline.streams.catalog.Cluster;
 import com.hortonworks.streamline.streams.cluster.Constants;
 import com.hortonworks.streamline.streams.cluster.bundle.AbstractBundleHintProvider;
 
+import javax.security.auth.Subject;
+import javax.ws.rs.core.SecurityContext;
 import java.util.Collections;
 import java.util.Map;
 
 public class EventHubsSourceHintProvider extends AbstractBundleHintProvider {
     @Override
-    public Map<String, Object> getHintsOnCluster(Cluster cluster) {
+    public Map<String, Object> getHintsOnCluster(Cluster cluster, SecurityContext securityContext, Subject subject) {
         return Collections.emptyMap();
     }
 

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/HBaseBundleHintProvider.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/HBaseBundleHintProvider.java
@@ -22,6 +22,8 @@ import com.hortonworks.streamline.streams.cluster.Constants;
 import com.hortonworks.streamline.streams.cluster.bundle.AbstractBundleHintProvider;
 import com.hortonworks.streamline.streams.cluster.service.metadata.HBaseMetadataService;
 
+import javax.security.auth.Subject;
+import javax.ws.rs.core.SecurityContext;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,9 +31,9 @@ public class HBaseBundleHintProvider extends AbstractBundleHintProvider {
     public static final String FIELD_NAME_TABLE = "table";
 
     @Override
-    public Map<String, Object> getHintsOnCluster(Cluster cluster) {
+    public Map<String, Object> getHintsOnCluster(Cluster cluster, SecurityContext securityContext, Subject subject) {
         Map<String, Object> hintMap = new HashMap<>();
-        try (HBaseMetadataService hBaseMetadataService = HBaseMetadataService.newInstance(environmentService, cluster.getId())) {
+        try (HBaseMetadataService hBaseMetadataService = HBaseMetadataService.newInstance(environmentService, cluster.getId(), securityContext, subject)) {
             hintMap.put(FIELD_NAME_TABLE, hBaseMetadataService.getHBaseTables().getTables());
         } catch (ServiceNotFoundException e) {
             // we access it from mapping information so shouldn't be here

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/KafkaBundleHintProvider.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/KafkaBundleHintProvider.java
@@ -27,6 +27,8 @@ import com.hortonworks.streamline.streams.cluster.service.metadata.json.KafkaTop
 
 import org.apache.commons.lang3.StringUtils;
 
+import javax.security.auth.Subject;
+import javax.ws.rs.core.SecurityContext;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,9 +45,9 @@ public class KafkaBundleHintProvider extends AbstractBundleHintProvider {
     public static final String FIELD_NAME_ZK_PORT = "zkPort";
 
     @Override
-    public Map<String, Object> getHintsOnCluster(Cluster cluster) {
+    public Map<String, Object> getHintsOnCluster(Cluster cluster, SecurityContext securityContext, Subject subject) {
         Map<String, Object> hintClusterMap = new HashMap<>();
-        try (KafkaMetadataService kafkaMetadataService = KafkaMetadataService.newInstance(environmentService, cluster.getId())) {
+        try (KafkaMetadataService kafkaMetadataService = KafkaMetadataService.newInstance(environmentService, cluster.getId(), securityContext)) {
             KafkaMetadataService.KafkaZkConnection zkConnection = kafkaMetadataService.getKafkaZkConnection();
             KafkaTopics topics = kafkaMetadataService.getTopicsFromZk();
 

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/KafkaSinkBundleHintProvider.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/KafkaSinkBundleHintProvider.java
@@ -27,6 +27,8 @@ import com.hortonworks.streamline.streams.cluster.service.metadata.json.KafkaTop
 
 import org.apache.commons.lang.StringUtils;
 
+import javax.security.auth.Subject;
+import javax.ws.rs.core.SecurityContext;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,9 +41,9 @@ public class KafkaSinkBundleHintProvider extends AbstractBundleHintProvider {
     public static final String FIELD_NAME_SECURITY_PROTOCOL = "securityProtocol";
 
     @Override
-    public Map<String, Object> getHintsOnCluster(Cluster cluster) {
+    public Map<String, Object> getHintsOnCluster(Cluster cluster, SecurityContext securityContext, Subject subject) {
         Map<String, Object> hintClusterMap = new HashMap<>();
-        try (KafkaMetadataService kafkaMetadataService = KafkaMetadataService.newInstance(environmentService, cluster.getId())) {
+        try (KafkaMetadataService kafkaMetadataService = KafkaMetadataService.newInstance(environmentService, cluster.getId(), securityContext)) {
             KafkaTopics topics = kafkaMetadataService.getTopicsFromZk();
             hintClusterMap.put(FIELD_NAME_TOPIC, topics.list());
 

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/NotificationSinkBundleHintProvider.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/bundle/impl/NotificationSinkBundleHintProvider.java
@@ -8,6 +8,8 @@ import com.hortonworks.streamline.streams.catalog.exception.ServiceNotFoundExcep
 import com.hortonworks.streamline.streams.cluster.Constants;
 import com.hortonworks.streamline.streams.cluster.bundle.AbstractBundleHintProvider;
 
+import javax.security.auth.Subject;
+import javax.ws.rs.core.SecurityContext;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -27,7 +29,7 @@ public class NotificationSinkBundleHintProvider extends AbstractBundleHintProvid
     }
 
     @Override
-    public Map<String, Object> getHintsOnCluster(Cluster cluster) {
+    public Map<String, Object> getHintsOnCluster(Cluster cluster, SecurityContext securityContext, Subject subject) {
         Map<String, Object> hintMap = new HashMap<>();
 
         try {

--- a/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/bundle/AbstractBundleHintProviderTest.java
+++ b/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/bundle/AbstractBundleHintProviderTest.java
@@ -28,6 +28,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import javax.security.auth.Subject;
+import javax.ws.rs.core.SecurityContext;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -41,7 +43,7 @@ public class AbstractBundleHintProviderTest {
 
     private class TestBundleHintProviderTest extends AbstractBundleHintProvider {
         @Override
-        public Map<String, Object> getHintsOnCluster(Cluster cluster) {
+        public Map<String, Object> getHintsOnCluster(Cluster cluster, SecurityContext securityContext, Subject subject) {
             return TEST_HINTS;
         }
 
@@ -87,7 +89,7 @@ public class AbstractBundleHintProviderTest {
         Namespace namespace = new Namespace();
         namespace.setId(TEST_NAMESPACE_ID);
 
-        Map<Long, ComponentBundleHintProvider.BundleHintsResponse> hints = provider.provide(namespace);
+        Map<Long, ComponentBundleHintProvider.BundleHintsResponse> hints = provider.provide(namespace, null, null);
         Assert.assertEquals(3, hints.size());
         Assert.assertEquals(cluster1, hints.get(cluster1.getId()).getCluster());
         Assert.assertEquals(TEST_HINTS, hints.get(cluster1.getId()).getHints());

--- a/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/bundle/impl/AbstractHDFSBundleHintProviderTest.java
+++ b/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/bundle/impl/AbstractHDFSBundleHintProviderTest.java
@@ -66,7 +66,7 @@ public class AbstractHDFSBundleHintProviderTest {
         cluster.setId(1L);
         cluster.setName("cluster1");
 
-        Map<String, Object> hints = provider.getHintsOnCluster(cluster);
+        Map<String, Object> hints = provider.getHintsOnCluster(cluster, null, null);
         Assert.assertEquals(1, hints.size());
         Assert.assertEquals(expectedFsUrl, hints.get(TEST_FIELD_NAME_FS_URL));
     }

--- a/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/bundle/impl/DruidSinkBundleHintProviderTest.java
+++ b/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/bundle/impl/DruidSinkBundleHintProviderTest.java
@@ -55,7 +55,7 @@ public class DruidSinkBundleHintProviderTest {
 
         provider.init(environmentService);
 
-        Map<String, Object> hints = provider.getHintsOnCluster(cluster);
+        Map<String, Object> hints = provider.getHintsOnCluster(cluster, null, null);
         Assert.assertNotNull(hints);
         Assert.assertEquals("svr1:2181,svr2:2181", hints.get(DruidSinkBundleHintProvider.FIELD_NAME_ZK_CONNECT));
         Assert.assertEquals("druid/overlord", hints.get(DruidSinkBundleHintProvider.FIELD_NAME_INDEX_SERVICE));

--- a/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/bundle/impl/HBaseBundleHintProviderTest.java
+++ b/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/bundle/impl/HBaseBundleHintProviderTest.java
@@ -65,7 +65,7 @@ public class HBaseBundleHintProviderTest {
         cluster.setId(1L);
         cluster.setName("cluster1");
 
-        Map<String, Object> hints = provider.getHintsOnCluster(cluster);
+        Map<String, Object> hints = provider.getHintsOnCluster(cluster, null, null);
         Assert.assertNotNull(hints);
         Assert.assertEquals(1, hints.size());
         Assert.assertEquals(tables, hints.get(HBaseBundleHintProvider.FIELD_NAME_TABLE));

--- a/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/bundle/impl/KafkaBundleHintProviderTest.java
+++ b/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/bundle/impl/KafkaBundleHintProviderTest.java
@@ -88,7 +88,7 @@ public class KafkaBundleHintProviderTest {
         cluster.setId(1L);
         cluster.setName("cluster1");
 
-        Map<String, Object> hints = provider.getHintsOnCluster(cluster);
+        Map<String, Object> hints = provider.getHintsOnCluster(cluster, null, null);
         Assert.assertNotNull(hints);
         Assert.assertEquals(5, hints.size());
         Assert.assertEquals(topics, hints.get(KafkaBundleHintProvider.FIELD_NAME_TOPIC));
@@ -125,7 +125,7 @@ public class KafkaBundleHintProviderTest {
         cluster.setId(1L);
         cluster.setName("cluster1");
 
-        Map<String, Object> hints = provider.getHintsOnCluster(cluster);
+        Map<String, Object> hints = provider.getHintsOnCluster(cluster, null, null);
         Assert.assertNotNull(hints);
         Assert.assertEquals(3, hints.size());
         Assert.assertEquals(topics, hints.get(KafkaBundleHintProvider.FIELD_NAME_TOPIC));

--- a/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/bundle/impl/KafkaSinkBundleHintProviderTest.java
+++ b/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/bundle/impl/KafkaSinkBundleHintProviderTest.java
@@ -88,7 +88,7 @@ public class KafkaSinkBundleHintProviderTest {
         cluster.setId(1L);
         cluster.setName("cluster1");
 
-        Map<String, Object> hints = provider.getHintsOnCluster(cluster);
+        Map<String, Object> hints = provider.getHintsOnCluster(cluster, null, null);
         Assert.assertNotNull(hints);
         Assert.assertEquals(3, hints.size());
         Assert.assertEquals(topics, hints.get(KafkaSinkBundleHintProvider.FIELD_NAME_TOPIC));

--- a/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/bundle/impl/NotificationSinkBundleSourceHintProviderTest.java
+++ b/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/bundle/impl/NotificationSinkBundleSourceHintProviderTest.java
@@ -58,7 +58,7 @@ public class NotificationSinkBundleSourceHintProviderTest {
 
         provider.init(environmentService);
 
-        Map<String, Object> hints = provider.getHintsOnCluster(cluster);
+        Map<String, Object> hints = provider.getHintsOnCluster(cluster, null, null);
         Assert.assertNotNull(hints);
         Assert.assertEquals("svr1", hints.get(NotificationSinkBundleHintProvider.FIELD_NAME_HOST));
         Assert.assertEquals("1111", hints.get(NotificationSinkBundleHintProvider.FIELD_NAME_PORT));

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/StreamsModule.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/StreamsModule.java
@@ -92,7 +92,7 @@ public class StreamsModule implements ModuleRegistration, StorageManagerAware {
         result.addAll(getClusterRelatedResources(authorizer, environmentService));
         result.add(new FileCatalogResource(authorizer, catalogService));
         result.addAll(getTopologyRelatedResources(authorizer, streamcatalogService, environmentService, topologyActionsService,
-                topologyMetricsService, securityCatalogService));
+                topologyMetricsService, securityCatalogService, subject));
         result.add(new UDFCatalogResource(authorizer, streamcatalogService, fileStorage));
         result.addAll(getNotificationsRelatedResources(authorizer, streamcatalogService));
         result.add(new SchemaResource(createSchemaRegistryClient()));
@@ -125,10 +125,11 @@ public class StreamsModule implements ModuleRegistration, StorageManagerAware {
                                                      EnvironmentService environmentService,
                                                      TopologyActionsService actionsService,
                                                      TopologyMetricsService metricsService,
-                                                     SecurityCatalogService securityCatalogService) {
+                                                     SecurityCatalogService securityCatalogService,
+                                                     Subject subject) {
         return Arrays.asList(
                 new TopologyCatalogResource(authorizer, streamcatalogService, environmentService, actionsService, metricsService),
-                new TopologyComponentBundleResource(authorizer, streamcatalogService, environmentService),
+                new TopologyComponentBundleResource(authorizer, streamcatalogService, environmentService, subject),
                 new TopologyStreamCatalogResource(authorizer, streamcatalogService),
                 new TopologyEditorMetadataResource(authorizer, streamcatalogService),
                 new TopologySourceCatalogResource(authorizer, streamcatalogService),

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyComponentBundleResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyComponentBundleResource.java
@@ -43,6 +43,7 @@ import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.security.auth.Subject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -86,12 +87,15 @@ public class TopologyComponentBundleResource {
     private final StreamlineAuthorizer authorizer;
     private final StreamCatalogService catalogService;
     private final EnvironmentService environmentService;
+    private final Subject subject;
     private final ProxyUtil<ComponentBundleHintProvider> hintProviderProxyUtil;
 
-    public TopologyComponentBundleResource(StreamlineAuthorizer authorizer, StreamCatalogService catalogService, EnvironmentService environmentService) {
+    public TopologyComponentBundleResource(StreamlineAuthorizer authorizer, StreamCatalogService catalogService,
+                                           EnvironmentService environmentService, Subject subject) {
         this.authorizer = authorizer;
         this.catalogService = catalogService;
         this.environmentService = environmentService;
+        this.subject = subject;
         this.hintProviderProxyUtil = new ProxyUtil<>(ComponentBundleHintProvider.class);
     }
 
@@ -532,7 +536,8 @@ public class TopologyComponentBundleResource {
                 throw EntityNotFoundException.byId("namespace id: " + namespaceId);
             }
 
-            Map<Long, ComponentBundleHintProvider.BundleHintsResponse> hints = provider.provide(namespace);
+            Map<Long, ComponentBundleHintProvider.BundleHintsResponse> hints = provider.provide(namespace,
+                    securityContext, subject);
             return WSUtils.respondEntity(hints, OK);
         } else {
             return WSUtils.respondEntity(Collections.emptyMap(), OK);


### PR DESCRIPTION
* this is needed for getting metadata from secured cluster to build hints
  * especially HBaseMetadataService and HBaseBundleHintProvider
