### PR TITLE
ISSUE-637 Reduce the cache duration for Storm metrics query result

### DIFF
--- a/streams/runners/storm/metrics/src/main/java/com/hortonworks/streamline/streams/metrics/storm/topology/StormTopologyMetricsImpl.java
+++ b/streams/runners/storm/metrics/src/main/java/com/hortonworks/streamline/streams/metrics/storm/topology/StormTopologyMetricsImpl.java
@@ -78,7 +78,7 @@ public class StormTopologyMetricsImpl implements TopologyMetrics {
     private static final String FRAMEWORK = "STORM";
     private static final int MAX_SIZE_TOPOLOGY_CACHE = 10;
     private static final int MAX_SIZE_COMPONENT_CACHE = 50;
-    private static final int CACHE_DURATION_SECS = 30;
+    private static final int CACHE_DURATION_SECS = 5;
     private static final int FORK_JOIN_POOL_PARALLELISM = 50;
 
     // shared across the metrics instances


### PR DESCRIPTION
* currently 30 secs which might give feeling a bit long
* Storm itself updates the executors metrics via heartbeat, which is by default per 3 seconds
  * so 5 secs would make users feel close to real time update

Change-Id: I44dffb5f9fb1ce5d705e219ce2046279ccbf9852