### PR TITLE
ISSUE-604 Use DRIVER CLASS NAME in JDBC sink for as its name represents

### DIFF
--- a/bootstrap/components/sinks/jdbc-sink-topology-component.json
+++ b/bootstrap/components/sinks/jdbc-sink-topology-component.json
@@ -17,28 +17,28 @@
       },
       {
         "uiName": "Driver class name",
-        "fieldName": "dataSourceClassName",
+        "fieldName": "driverClassName",
         "isOptional": false,
-        "tooltip": "The driver class name. E.g. com.mysql.jdbc.jdbc2.optional.MysqlDataSource",
+        "tooltip": "The driver class name. E.g. com.mysql.jdbc.Driver",
         "type": "string"
       },
       {
         "uiName": "JDBC Url",
-        "fieldName": "dataSource.url",
+        "fieldName": "jdbcUrl",
         "isOptional": false,
         "tooltip": "JDBC Url, E.g. jdbc:mysql://localhost:3306/test",
         "type": "string"
       },
       {
         "uiName": "Username",
-        "fieldName": "dataSource.user",
+        "fieldName": "username",
         "isOptional": false,
         "tooltip": "Database username",
         "type": "string"
       },
       {
         "uiName": "Password",
-        "fieldName": "dataSource.password",
+        "fieldName": "password",
         "isOptional": false,
         "tooltip": "Database password",
         "type": "string",

--- a/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/JDBCBoltFluxComponent.java
+++ b/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/JDBCBoltFluxComponent.java
@@ -29,10 +29,10 @@ import java.util.Map;
 public class JDBCBoltFluxComponent extends AbstractFluxComponent {
     private static final String KEY_TABLE_NAME = "tableName";
     private static final String KEY_COLUMNS = "columns";
-    private static final String KEY_DATASOURCE_CLASSNAME = "dataSourceClassName";
-    private static final String KEY_DATASOURCE_URL = "dataSource.url";
-    private static final String KEY_DATASOURCE_USER = "dataSource.user";
-    private static final String KEY_DATASOURCE_PASSWORD = "dataSource.password";
+    private static final String KEY_DRIVER_CLASSNAME = "driverClassName";
+    private static final String KEY_JDBC_URL = "jdbcUrl";
+    private static final String KEY_USERNAME = "username";
+    private static final String KEY_PASSWORD = "password";
 
     @Override
     protected void generateComponent() {
@@ -64,10 +64,10 @@ public class JDBCBoltFluxComponent extends AbstractFluxComponent {
     private String getHikariCPConfigMap() {
         String componentId = "HikariCpConfigMap" + UUID_FOR_COMPONENTS;
         List<Map<String, Object>> configMethods = new ArrayList<>();
-        put(configMethods, KEY_DATASOURCE_CLASSNAME);
-        put(configMethods, KEY_DATASOURCE_URL);
-        put(configMethods, KEY_DATASOURCE_USER);
-        put(configMethods, KEY_DATASOURCE_PASSWORD);
+        put(configMethods, KEY_DRIVER_CLASSNAME);
+        put(configMethods, KEY_JDBC_URL);
+        put(configMethods, KEY_USERNAME);
+        put(configMethods, KEY_PASSWORD);
         String className = "java.util.HashMap";
         addToComponents(createComponent(componentId, className, null, null, configMethods));
         return componentId;


### PR DESCRIPTION
* since some storages including Phoenix doesn't support javax.sql.DataSource
* modify all fields to conform to driverClassName (we no longer use datasource config)

Please refer https://github.com/brettwooldridge/HikariCP for field descriptions.