### PR TITLE
ISSUE-693 use "cluster id" for Cluster security config to ensure selected cluster unique

### DIFF
--- a/bootstrap/components/topology/storm-topology-component.json
+++ b/bootstrap/components/topology/storm-topology-component.json
@@ -49,7 +49,7 @@
         "fields": [
           {
             "uiName": "Cluster Name",
-            "fieldName": "clusterName",
+            "fieldName": "clusterId",
             "tooltip": "Name of the cluster (same as service pool)",
             "isOptional": false,
             "type": "enumstring",

--- a/streams/runners/storm/common/src/main/java/com/hortonworks/streamline/streams/storm/common/ServiceConfigurationReadable.java
+++ b/streams/runners/storm/common/src/main/java/com/hortonworks/streamline/streams/storm/common/ServiceConfigurationReadable.java
@@ -5,5 +5,4 @@ import java.util.Map;
 public interface ServiceConfigurationReadable {
     Map<Long, Map<String, String>> readAllClusters(String serviceName);
     Map<String, String> read(Long clusterId, String serviceName);
-    Map<String, String> read(String clusterName, String serviceName);
 }


### PR DESCRIPTION
This closes #693 .

@shahsank3t You can just put `clusterId` as Long (JSON default number type I guess) instead of `clusterName` in clusterSecurityConfig.