### PR TITLE
ISSUE-764: Remove stack trace when trying to register existing UDF

### DIFF
--- a/common/src/main/java/com/hortonworks/streamline/common/util/FileStorage.java
+++ b/common/src/main/java/com/hortonworks/streamline/common/util/FileStorage.java
@@ -67,4 +67,12 @@ public interface FileStorage {
      */
     boolean deleteFile(String name) throws IOException;
 
+    /**
+     * Returns if a file for the given name exists.
+     *
+     * @param name identifier of the file to be checked that was first
+     *             passed during {@link #uploadFile(InputStream, String)}
+     * @return true if the file exists
+     */
+    boolean exists(String name);
 }

--- a/common/src/main/java/com/hortonworks/streamline/common/util/HdfsFileStorage.java
+++ b/common/src/main/java/com/hortonworks/streamline/common/util/HdfsFileStorage.java
@@ -88,4 +88,14 @@ public class HdfsFileStorage implements FileStorage {
     public boolean deleteFile(String name) throws IOException {
         return hdfsFileSystem.delete(new Path(directory, name), true);
     }
+
+    @Override
+    public boolean exists(String name) {
+        try {
+            return hdfsFileSystem.exists(new Path(directory, name));
+        } catch (Exception ex) {
+            // ignore
+        }
+        return false;
+    }
 }

--- a/common/src/main/java/com/hortonworks/streamline/common/util/LocalFileSystemStorage.java
+++ b/common/src/main/java/com/hortonworks/streamline/common/util/LocalFileSystemStorage.java
@@ -94,4 +94,8 @@ public class LocalFileSystemStorage implements FileStorage {
         return Files.deleteIfExists(path);
     }
 
+    @Override
+    public boolean exists(String name) {
+        return Files.exists(FileSystems.getDefault().getPath(directory, name));
+    }
 }


### PR DESCRIPTION
1. Log warn and throw EntityAlreadyExistsException if the UDF already exists
2. Fix the issue where the jar file was getting uploaded even if the digest match

Fixes #764