### PR TITLE
BUG-82171 NullPointer exception when using PostgreSQL as backend storage

### DIFF
--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/TopologyTestRunHistory.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/TopologyTestRunHistory.java
@@ -298,13 +298,13 @@ public class TopologyTestRunHistory extends AbstractStorable {
         testCaseId = (Long) map.get(TEST_CASE_ID);
 
         if (map.get(FINISHED) != null) {
-            finished = Boolean.valueOf((String) map.get(FINISHED));
+            finished = Boolean.valueOf(((String) map.get(FINISHED)).trim());
         } else {
             finished = null;
         }
 
         if (map.get(SUCCESS) != null) {
-            success = Boolean.valueOf((String) map.get(SUCCESS));
+            success = Boolean.valueOf(((String) map.get(SUCCESS)).trim());
         } else {
             success = null;
         }
@@ -313,7 +313,7 @@ public class TopologyTestRunHistory extends AbstractStorable {
         actualOutputRecords = (String) map.get(ACTUAL_OUTPUT_RECORDS);
 
         if (map.get(MATCHED) != null) {
-            matched = Boolean.valueOf((String) map.get(MATCHED));
+            matched = Boolean.valueOf(((String) map.get(MATCHED)).trim());
         } else {
             matched = null;
         }

--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/UDF.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/UDF.java
@@ -230,7 +230,9 @@ public class UDF extends AbstractStorable {
         setClassName((String) map.get(CLASSNAME));
         setJarStoragePath((String) map.get(JARSTORAGEPATH));
         setDigest((String) map.get(DIGEST));
-        setBuiltin(Boolean.valueOf((String) map.get(BUILTIN)));
+        if (map.get(BUILTIN) != null) {
+            setBuiltin(Boolean.valueOf(((String) map.get(BUILTIN)).trim()));
+        }
 
         String typeStr = (String) map.get(TYPE);
         try {

--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/topology/TopologyComponentBundle.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/topology/TopologyComponentBundle.java
@@ -207,7 +207,9 @@ public class TopologyComponentBundle implements Storable {
         }
         fieldHintProviderClass = (String) map.get(FIELD_HINT_PROVIDER_CLASS);
         transformationClass = (String) map.get(TRANSFORMATION_CLASS);
-        builtin = Boolean.valueOf((String) map.get(BUILTIN));
+        if (map.get(BUILTIN) != null) {
+            setBuiltin(Boolean.valueOf(((String) map.get(BUILTIN)).trim()));
+        }
         mavenDeps = (String) map.get(MAVEN_DEPS);
         return this;
     }


### PR DESCRIPTION
While we get the value from CHAR(5) which contains "true" (hence 1 space left), rightmost whitespace is trimmed for MySQL but unfortunately not for PostgreSQL.

Change-Id: Iac69fea23975949d5b1a08040878943078ae5a77