### PR TITLE
ISSUE-745: Added logout REST endpoint

### DIFF
--- a/conf/streamline-dev.yaml
+++ b/conf/streamline-dev.yaml
@@ -98,3 +98,5 @@ logging:
 #     kerberos.principal: "HTTP/streamline-ui-host.com"
 #     kerberos.keytab: "/vagrant/keytabs/http.keytab"
 #     kerberos.name.rules: "RULE:[2:$1@$0]([jt]t@.*EXAMPLE.COM)s/.*/$MAPRED_USER/ RULE:[2:$1@$0]([nd]n@.*EXAMPLE.COM)s/.*/$HDFS_USER/DEFAULT"
+#     token.validity: "36000"
+#     cookie.path: "/"

--- a/conf/streamline.mysql.yaml
+++ b/conf/streamline.mysql.yaml
@@ -97,3 +97,5 @@ logging:
 #     kerberos.principal: "HTTP/streamline-ui-host.com"
 #     kerberos.keytab: "/vagrant/keytabs/http.keytab"
 #     kerberos.name.rules: "RULE:[2:$1@$0]([jt]t@.*EXAMPLE.COM)s/.*/$MAPRED_USER/ RULE:[2:$1@$0]([nd]n@.*EXAMPLE.COM)s/.*/$HDFS_USER/DEFAULT"
+#     token.validity: "36000"
+#     cookie.path: "/"

--- a/conf/streamline.phoenix.yaml
+++ b/conf/streamline.phoenix.yaml
@@ -87,3 +87,5 @@ logging:
 #     kerberos.principal: "HTTP/streamline-ui-host.com"
 #     kerberos.keytab: "/vagrant/keytabs/http.keytab"
 #     kerberos.name.rules: "RULE:[2:$1@$0]([jt]t@.*EXAMPLE.COM)s/.*/$MAPRED_USER/ RULE:[2:$1@$0]([nd]n@.*EXAMPLE.COM)s/.*/$HDFS_USER/DEFAULT"
+#     token.validity: "36000"
+#     cookie.path: "/"

--- a/conf/streamline.postgre.yaml
+++ b/conf/streamline.postgre.yaml
@@ -95,3 +95,5 @@ logging:
 #     kerberos.principal: "HTTP/streamline-ui-host.com"
 #     kerberos.keytab: "/vagrant/keytabs/http.keytab"
 #     kerberos.name.rules: "RULE:[2:$1@$0]([jt]t@.*EXAMPLE.COM)s/.*/$MAPRED_USER/ RULE:[2:$1@$0]([nd]n@.*EXAMPLE.COM)s/.*/$HDFS_USER/DEFAULT"
+#     token.validity: "36000"
+#     cookie.path: "/"

--- a/conf/streamline.yaml
+++ b/conf/streamline.yaml
@@ -104,3 +104,5 @@ logging:
 #     kerberos.principal: "HTTP/streamline-ui-host.com"
 #     kerberos.keytab: "/vagrant/keytabs/http.keytab"
 #     kerberos.name.rules: "RULE:[2:$1@$0]([jt]t@.*EXAMPLE.COM)s/.*/$MAPRED_USER/ RULE:[2:$1@$0]([nd]n@.*EXAMPLE.COM)s/.*/$HDFS_USER/DEFAULT"
+#     token.validity: "36000"
+#     cookie.path: "/"


### PR DESCRIPTION
Fixes #745 

@shahsank3t, sending a POST to "api/v1/catalog/users/current/logout" will invalidate the cookie. Checked in safari and via cUrl.

@harshach, we need to configure ambari to set `cookie.path: "/"` under servletFilters config in the generated streamline.yaml to always set cookie for "/".