### PR TITLE
Use custom JsonSerializer to serialize StreamlineConfiguration

### DIFF
--- a/webservice/src/main/java/com/hortonworks/streamline/webservice/StreamlineApplication.java
+++ b/webservice/src/main/java/com/hortonworks/streamline/webservice/StreamlineApplication.java
@@ -40,6 +40,9 @@ import com.hortonworks.streamline.streams.security.authentication.StreamlineKerb
 import com.hortonworks.streamline.streams.security.impl.DefaultStreamlineAuthorizer;
 import com.hortonworks.streamline.streams.security.service.SecurityCatalogService;
 import com.hortonworks.streamline.streams.service.GenericExceptionMapper;
+
+import com.hortonworks.streamline.webservice.configurations.*;
+import com.hortonworks.streamline.webservice.resources.StreamlineConfigurationResource;
 import io.dropwizard.Application;
 import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.jetty.HttpConnectorFactory;

--- a/webservice/src/main/java/com/hortonworks/streamline/webservice/StreamlineApplication.java
+++ b/webservice/src/main/java/com/hortonworks/streamline/webservice/StreamlineApplication.java
@@ -40,8 +40,11 @@ import com.hortonworks.streamline.streams.security.authentication.StreamlineKerb
 import com.hortonworks.streamline.streams.security.impl.DefaultStreamlineAuthorizer;
 import com.hortonworks.streamline.streams.security.service.SecurityCatalogService;
 import com.hortonworks.streamline.streams.service.GenericExceptionMapper;
-
-import com.hortonworks.streamline.webservice.configurations.*;
+import com.hortonworks.streamline.webservice.configurations.AuthorizerConfiguration;
+import com.hortonworks.streamline.webservice.configurations.LoginConfiguration;
+import com.hortonworks.streamline.webservice.configurations.StorageProviderConfiguration;
+import com.hortonworks.streamline.webservice.configurations.StreamlineConfiguration;
+import com.hortonworks.streamline.webservice.configurations.ModuleConfiguration;
 import com.hortonworks.streamline.webservice.resources.StreamlineConfigurationResource;
 import io.dropwizard.Application;
 import io.dropwizard.assets.AssetsBundle;

--- a/webservice/src/main/java/com/hortonworks/streamline/webservice/configurations/AuthorizerConfiguration.java
+++ b/webservice/src/main/java/com/hortonworks/streamline/webservice/configurations/AuthorizerConfiguration.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-package com.hortonworks.streamline.webservice;
+package com.hortonworks.streamline.webservice.configurations;
 
 import org.hibernate.validator.constraints.NotEmpty;
 

--- a/webservice/src/main/java/com/hortonworks/streamline/webservice/configurations/DashboardConfiguration.java
+++ b/webservice/src/main/java/com/hortonworks/streamline/webservice/configurations/DashboardConfiguration.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package com.hortonworks.streamline.webservice;
+package com.hortonworks.streamline.webservice.configurations;
 
 import javax.validation.constraints.NotNull;
 

--- a/webservice/src/main/java/com/hortonworks/streamline/webservice/configurations/FileStorageConfiguration.java
+++ b/webservice/src/main/java/com/hortonworks/streamline/webservice/configurations/FileStorageConfiguration.java
@@ -13,34 +13,37 @@
   * See the License for the specific language governing permissions and
   * limitations under the License.
  **/
+package com.hortonworks.streamline.webservice.configurations;
 
-package com.hortonworks.streamline.webservice;
+import org.hibernate.validator.constraints.NotEmpty;
 
 import java.util.Map;
 
 /**
- * This class represents storage provider configuration.
+ * The configuration for jar storage.
+ *
  */
-public class StorageProviderConfiguration {
-    private String providerClass;
+public class FileStorageConfiguration {
 
-    private Map<String, Object> properties;
+    @NotEmpty
+    private String className;
 
-    public StorageProviderConfiguration() {
-    }
-    public String getProviderClass() {
-        return providerClass;
-    }
+    private Map<String, String> properties;
 
-    public void setProviderClass(String providerClass) {
-        this.providerClass = providerClass;
+    public String getClassName() {
+        return className;
     }
 
-    public Map<String, Object> getProperties() {
+    public void setClassName(String className) {
+        this.className = className;
+    }
+
+    public Map<String, String> getProperties() {
         return properties;
     }
 
-    public void setProperties(Map<String, Object> properties) {
-        this.properties = properties;
+    public void setProperties(Map<String, String> config) {
+        this.properties = config;
     }
+
 }

--- a/webservice/src/main/java/com/hortonworks/streamline/webservice/configurations/LoginConfiguration.java
+++ b/webservice/src/main/java/com/hortonworks/streamline/webservice/configurations/LoginConfiguration.java
@@ -1,4 +1,4 @@
-package com.hortonworks.streamline.webservice;
+package com.hortonworks.streamline.webservice.configurations;
 
 import java.util.Map;
 

--- a/webservice/src/main/java/com/hortonworks/streamline/webservice/configurations/ModuleConfiguration.java
+++ b/webservice/src/main/java/com/hortonworks/streamline/webservice/configurations/ModuleConfiguration.java
@@ -13,7 +13,7 @@
   * See the License for the specific language governing permissions and
   * limitations under the License.
  **/
-package com.hortonworks.streamline.webservice;
+package com.hortonworks.streamline.webservice.configurations;
 
 import java.util.Map;
 

--- a/webservice/src/main/java/com/hortonworks/streamline/webservice/configurations/StorageProviderConfiguration.java
+++ b/webservice/src/main/java/com/hortonworks/streamline/webservice/configurations/StorageProviderConfiguration.java
@@ -13,37 +13,34 @@
   * See the License for the specific language governing permissions and
   * limitations under the License.
  **/
-package com.hortonworks.streamline.webservice;
 
-import org.hibernate.validator.constraints.NotEmpty;
+package com.hortonworks.streamline.webservice.configurations;
 
 import java.util.Map;
 
 /**
- * The configuration for jar storage.
- *
+ * This class represents storage provider configuration.
  */
-public class FileStorageConfiguration {
+public class StorageProviderConfiguration {
+    private String providerClass;
 
-    @NotEmpty
-    private String className;
+    private Map<String, Object> properties;
 
-    private Map<String, String> properties;
-
-    public String getClassName() {
-        return className;
+    public StorageProviderConfiguration() {
+    }
+    public String getProviderClass() {
+        return providerClass;
     }
 
-    public void setClassName(String className) {
-        this.className = className;
+    public void setProviderClass(String providerClass) {
+        this.providerClass = providerClass;
     }
 
-    public Map<String, String> getProperties() {
+    public Map<String, Object> getProperties() {
         return properties;
     }
 
-    public void setProperties(Map<String, String> config) {
-        this.properties = config;
+    public void setProperties(Map<String, Object> properties) {
+        this.properties = properties;
     }
-
 }

--- a/webservice/src/main/java/com/hortonworks/streamline/webservice/configurations/StreamlineConfiguration.java
+++ b/webservice/src/main/java/com/hortonworks/streamline/webservice/configurations/StreamlineConfiguration.java
@@ -1,24 +1,26 @@
 /**
-  * Copyright 2017 Hortonworks.
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-
-  *   http://www.apache.org/licenses/LICENSE-2.0
-
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
+ * Copyright 2017 Hortonworks.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  **/
 
-package com.hortonworks.streamline.webservice;
+package com.hortonworks.streamline.webservice.configurations;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.hortonworks.registries.common.ServletFilterConfiguration;
 
+import com.hortonworks.streamline.webservice.util.StreamlineConfigurationSerializer;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import java.util.List;
@@ -26,6 +28,8 @@ import java.util.List;
 import javax.validation.constraints.NotNull;
 
 import io.dropwizard.Configuration;
+
+@JsonSerialize(using = StreamlineConfigurationSerializer.class)
 
 public class StreamlineConfiguration extends Configuration {
 
@@ -73,11 +77,11 @@ public class StreamlineConfiguration extends Configuration {
 
     private LoginConfiguration loginConfiguration;
 
-    public String getCatalogRootUrl () {
+    public String getCatalogRootUrl() {
         return catalogRootUrl;
     }
 
-    public void setCatalogRootUrl (String catalogRootUrl) {
+    public void setCatalogRootUrl(String catalogRootUrl) {
         this.catalogRootUrl = catalogRootUrl;
     }
 
@@ -129,9 +133,13 @@ public class StreamlineConfiguration extends Configuration {
         this.trustStorePassword = trustStorePassword;
     }
 
-    public DashboardConfiguration getDashboardConfiguration () { return dashboardConfiguration; }
+    public DashboardConfiguration getDashboardConfiguration() {
+        return dashboardConfiguration;
+    }
 
-    public void setDashboardConfiguration (DashboardConfiguration dashboardConfiguration) { this.dashboardConfiguration = dashboardConfiguration; }
+    public void setDashboardConfiguration(DashboardConfiguration dashboardConfiguration) {
+        this.dashboardConfiguration = dashboardConfiguration;
+    }
 
 
     public AuthorizerConfiguration getAuthorizerConfiguration() {
@@ -150,11 +158,11 @@ public class StreamlineConfiguration extends Configuration {
         this.servletFilters = servletFilters;
     }
 
-    public LoginConfiguration getLoginConfiguration () {
+    public LoginConfiguration getLoginConfiguration() {
         return loginConfiguration;
     }
 
-    public void setLoginConfiguration (LoginConfiguration loginConfiguration) {
+    public void setLoginConfiguration(LoginConfiguration loginConfiguration) {
         this.loginConfiguration = loginConfiguration;
     }
 

--- a/webservice/src/main/java/com/hortonworks/streamline/webservice/resources/StreamlineConfigurationResource.java
+++ b/webservice/src/main/java/com/hortonworks/streamline/webservice/resources/StreamlineConfigurationResource.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2017 Hortonworks.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.webservice.resources;
+
+import com.codahale.metrics.annotation.Timed;
+import com.hortonworks.streamline.common.util.WSUtils;
+import com.hortonworks.streamline.webservice.configurations.StreamlineConfiguration;
+
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import static javax.ws.rs.core.Response.Status.OK;
+
+
+@Path("/v1/config")
+@Produces(MediaType.APPLICATION_JSON)
+
+public class StreamlineConfigurationResource {
+
+    private StreamlineConfiguration streamlineConfiguration;
+
+    public StreamlineConfigurationResource(StreamlineConfiguration streamlineConfiguration) {
+        this.streamlineConfiguration = streamlineConfiguration;
+    }
+
+    /**
+     * List ALL streamline configuration.
+     */
+    @GET
+    @Path("/streamline")
+    @Timed
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getStreamlineConfiguraiton(@Context UriInfo uriInfo) {
+
+        // StreamlineConfiguration object here is serialized with StreamlineConfigurationSerializer
+        return WSUtils.respondEntity(this.streamlineConfiguration, OK);
+    }
+
+}

--- a/webservice/src/main/java/com/hortonworks/streamline/webservice/util/StreamlineConfigurationSerializer.java
+++ b/webservice/src/main/java/com/hortonworks/streamline/webservice/util/StreamlineConfigurationSerializer.java
@@ -1,57 +1,32 @@
-/**
-  * Copyright 2017 Hortonworks.
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
+package com.hortonworks.streamline.webservice.util;
 
-  *   http://www.apache.org/licenses/LICENSE-2.0
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
 
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
- **/
-package com.hortonworks.streamline.webservice;
-
-import com.codahale.metrics.annotation.Timed;
+import com.hortonworks.streamline.webservice.configurations.ModuleConfiguration;
+import com.hortonworks.streamline.webservice.configurations.StreamlineConfiguration;
 import com.hortonworks.streamline.common.Constants;
-import com.hortonworks.streamline.common.util.WSUtils;
-import org.datanucleus.util.StringUtils;
+import com.hortonworks.streamline.webservice.resources.StreamlineConfigurationResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import static javax.ws.rs.core.Response.Status.OK;
+/**
+ * This JSON serializer serializes StreamlineConfiguration to a format as required by
+ * streamline api of StreamlineConfigurationResource
+ */
+public class StreamlineConfigurationSerializer extends JsonSerializer<StreamlineConfiguration> {
 
-
-
-@Path("/v1/config")
-@Produces(MediaType.APPLICATION_JSON)
-
-public class StreamlineConfigurationResource {
     private static final Logger LOG = LoggerFactory.getLogger(StreamlineConfigurationResource.class);
     public static final String DEFAULT_VERSION_FILE = "VERSION";
-    private Map<String, Object> conf;
-
     private final String CONFIG_REGISTRY = "registry";
     private final String CONFIG_REGISTRY_API_URL = "apiUrl";
     private final String CONFIG_HOST = "host";
@@ -61,26 +36,13 @@ public class StreamlineConfigurationResource {
     private final String CONFIG_VERSION = "version";
     private final String CONFIG_GIT = "git";
 
-
-
-
-    public StreamlineConfigurationResource(StreamlineConfiguration streamlineConfiguration) {
-        this.conf = new HashMap<>();
-        buildStreamlineConfig(streamlineConfiguration);
+    @Override
+    public void serialize(StreamlineConfiguration streamlineConfiguration, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        jsonGenerator.writeObject(createConfigurationMap(streamlineConfiguration));
     }
 
-    /**
-     * List ALL streamline configuration.
-     */
-    @GET
-    @Path("/streamline")
-    @Timed
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response getStreamlineConfiguraiton(@Context UriInfo uriInfo) {
-        return WSUtils.respondEntity(this.conf, OK);
-    }
-
-    private void buildStreamlineConfig(StreamlineConfiguration streamlineConfiguration) {
+    private Map<String, Object> createConfigurationMap(StreamlineConfiguration streamlineConfiguration) {
+        Map<String, Object> conf = new HashMap<>();
         // do not add any storage configuration as we don't want to return username and passwords through api
         conf.put(Constants.CONFIG_MODULES, streamlineConfiguration.getModules());
         conf.put(Constants.CONFIG_CATALOG_ROOT_URL, streamlineConfiguration.getCatalogRootUrl());
@@ -93,9 +55,9 @@ public class StreamlineConfigurationResource {
             conf.put(CONFIG_GIT, props.get(CONFIG_GIT));
         }
 
-        //adding schema regisry details to make it easier for UI to parser the host & port.
+        //adding schema registry details to make it easier for UI to parser the host & port.
         Map<String, String> registryConf = new HashMap<>();
-        for (ModuleConfiguration moduleConfiguration: streamlineConfiguration.getModules()) {
+        for (ModuleConfiguration moduleConfiguration : streamlineConfiguration.getModules()) {
             String moduleName = moduleConfiguration.getName();
             if (moduleName.equals(Constants.CONFIG_STREAMS_MODULE)) {
                 String schemaRegistryUrl = (String) moduleConfiguration.getConfig().get(Constants.CONFIG_SCHEMA_REGISTRY_URL);
@@ -112,6 +74,7 @@ public class StreamlineConfigurationResource {
         conf.put(CONFIG_REGISTRY, registryConf);
         conf.put(CONFIG_DASHBOARD, streamlineConfiguration.getDashboardConfiguration());
         conf.put(CONFIG_AUTHORIZER, streamlineConfiguration.getAuthorizerConfiguration());
+        return conf;
     }
 
     private Properties readStreamlineVersion() {
@@ -129,6 +92,4 @@ public class StreamlineConfigurationResource {
         }
         return props;
     }
-
-
 }

--- a/webservice/src/main/java/com/hortonworks/streamline/webservice/util/StreamlineConfigurationSerializer.java
+++ b/webservice/src/main/java/com/hortonworks/streamline/webservice/util/StreamlineConfigurationSerializer.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
 package com.hortonworks.streamline.webservice.util;
 
 import com.fasterxml.jackson.core.JsonGenerator;

--- a/webservice/src/test/java/com/hortonworks/streamline/webservice/RestIntegrationTest.java
+++ b/webservice/src/test/java/com/hortonworks/streamline/webservice/RestIntegrationTest.java
@@ -38,6 +38,7 @@ import com.hortonworks.streamline.streams.cluster.discovery.ambari.ServiceConfig
 import com.hortonworks.streamline.streams.layout.TopologyLayoutConstants;
 import com.hortonworks.streamline.examples.processors.ConsoleCustomProcessor;
 import com.hortonworks.streamline.streams.catalog.topology.TopologyComponentBundle;
+import com.hortonworks.streamline.webservice.configurations.StreamlineConfiguration;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.apache.commons.io.IOUtils;
@@ -75,7 +76,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 


### PR DESCRIPTION
This commit contains following changes :
  * Move configurations and resources under webservice to their respective directories.
  * Instead of serializing StreamlineConfiguration manually abstract out serializing logic to its dedicated JsonSerializer.