### PR TITLE
ISSUE-796: HBase Client Retries Must be Configurable

### DIFF
--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/service/metadata/common/OverrideHadoopConfiguration.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/service/metadata/common/OverrideHadoopConfiguration.java
@@ -18,22 +18,29 @@ package com.hortonworks.streamline.streams.cluster.service.metadata.common;
 import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
 import com.hortonworks.streamline.streams.catalog.exception.ServiceConfigurationNotFoundException;
 import com.hortonworks.streamline.streams.catalog.exception.ServiceNotFoundException;
-
-import org.apache.hadoop.conf.Configuration;
-import com.hortonworks.streamline.streams.cluster.service.EnvironmentService;
 import com.hortonworks.streamline.streams.cluster.discovery.ambari.ServiceConfigurations;
+import com.hortonworks.streamline.streams.cluster.service.EnvironmentService;
+import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 public class OverrideHadoopConfiguration {
     private static final Logger LOG = LoggerFactory.getLogger(OverrideHadoopConfiguration.class);
 
     public static <T extends Configuration> T override(EnvironmentService environmentService, Long clusterId,
                                                        ServiceConfigurations service, List<String> configNames, T configuration)
+            throws IOException, ServiceConfigurationNotFoundException, ServiceNotFoundException {
+        return override(environmentService, clusterId, service, configNames, configuration, Collections.emptyMap());
+    }
+
+    public static <T extends Configuration> T override(EnvironmentService environmentService, Long clusterId,
+            ServiceConfigurations service, List<String> configNames, T configuration, Map<String, Function<String, String>> samOverrides)
                 throws IOException, ServiceConfigurationNotFoundException, ServiceNotFoundException {
 
         for (String configName : configNames) {
@@ -44,12 +51,15 @@ public class OverrideHadoopConfiguration {
                 final Map<String, String> configurationMap = serviceConfig.getConfigurationMap();
                 if (configurationMap != null) {
                     for (Map.Entry<String, String> propKeyVal : configurationMap.entrySet()) {
+                        LOG.debug("Overriding property {}", propKeyVal);
                         final String key = propKeyVal.getKey();
-                        final String val = propKeyVal.getValue();
+                        final String val = samOverrides.containsKey(key)
+                            ? getSamOverride(samOverrides, propKeyVal)
+                            : propKeyVal.getValue();
 
                         if (key != null && val != null) {
                             configuration.set(key, val);
-                            LOG.debug("Set property {}", propKeyVal);
+                            LOG.debug("Set property {}={}", key, val);
                         } else {
                             LOG.warn("Skipping null key/val property {}", propKeyVal);
                         }
@@ -61,6 +71,12 @@ public class OverrideHadoopConfiguration {
             }
         }
         return configuration;
+    }
+
+    private static String getSamOverride(Map<String, Function<String, String>> samOverrides, Map.Entry<String, String> propKeyVal) {
+        final String samOverride = samOverrides.get(propKeyVal.getKey()).apply(propKeyVal.getValue());
+        LOG.debug("Streaming Analytics Manager property override {}={}", propKeyVal.getKey(), samOverride);
+        return samOverride;
     }
 
     private static Long getServiceIdByClusterId(EnvironmentService environmentService, Long clusterId,

--- a/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/service/metadata/common/OverrideHadoopConfigurationTest.java
+++ b/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/service/metadata/common/OverrideHadoopConfigurationTest.java
@@ -16,33 +16,36 @@
 package com.hortonworks.streamline.streams.cluster.service.metadata.common;
 
 import com.google.common.collect.Lists;
-
+import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
+import com.hortonworks.streamline.streams.cluster.discovery.ambari.ServiceConfigurations;
+import com.hortonworks.streamline.streams.cluster.service.EnvironmentService;
+import com.hortonworks.streamline.streams.cluster.service.metadata.HBaseMetadataService;
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
-import com.hortonworks.streamline.streams.catalog.ServiceConfiguration;
-import com.hortonworks.streamline.streams.cluster.service.EnvironmentService;
-import com.hortonworks.streamline.streams.cluster.discovery.ambari.ServiceConfigurations;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.function.Function;
 
-import mockit.Expectations;
-import mockit.Mocked;
-import mockit.Tested;
-import mockit.integration.junit4.JMockit;
+import static com.hortonworks.streamline.streams.cluster.service.metadata.HBaseMetadataService.SAM_MAX_HBASE_CLIENT_RETRIES_NUMBER;
+import static org.apache.hadoop.hbase.HConstants.HBASE_CLIENT_RETRIES_NUMBER;
 
 @RunWith(JMockit.class)
 public class OverrideHadoopConfigurationTest {
     private static final Logger LOG = LoggerFactory.getLogger(OverrideHadoopConfigurationTest.class);
+    private static final int DEFAULT_HBASE_CLIENT_RETRIES_NUMBER = 35;
 
-    @Tested
-    private OverrideHadoopConfiguration overrideHadoopConfiguration;
     @Mocked
     private EnvironmentService environmentService;
     @Mocked
@@ -53,76 +56,83 @@ public class OverrideHadoopConfigurationTest {
      * Helper class to expose the protected method {@code getProps}, used to verify if properties get correctly set
      */
     private static class HBaseConfigurationTest extends HBaseConfiguration {
+        HBaseConfigurationTest(Configuration config) {
+            super(config);
+        }
 
-        HBaseConfigurationTest(Configuration c) {
-            super(c);
+        static HBaseConfigurationTest newInstance() {
+            return new HBaseConfigurationTest(HBaseConfiguration.create());
         }
 
         @Override
-        public synchronized Properties getProps() {
+        protected synchronized Properties getProps() {
             return super.getProps();
         }
     }
 
     @Test
-    public void test_overrideProperties() throws Exception {
-        final Properties added = new Properties() {{
-            put("k1", "v11");
-            put("k2", "v21");
-        }};
-
-        final Map<String, String> updated = new HashMap<String, String>() {{
-            put("k1", "v12");
-            put("k2", "v22");
-        }};
-
-        new Expectations() {{
-            serviceConfiguration.getConfigurationMap();
-            result = updated;
-            times = 1;
-        }};
-
-        final HBaseConfigurationTest hbaseConfig = new HBaseConfigurationTest(HBaseConfiguration.create());
-        final Properties configProps = hbaseConfig.getProps();
-        LOG.debug("Initial configuration {}", configProps);
-
-        Assert.assertFalse(configProps.containsKey("k1"));
-        Assert.assertFalse(configProps.containsKey("k2"));
-
-        configProps.putAll(added);
-
-        Assert.assertEquals(configProps.get("k1"), "v11");
-        Assert.assertEquals(configProps.get("k2"), "v21");
-
-        OverrideHadoopConfiguration.override(environmentService, 23L, ServiceConfigurations.HBASE,
-                Lists.newArrayList("hbase-site"), hbaseConfig);
-
-        Assert.assertEquals(configProps.get("k1"), "v12");
-        Assert.assertEquals(configProps.get("k2"), "v22");
-
-        LOG.debug("Updated configuration {}", configProps);
+    public void test_overridePropHBaseClientRetriesNum_lessThanSamMax_lessThanSamMax() throws Exception {
+        test_overrideProp(HBASE_CLIENT_RETRIES_NUMBER,
+            SAM_MAX_HBASE_CLIENT_RETRIES_NUMBER - 1,
+            SAM_MAX_HBASE_CLIENT_RETRIES_NUMBER - 1);
     }
 
     @Test
-    public void test_addProperties_nullKeyVal_notAdded() throws Exception {
-        final Map<String, String> updated = new HashMap<String, String>() {{
+    public void test_overridePropHBaseClientRetriesNum_greaterThanSamMax_SamMax() throws Exception {
+        test_overrideProp(HBASE_CLIENT_RETRIES_NUMBER,
+            DEFAULT_HBASE_CLIENT_RETRIES_NUMBER + 1,
+                            SAM_MAX_HBASE_CLIENT_RETRIES_NUMBER);
+    }
+
+    @Test
+    public void test_overrideNonExistingProp_someVal_someVal() throws Exception {
+        final int newPropVal = 10;
+        test_overrideProp("new.prop", newPropVal, newPropVal);
+    }
+
+    @Test
+    public void test_addProperty_nullKeyVal_notAdded() throws Exception {
+        final HBaseConfigurationTest initialConfig = HBaseConfigurationTest.newInstance();
+        final Map<String, String> updatedConfig = new HashMap<String, String>() {{
             put(null, "val");   // null key
             put("key", null);   // null val
+            put(null, null);
         }};
+        new ConfigExpectations(updatedConfig);
 
-        new Expectations() {{
-            serviceConfiguration.getConfigurationMap();
-            result = updated;
-            times = 1;
+        doOverride(initialConfig, Collections.emptyMap());
+
+        // validates it does not contain prop with null val
+        Assert.assertFalse(initialConfig.getProps().containsKey("key"));
+    }
+
+    private void test_overrideProp(final String propName, final int actualInitialVal, final int expectedOverriddenVal) throws Exception {
+        final HBaseConfigurationTest initialConfig = HBaseConfigurationTest.newInstance();
+        initialConfig.getProps().setProperty(propName, String.valueOf(actualInitialVal));
+        Assert.assertEquals(String.valueOf(actualInitialVal), initialConfig.get(propName));
+
+        final Map<String, String> updatedConfig = new HashMap<String, String>() {{
+            put(propName, String.valueOf(actualInitialVal));
         }};
+        new ConfigExpectations(updatedConfig);
 
-        final HBaseConfigurationTest hbaseConfig = new HBaseConfigurationTest(HBaseConfiguration.create());
-        final Properties configProps = hbaseConfig.getProps();
+        doOverride(initialConfig, HBaseMetadataService.getMaxHBaseClientRetries());
 
+        Assert.assertEquals(String.valueOf(expectedOverriddenVal), initialConfig.get(propName));
+    }
+
+    private void doOverride(HBaseConfigurationTest initialConfig, Map<String, Function<String, String>> samOverrides) throws Exception {
         OverrideHadoopConfiguration.override(environmentService, 23L, ServiceConfigurations.HBASE,
-                Lists.newArrayList("hbase-site"), hbaseConfig);
+            Lists.newArrayList("hbase-site"), initialConfig, samOverrides);
+    }
 
-        Assert.assertFalse(configProps.containsKey("k1"));  // does not contain prop with null val
+    private final class ConfigExpectations extends Expectations {
+        ConfigExpectations(Map<String, String> config) throws IOException {
+            super();
+            serviceConfiguration.getConfigurationMap();
+            result = config;
+            times = 1;
+        }
     }
 }
 


### PR DESCRIPTION
 - Set hbase.client.retries.number to max value of 3
 - Refactor Hadoop configuration override to support prop values computed by functions
 - Enhance unit tests

Change-Id: I5628a37813b96634cbcdd66798d8afb988757f25