### PR TITLE
ISSUE-583: 'readerSchemaVersion' in Kafka config key is marked as opt…

### DIFF
--- a/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/KafkaSpoutFluxComponent.java
+++ b/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/KafkaSpoutFluxComponent.java
@@ -144,7 +144,12 @@ public class KafkaSpoutFluxComponent extends AbstractFluxComponent {
                 .JSON_KEY_TOPIC}));
         constructorArgs.add(kafkaSource != null ? kafkaSource.getId() : "");
         constructorArgs.add(conf.get(TopologyLayoutConstants.SCHEMA_REGISTRY_URL));
-        constructorArgs.add(conf.get("readerSchemaVersion") != null ? Integer.parseInt((String) conf.get("readerSchemaVersion")) : null);
+
+        // add readerSchemaVersion to constructor arg only when it's not null and not empty
+        String readerSchemaVersion = (String) conf.get("readerSchemaVersion");
+        if(readerSchemaVersion != null && !readerSchemaVersion.isEMpty()) {
+            constructorArgs.add(Integer.parseInt(readerSchemaVersion))
+        }
         addToComponents(createComponent(translatorId, translatorClassname, null, constructorArgs, null));
         return translatorId;
     }

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/spout/AvroKafkaSpoutTranslator.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/spout/AvroKafkaSpoutTranslator.java
@@ -44,6 +44,10 @@ public class AvroKafkaSpoutTranslator implements RecordTranslator<Object, ByteBu
     private final Integer readerSchemaVersion;
     private transient volatile AvroStreamsSnapshotDeserializer avroStreamsSnapshotDeserializer;
 
+    public AvroKafkaSpoutTranslator (String outputStream, String topic, String dataSourceId, String schemaRegistryUrl) {
+        this(outputStream, topic, dataSourceId, schemaRegistryUrl, null);
+    }
+
     public AvroKafkaSpoutTranslator (String outputStream, String topic, String dataSourceId, String schemaRegistryUrl, Integer readerSchemaVersion) {
         this.outputStream = outputStream;
         this.topic = topic;
@@ -51,6 +55,7 @@ public class AvroKafkaSpoutTranslator implements RecordTranslator<Object, ByteBu
         this.schemaRegistryUrl = schemaRegistryUrl;
         this.readerSchemaVersion = readerSchemaVersion;
     }
+
     @Override
     public List<Object> apply (ConsumerRecord<Object, ByteBuffer> consumerRecord) {
         Map < String, Object > keyValues = (Map<String, Object>) deserializer().deserialize(new ByteBufferInputStream(consumerRecord.value()),


### PR DESCRIPTION
…ional but effectively required due to Flux

* add a new constructor for AvroKafkaSpoutTranslator which excludes readerSchemaVersion from parameters
* handle empty string as null for readerSchemaVersion as well since it throws NumberFormatException

This closes #583 