### PR TITLE
ISSUE-856 Event logging for test runner should log output events for …

### DIFF
--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/EventLoggingOutputCollector.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/EventLoggingOutputCollector.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.streamline.streams.runtime.storm.testing;
+
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.utils.Utils;
+
+import java.util.Collection;
+import java.util.List;
+
+public class EventLoggingOutputCollector extends OutputCollector {
+    private final OutputCollector delegate;
+    private final OutputCollectorStreamlineEventLogger outputCollectorEventLogger;
+
+    public EventLoggingOutputCollector(OutputCollector delegate, String componentName, TestRunEventLogger eventLogger) {
+        // we simply ignore the _delegate in OutputCollector and override all of the methods
+        // this will work with subclass of OutputCollector since we only expose methods what we know about
+        super(null);
+        this.delegate = delegate;
+        this.outputCollectorEventLogger = new OutputCollectorStreamlineEventLogger(eventLogger, componentName);
+    }
+
+    @Override
+    public List<Integer> emit(String streamId, Tuple anchor, List<Object> tuple) {
+        return outputCollectorEventLogger.emitWithLoggingEvent(streamId, tuple, t -> delegate.emit(streamId, anchor, t));
+    }
+
+    @Override
+    public List<Integer> emit(String streamId, List<Object> tuple) {
+        return outputCollectorEventLogger.emitWithLoggingEvent(streamId, tuple, t -> delegate.emit(streamId, t));
+    }
+
+    @Override
+    public List<Integer> emit(Collection<Tuple> anchors, List<Object> tuple) {
+        return outputCollectorEventLogger.emitWithLoggingEvent(Utils.DEFAULT_STREAM_ID, tuple, t -> delegate.emit(anchors, t));
+    }
+
+    @Override
+    public List<Integer> emit(Tuple anchor, List<Object> tuple) {
+        return outputCollectorEventLogger.emitWithLoggingEvent(Utils.DEFAULT_STREAM_ID, tuple, t -> delegate.emit(anchor, t));
+    }
+
+    @Override
+    public List<Integer> emit(List<Object> tuple) {
+        return outputCollectorEventLogger.emitWithLoggingEvent(Utils.DEFAULT_STREAM_ID, tuple, t -> delegate.emit(t));
+    }
+
+    @Override
+    public List<Integer> emit(String streamId, Collection<Tuple> anchors, List<Object> tuple) {
+        return outputCollectorEventLogger.emitWithLoggingEvent(streamId, tuple, t -> delegate.emit(streamId, anchors, t));
+    }
+
+    @Override
+    public void emitDirect(int taskId, String streamId, Tuple anchor, List<Object> tuple) {
+        outputCollectorEventLogger.emitDirectWithLoggingEvent(streamId, tuple, t -> delegate.emitDirect(taskId, streamId, anchor, t));
+    }
+
+    @Override
+    public void emitDirect(int taskId, String streamId, List<Object> tuple) {
+        outputCollectorEventLogger.emitDirectWithLoggingEvent(streamId, tuple, t -> delegate.emitDirect(taskId, streamId, t));
+    }
+
+    @Override
+    public void emitDirect(int taskId, Collection<Tuple> anchors, List<Object> tuple) {
+        outputCollectorEventLogger.emitDirectWithLoggingEvent(Utils.DEFAULT_STREAM_ID, tuple, t -> delegate.emitDirect(taskId, anchors, t));
+    }
+
+    @Override
+    public void emitDirect(int taskId, Tuple anchor, List<Object> tuple) {
+        outputCollectorEventLogger.emitDirectWithLoggingEvent(Utils.DEFAULT_STREAM_ID, tuple, t -> delegate.emitDirect(taskId, anchor, t));
+    }
+
+    @Override
+    public void emitDirect(int taskId, List<Object> tuple) {
+        outputCollectorEventLogger.emitDirectWithLoggingEvent(Utils.DEFAULT_STREAM_ID, tuple, t -> delegate.emitDirect(taskId, t));
+    }
+
+    @Override
+    public void emitDirect(int taskId, String streamId, Collection<Tuple> anchors, List<Object> tuple) {
+        outputCollectorEventLogger.emitDirectWithLoggingEvent(streamId, tuple, t -> delegate.emitDirect(taskId, streamId, anchors, t));
+    }
+
+    @Override
+    public void ack(Tuple tuple) {
+        delegate.ack(tuple);
+    }
+
+    @Override
+    public void fail(Tuple tuple) {
+        delegate.fail(tuple);
+    }
+
+    @Override
+    public void resetTimeout(Tuple tuple) {
+        delegate.resetTimeout(tuple);
+    }
+
+    @Override
+    public void reportError(Throwable throwable) {
+        delegate.reportError(throwable);
+    }
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/EventLoggingSpoutOutputCollector.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/EventLoggingSpoutOutputCollector.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.streamline.streams.runtime.storm.testing;
+
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.utils.Utils;
+
+import java.util.List;
+
+public class EventLoggingSpoutOutputCollector extends SpoutOutputCollector {
+    private final SpoutOutputCollector delegate;
+    private final OutputCollectorStreamlineEventLogger outputCollectorEventLogger;
+
+    public EventLoggingSpoutOutputCollector(SpoutOutputCollector delegate, String componentName, TestRunEventLogger eventLogger) {
+        // we simply ignore the _delegate in SpoutOutputCollector and override all of the methods
+        // this will work with subclass of SpoutOutputCollector since we only expose methods what we know about
+        super(null);
+        this.delegate = delegate;
+        this.outputCollectorEventLogger = new OutputCollectorStreamlineEventLogger(eventLogger, componentName);
+    }
+
+    @Override
+    public List<Integer> emit(String streamId, List<Object> tuple) {
+        return outputCollectorEventLogger.emitWithLoggingEvent(streamId, tuple, t -> delegate.emit(streamId, t));
+    }
+
+    @Override
+    public List<Integer> emit(List<Object> tuple) {
+        return outputCollectorEventLogger.emitWithLoggingEvent(Utils.DEFAULT_STREAM_ID, tuple, t -> delegate.emit(t));
+    }
+
+    @Override
+    public List<Integer> emit(String streamId, List<Object> tuple, Object messageId) {
+        return outputCollectorEventLogger.emitWithLoggingEvent(streamId, tuple, t -> delegate.emit(streamId, t, messageId));
+    }
+
+    @Override
+    public List<Integer> emit(List<Object> tuple, Object messageId) {
+        return outputCollectorEventLogger.emitWithLoggingEvent(Utils.DEFAULT_STREAM_ID, tuple, t -> delegate.emit(t, messageId));
+    }
+
+    @Override
+    public void emitDirect(int taskId, String streamId, List<Object> tuple) {
+        outputCollectorEventLogger.emitDirectWithLoggingEvent(streamId, tuple, t -> delegate.emitDirect(taskId, streamId, t));
+    }
+
+    @Override
+    public void emitDirect(int taskId, List<Object> tuple) {
+        outputCollectorEventLogger.emitDirectWithLoggingEvent(Utils.DEFAULT_STREAM_ID, tuple, t -> delegate.emitDirect(taskId, t));
+    }
+
+    @Override
+    public void emitDirect(int taskId, String streamId, List<Object> tuple, Object messageId) {
+        outputCollectorEventLogger.emitDirectWithLoggingEvent(streamId, tuple, t -> delegate.emitDirect(taskId, streamId, t, messageId));
+    }
+
+    @Override
+    public void emitDirect(int taskId, List<Object> tuple, Object messageId) {
+        outputCollectorEventLogger.emitDirectWithLoggingEvent(Utils.DEFAULT_STREAM_ID, tuple, t -> delegate.emitDirect(taskId, t, messageId));
+    }
+
+    @Override
+    public void reportError(Throwable throwable) {
+        delegate.reportError(throwable);
+    }
+
+    @Override
+    public long getPendingCount() {
+        return delegate.getPendingCount();
+    }
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/OutputCollectorStreamlineEventLogger.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/OutputCollectorStreamlineEventLogger.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.streamline.streams.runtime.storm.testing;
+
+import com.hortonworks.streamline.streams.StreamlineEvent;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class OutputCollectorStreamlineEventLogger {
+    private final TestRunEventLogger eventLogger;
+    private final String componentName;
+
+    public OutputCollectorStreamlineEventLogger(TestRunEventLogger eventLogger, String componentName) {
+        this.eventLogger = eventLogger;
+        this.componentName = componentName;
+    }
+
+    public List<Integer> emitWithLoggingEvent(String streamId, List<Object> tuple, Function<List<Object>, List<Integer>> emitFunc) {
+        List<Integer> ret = emitFunc.apply(tuple);
+        StreamlineEvent streamlineEvent = (StreamlineEvent) tuple.get(0);
+        eventLogger.writeEvent(System.currentTimeMillis(), TestRunEventLogger.EventType.OUTPUT, componentName,
+                streamId, streamlineEvent);
+        return ret;
+    }
+
+    public void emitDirectWithLoggingEvent(String streamId, List<Object> tuple, Consumer<List<Object>> emitFunc) {
+        emitFunc.accept(tuple);
+        StreamlineEvent streamlineEvent = (StreamlineEvent) tuple.get(0);
+        eventLogger.writeEvent(System.currentTimeMillis(), TestRunEventLogger.EventType.OUTPUT, componentName,
+                streamId, streamlineEvent);
+    }
+
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunEventLogger.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunEventLogger.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
 package com.hortonworks.streamline.streams.runtime.storm.testing;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -42,11 +58,12 @@ public class TestRunEventLogger {
 
     // Writing event to file should be mutually exclusive.
     // We don't need to worry about performance since it's just for testing topology locally.
-    public synchronized void writeEvent(long timestamp, String componentName, StreamlineEvent event) {
+    public synchronized void writeEvent(long timestamp, EventType eventType, String componentName,
+                                        String streamId, StreamlineEvent event) {
         try (FileWriter fw = new FileWriter(eventLogFilePath, true)) {
             LOG.debug("writing event to file " + eventLogFilePath);
 
-            EventInformation eventInfo = new EventInformation(timestamp, componentName, event);
+            EventInformation eventInfo = new EventInformation(timestamp, eventType, componentName, streamId, event);
             fw.write(objectMapper.writeValueAsString(eventInfo) + "\n");
             fw.flush();
         } catch (FileNotFoundException e) {
@@ -58,14 +75,22 @@ public class TestRunEventLogger {
         }
     }
 
+    public static enum EventType {
+        INPUT, OUTPUT
+    }
+
     public static class EventInformation {
         private long timestamp;
+        private EventType eventType;
         private String componentName;
+        private String streamId;
         private StreamlineEvent streamlineEvent;
 
-        public EventInformation(long timestamp, String componentName, StreamlineEvent streamlineEvent) {
+        public EventInformation(long timestamp, EventType eventType, String componentName, String streamId, StreamlineEvent streamlineEvent) {
             this.timestamp = timestamp;
+            this.eventType = eventType;
             this.componentName = componentName;
+            this.streamId = streamId;
             this.streamlineEvent = streamlineEvent;
         }
 
@@ -73,8 +98,16 @@ public class TestRunEventLogger {
             return timestamp;
         }
 
+        public EventType getEventType() {
+            return eventType;
+        }
+
         public String getComponentName() {
             return componentName;
+        }
+
+        public String getStreamId() {
+            return streamId;
         }
 
         public StreamlineEvent getStreamlineEvent() {

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunProcessorBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunProcessorBolt.java
@@ -1,6 +1,21 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
 package com.hortonworks.streamline.streams.runtime.storm.testing;
 
-import com.hortonworks.streamline.streams.StreamlineEvent;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
@@ -13,7 +28,6 @@ public class TestRunProcessorBolt extends BaseRichBolt {
     private final String componentName;
     private final BaseRichBolt processorBolt;
     private final String eventLogFilePath;
-    private transient TestRunEventLogger eventLogger;
 
     public TestRunProcessorBolt(String componentName, BaseRichBolt processorBolt, String eventLogFilePath) {
         this.componentName = componentName;
@@ -23,17 +37,13 @@ public class TestRunProcessorBolt extends BaseRichBolt {
 
     @Override
     public void prepare(Map map, TopologyContext topologyContext, OutputCollector outputCollector) {
-        processorBolt.prepare(map, topologyContext, outputCollector);
-
-        eventLogger = TestRunEventLogger.getEventLogger(eventLogFilePath);
+        EventLoggingOutputCollector collector = new EventLoggingOutputCollector(outputCollector, componentName,
+                TestRunEventLogger.getEventLogger(eventLogFilePath));
+        processorBolt.prepare(map, topologyContext, collector);
     }
 
     @Override
     public void execute(Tuple tuple) {
-        Object value = tuple.getValueByField(StreamlineEvent.STREAMLINE_EVENT);
-        StreamlineEvent event = (StreamlineEvent) value;
-        eventLogger.writeEvent(System.currentTimeMillis(), componentName, event);
-
         processorBolt.execute(tuple);
     }
 
@@ -51,4 +61,5 @@ public class TestRunProcessorBolt extends BaseRichBolt {
     public void cleanup() {
         processorBolt.cleanup();
     }
+
 }

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunSinkBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunSinkBolt.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+
 package com.hortonworks.streamline.streams.runtime.storm.testing;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -77,9 +78,11 @@ public class TestRunSinkBolt extends BaseRichBolt {
     @Override
     public void execute(Tuple input) {
         Object value = input.getValueByField(StreamlineEvent.STREAMLINE_EVENT);
+        String streamId = input.getSourceStreamId();
         StreamlineEvent event = (StreamlineEvent) value;
 
-        eventLogger.writeEvent(System.currentTimeMillis(), testRunSink.getName(), event);
+        eventLogger.writeEvent(System.currentTimeMillis(), TestRunEventLogger.EventType.INPUT, testRunSink.getName(),
+                streamId, event);
 
         String outputFilePath = testRunSink.getOutputFilePath();
         try (FileWriter fw = new FileWriter(outputFilePath, true)) {

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunSourceSpout.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunSourceSpout.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+
 package com.hortonworks.streamline.streams.runtime.storm.testing;
 
 import com.hortonworks.streamline.common.util.Utils;
@@ -36,11 +37,10 @@ import java.util.Queue;
 
 public class TestRunSourceSpout extends BaseRichSpout {
     private static final Logger LOG = LoggerFactory.getLogger(TestRunSourceSpout.class);
-    private SpoutOutputCollector _collector;
+    private EventLoggingSpoutOutputCollector collector;
 
     private final TestRunSource testRunSource;
     private final Map<String, Queue<Map<String, Object>>> testRecordsQueueMap;
-    private transient TestRunEventLogger eventLogger;
 
     public TestRunSourceSpout(String testRunSourceJson) {
         this(Utils.createObjectFromJson(testRunSourceJson, TestRunSource.class));
@@ -70,9 +70,9 @@ public class TestRunSourceSpout extends BaseRichSpout {
         if (this.testRunSource == null) {
             throw new RuntimeException("testRunSource cannot be null");
         }
-        _collector = collector;
 
-        eventLogger = TestRunEventLogger.getEventLogger(testRunSource.getEventLogFilePath());
+        this.collector = new EventLoggingSpoutOutputCollector(collector, testRunSource.getName(),
+                TestRunEventLogger.getEventLogger(testRunSource.getEventLogFilePath()));
     }
 
     @Override
@@ -88,10 +88,7 @@ public class TestRunSourceSpout extends BaseRichSpout {
             if (record != null) {
                 StreamlineEventImpl streamlineEvent = new StreamlineEventImpl(record, testRunSource.getId());
                 LOG.debug("Emitting event {} to stream {}", streamlineEvent, outputStream);
-                _collector.emit(outputStream, new Values(streamlineEvent), streamlineEvent.getId());
-
-                eventLogger.writeEvent(System.currentTimeMillis(), testRunSource.getName(), streamlineEvent);
-
+                collector.emit(outputStream, new Values(streamlineEvent), streamlineEvent.getId());
                 emitCount++;
             }
         }

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/testing/EventLoggingOutputCollectorTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/testing/EventLoggingOutputCollectorTest.java
@@ -1,0 +1,284 @@
+package com.hortonworks.streamline.streams.runtime.storm.testing;
+
+import com.google.common.collect.Lists;
+import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Verifications;
+import mockit.integration.junit4.JMockit;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.Utils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@RunWith(JMockit.class)
+public class EventLoggingOutputCollectorTest {
+    private static final String TEST_COMPONENT_NAME = "testComponent";
+
+    @Injectable
+    private TestRunEventLogger mockedEventLogger;
+
+    @Injectable
+    private OutputCollector mockedOutputCollector;
+
+    @Injectable
+    private Tuple anchor;
+
+    private Collection<Tuple> anchors;
+
+    private EventLoggingOutputCollector sut;
+
+    public static final StreamlineEventImpl INPUT_STREAMLINE_EVENT = new StreamlineEventImpl(new HashMap<String, Object>() {{
+        put("illuminance", 70);
+        put("temp", 104);
+        put("foo", 100);
+        put("humidity", "40h");
+    }}, "ds-" + System.currentTimeMillis(), "id-" + System.currentTimeMillis());
+
+    @Before
+    public void setUp() {
+        sut = new EventLoggingOutputCollector(mockedOutputCollector, TEST_COMPONENT_NAME, mockedEventLogger);
+        anchors = Collections.singletonList(anchor);
+    }
+
+    @Test
+    public void emit() throws Exception {
+        String testStreamId = "testStreamId";
+        ArrayList<Integer> expectedTasks = Lists.newArrayList(1, 2);
+        final List<Tuple> anchors = Collections.singletonList(anchor);
+        final Values tuple = new Values(INPUT_STREAMLINE_EVENT);
+
+        // String streamId, Tuple anchor, List<Object> anchor
+        new Expectations() {{
+            mockedOutputCollector.emit(testStreamId, anchor, tuple);
+            result = expectedTasks;
+        }};
+
+        List<Integer> tasks = sut.emit(testStreamId, anchor, tuple);
+        assertEquals(expectedTasks, tasks);
+
+        new Verifications() {{
+            mockedOutputCollector.emit(testStreamId, anchor, tuple);
+            mockedEventLogger.writeEvent(anyLong, TestRunEventLogger.EventType.OUTPUT, TEST_COMPONENT_NAME,
+                    testStreamId, INPUT_STREAMLINE_EVENT); times = 1;
+        }};
+
+        // String streamId, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emit(testStreamId, tuple);
+            result = expectedTasks;
+        }};
+
+        tasks = sut.emit(testStreamId, tuple);
+        assertEquals(expectedTasks, tasks);
+
+        new Verifications() {{
+            mockedOutputCollector.emit(testStreamId, tuple);
+            mockedEventLogger.writeEvent(anyLong, TestRunEventLogger.EventType.OUTPUT, TEST_COMPONENT_NAME,
+                    testStreamId, INPUT_STREAMLINE_EVENT); times = 1;
+        }};
+
+        // Collection<Tuple> anchors, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emit(anchors, tuple);
+            result = expectedTasks;
+        }};
+
+        tasks = sut.emit(anchors, tuple);
+        assertEquals(expectedTasks, tasks);
+
+        new Verifications() {{
+            mockedOutputCollector.emit(anchors, tuple);
+            mockedEventLogger.writeEvent(anyLong, TestRunEventLogger.EventType.OUTPUT, TEST_COMPONENT_NAME,
+                    Utils.DEFAULT_STREAM_ID, INPUT_STREAMLINE_EVENT); times = 1;
+        }};
+
+        // Tuple anchor, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emit(anchor, tuple);
+            result = expectedTasks;
+        }};
+
+        tasks = sut.emit(anchor, tuple);
+        assertEquals(expectedTasks, tasks);
+
+        new Verifications() {{
+            mockedOutputCollector.emit(anchor, tuple);
+            mockedEventLogger.writeEvent(anyLong, TestRunEventLogger.EventType.OUTPUT, TEST_COMPONENT_NAME,
+                    Utils.DEFAULT_STREAM_ID, INPUT_STREAMLINE_EVENT); times = 1;
+        }};
+
+        // List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emit(tuple);
+            result = expectedTasks;
+        }};
+
+        tasks = sut.emit(tuple);
+        assertEquals(expectedTasks, tasks);
+
+        new Verifications() {{
+            mockedOutputCollector.emit(tuple);
+            mockedEventLogger.writeEvent(anyLong, TestRunEventLogger.EventType.OUTPUT, TEST_COMPONENT_NAME,
+                    Utils.DEFAULT_STREAM_ID, INPUT_STREAMLINE_EVENT); times = 1;
+        }};
+
+        // String streamId, Collection<Tuple> anchors, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emit(testStreamId, anchors, tuple);
+            result = expectedTasks;
+        }};
+
+        tasks = sut.emit(testStreamId, anchors, tuple);
+        assertEquals(expectedTasks, tasks);
+
+        new Verifications() {{
+            mockedOutputCollector.emit(testStreamId, anchors, tuple);
+            mockedEventLogger.writeEvent(anyLong, TestRunEventLogger.EventType.OUTPUT, TEST_COMPONENT_NAME,
+                    testStreamId, INPUT_STREAMLINE_EVENT); times = 1;
+        }};
+
+    }
+
+    @Test
+    public void emitDirect() throws Exception {
+        int testTaskId = 1;
+        String testStreamId = "testStreamId";
+        ArrayList<Integer> expectedTasks = Lists.newArrayList(1, 2);
+        final List<Tuple> anchors = Collections.singletonList(anchor);
+        final Values tuple = new Values(INPUT_STREAMLINE_EVENT);
+
+        // int taskId, String streamId, Tuple anchor, List<Object> anchor
+        new Expectations() {{
+            mockedOutputCollector.emitDirect(testTaskId, testStreamId, anchor, tuple);
+            result = expectedTasks;
+        }};
+
+        sut.emitDirect(testTaskId, testStreamId, anchor, tuple);
+
+        new Verifications() {{
+            mockedOutputCollector.emitDirect(testTaskId, testStreamId, anchor, tuple);
+            mockedEventLogger.writeEvent(anyLong, TestRunEventLogger.EventType.OUTPUT, TEST_COMPONENT_NAME,
+                    testStreamId, INPUT_STREAMLINE_EVENT); times = 1;
+        }};
+
+        // int taskId, String streamId, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emitDirect(testTaskId, testStreamId, tuple);
+            result = expectedTasks;
+        }};
+
+        sut.emitDirect(testTaskId, testStreamId, tuple);
+
+        new Verifications() {{
+            mockedOutputCollector.emitDirect(testTaskId, testStreamId, tuple);
+            mockedEventLogger.writeEvent(anyLong, TestRunEventLogger.EventType.OUTPUT, TEST_COMPONENT_NAME,
+                    testStreamId, INPUT_STREAMLINE_EVENT); times = 1;
+        }};
+
+        // int taskId, Collection<Tuple> anchors, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emitDirect(testTaskId, anchors, tuple);
+            result = expectedTasks;
+        }};
+
+        sut.emitDirect(testTaskId, anchors, tuple);
+
+        new Verifications() {{
+            mockedOutputCollector.emitDirect(testTaskId, anchors, tuple);
+            mockedEventLogger.writeEvent(anyLong, TestRunEventLogger.EventType.OUTPUT, TEST_COMPONENT_NAME,
+                    Utils.DEFAULT_STREAM_ID, INPUT_STREAMLINE_EVENT); times = 1;
+        }};
+
+        // int taskId, Tuple anchor, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emitDirect(testTaskId, anchor, tuple);
+            result = expectedTasks;
+        }};
+
+        sut.emitDirect(testTaskId, anchor, tuple);
+
+        new Verifications() {{
+            mockedOutputCollector.emitDirect(testTaskId, anchor, tuple);
+            mockedEventLogger.writeEvent(anyLong, TestRunEventLogger.EventType.OUTPUT, TEST_COMPONENT_NAME,
+                    Utils.DEFAULT_STREAM_ID, INPUT_STREAMLINE_EVENT); times = 1;
+        }};
+
+        // int taskId, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emitDirect(testTaskId, tuple);
+            result = expectedTasks;
+        }};
+
+        sut.emitDirect(testTaskId, tuple);
+
+        new Verifications() {{
+            mockedOutputCollector.emitDirect(testTaskId, tuple);
+            mockedEventLogger.writeEvent(anyLong, TestRunEventLogger.EventType.OUTPUT, TEST_COMPONENT_NAME,
+                    Utils.DEFAULT_STREAM_ID, INPUT_STREAMLINE_EVENT); times = 1;
+        }};
+
+        // int taskId, String streamId, Collection<Tuple> anchors, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emitDirect(testTaskId, testStreamId, anchors, tuple);
+            result = expectedTasks;
+        }};
+
+        sut.emitDirect(testTaskId, testStreamId, anchors, tuple);
+
+        new Verifications() {{
+            mockedOutputCollector.emitDirect(testTaskId, testStreamId, anchors, tuple);
+            mockedEventLogger.writeEvent(anyLong, TestRunEventLogger.EventType.OUTPUT, TEST_COMPONENT_NAME,
+                    testStreamId, INPUT_STREAMLINE_EVENT); times = 1;
+        }};
+
+    }
+
+    @Test
+    public void testAck() throws Exception {
+        sut.ack(anchor);
+
+        new Verifications() {{
+            mockedOutputCollector.ack(anchor); times = 1;
+        }};
+    }
+
+    @Test
+    public void testFail() throws Exception {
+        sut.fail(anchor);
+
+        new Verifications() {{
+            mockedOutputCollector.fail(anchor); times = 1;
+        }};
+    }
+
+    @Test
+    public void testResetTimeout() throws Exception {
+        sut.resetTimeout(anchor);
+
+        new Verifications() {{
+            mockedOutputCollector.resetTimeout(anchor); times = 1;
+        }};
+    }
+
+    @Test
+    public void testReportError() throws Exception {
+        Throwable throwable = new RuntimeException("error");
+        sut.reportError(throwable);
+
+        new Verifications() {{
+            mockedOutputCollector.reportError(throwable); times = 1;
+        }};
+    }
+}

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/testing/EventLoggingSpoutOutputCollectorTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/testing/EventLoggingSpoutOutputCollectorTest.java
@@ -1,0 +1,211 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.streamline.streams.runtime.storm.testing;
+
+import com.google.common.collect.Lists;
+import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Verifications;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.Utils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class EventLoggingSpoutOutputCollectorTest {
+    private static final String TEST_COMPONENT_NAME = "testComponent";
+
+    @Injectable
+    private TestRunEventLogger mockedEventLogger;
+
+    @Injectable
+    private SpoutOutputCollector mockedOutputCollector;
+
+    private EventLoggingSpoutOutputCollector sut;
+
+    public static final StreamlineEventImpl INPUT_STREAMLINE_EVENT = new StreamlineEventImpl(new HashMap<String, Object>() {{
+        put("illuminance", 70);
+        put("temp", 104);
+        put("foo", 100);
+        put("humidity", "40h");
+    }}, "ds-" + System.currentTimeMillis(), "id-" + System.currentTimeMillis());
+
+    @Before
+    public void setUp() {
+        sut = new EventLoggingSpoutOutputCollector(mockedOutputCollector, TEST_COMPONENT_NAME, mockedEventLogger);
+    }
+
+    @Test
+    public void emit() throws Exception {
+        String testStreamId = "testStreamId";
+        ArrayList<Integer> expectedTasks = Lists.newArrayList(1, 2);
+        final Values tuple = new Values(INPUT_STREAMLINE_EVENT);
+        String messageId = "testMessageId";
+
+        // String streamId, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emit(testStreamId, tuple);
+            result = expectedTasks;
+        }};
+
+        List<Integer> tasks = sut.emit(testStreamId, tuple);
+        assertEquals(expectedTasks, tasks);
+
+        new Verifications() {{
+            mockedOutputCollector.emit(testStreamId, tuple);
+            mockedEventLogger.writeEvent(anyLong, TestRunEventLogger.EventType.OUTPUT, TEST_COMPONENT_NAME,
+                    testStreamId, INPUT_STREAMLINE_EVENT); times = 1;
+        }};
+
+        // List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emit(tuple);
+            result = expectedTasks;
+        }};
+
+        tasks = sut.emit(tuple);
+        assertEquals(expectedTasks, tasks);
+
+        new Verifications() {{
+            mockedOutputCollector.emit(tuple);
+            mockedEventLogger.writeEvent(anyLong, TestRunEventLogger.EventType.OUTPUT, TEST_COMPONENT_NAME,
+                    Utils.DEFAULT_STREAM_ID, INPUT_STREAMLINE_EVENT); times = 1;
+        }};
+
+        // String streamId, List<Object> tuple, Object messageId
+        new Expectations() {{
+            mockedOutputCollector.emit(testStreamId, tuple, messageId);
+            result = expectedTasks;
+        }};
+
+        tasks = sut.emit(testStreamId, tuple, messageId);
+        assertEquals(expectedTasks, tasks);
+
+        new Verifications() {{
+            mockedOutputCollector.emit(testStreamId, tuple, messageId);
+            mockedEventLogger.writeEvent(anyLong, TestRunEventLogger.EventType.OUTPUT, TEST_COMPONENT_NAME,
+                    testStreamId, INPUT_STREAMLINE_EVENT); times = 1;
+        }};
+
+        // List<Object> tuple, Object messageId
+        new Expectations() {{
+            mockedOutputCollector.emit(tuple, messageId);
+            result = expectedTasks;
+        }};
+
+        tasks = sut.emit(tuple, messageId);
+        assertEquals(expectedTasks, tasks);
+
+        new Verifications() {{
+            mockedOutputCollector.emit(tuple, messageId);
+            mockedEventLogger.writeEvent(anyLong, TestRunEventLogger.EventType.OUTPUT, TEST_COMPONENT_NAME,
+                    Utils.DEFAULT_STREAM_ID, INPUT_STREAMLINE_EVENT); times = 1;
+        }};
+    }
+
+    @Test
+    public void emitDirect() throws Exception {
+        int testTaskId = 1;
+        String testStreamId = "testStreamId";
+        ArrayList<Integer> expectedTasks = Lists.newArrayList(1, 2);
+        final Values tuple = new Values(INPUT_STREAMLINE_EVENT);
+        String messageId = "testMessageId";
+
+        // int taskId, String streamId, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emitDirect(testTaskId, testStreamId, tuple);
+            result = expectedTasks;
+        }};
+
+        sut.emitDirect(testTaskId, testStreamId, tuple);
+
+        new Verifications() {{
+            mockedOutputCollector.emitDirect(testTaskId, testStreamId, tuple);
+            mockedEventLogger.writeEvent(anyLong, TestRunEventLogger.EventType.OUTPUT, TEST_COMPONENT_NAME,
+                    testStreamId, INPUT_STREAMLINE_EVENT); times = 1;
+        }};
+
+        // int taskId, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emitDirect(testTaskId, tuple);
+            result = expectedTasks;
+        }};
+
+        sut.emitDirect(testTaskId, tuple);
+
+        new Verifications() {{
+            mockedOutputCollector.emitDirect(testTaskId, tuple);
+            mockedEventLogger.writeEvent(anyLong, TestRunEventLogger.EventType.OUTPUT, TEST_COMPONENT_NAME,
+                    Utils.DEFAULT_STREAM_ID, INPUT_STREAMLINE_EVENT); times = 1;
+        }};
+
+        // int taskId, String streamId, List<Object> tuple, Object messageId
+        new Expectations() {{
+            mockedOutputCollector.emitDirect(testTaskId, testStreamId, tuple, messageId);
+            result = expectedTasks;
+        }};
+
+        sut.emitDirect(testTaskId, testStreamId, tuple, messageId);
+
+        new Verifications() {{
+            mockedOutputCollector.emitDirect(testTaskId, testStreamId, tuple, messageId);
+            mockedEventLogger.writeEvent(anyLong, TestRunEventLogger.EventType.OUTPUT, TEST_COMPONENT_NAME,
+                    testStreamId, INPUT_STREAMLINE_EVENT); times = 1;
+        }};
+
+        // int taskId, List<Object> tuple, Object messageId
+        new Expectations() {{
+            mockedOutputCollector.emitDirect(testTaskId, tuple, messageId);
+            result = expectedTasks;
+        }};
+
+        sut.emitDirect(testTaskId, tuple, messageId);
+
+        new Verifications() {{
+            mockedOutputCollector.emitDirect(testTaskId, tuple, messageId);
+            mockedEventLogger.writeEvent(anyLong, TestRunEventLogger.EventType.OUTPUT, TEST_COMPONENT_NAME,
+                    Utils.DEFAULT_STREAM_ID, INPUT_STREAMLINE_EVENT); times = 1;
+        }};
+    }
+
+    @Test
+    public void reportError() throws Exception {
+        Throwable throwable = new RuntimeException("error");
+        sut.reportError(throwable);
+
+        new Verifications() {{
+            mockedOutputCollector.reportError(throwable); times = 1;
+        }};
+    }
+
+    @Test
+    public void getPendingCount() throws Exception {
+        sut.getPendingCount();
+
+        new Verifications() {{
+            mockedOutputCollector.getPendingCount(); times = 1;
+        }};
+    }
+
+}


### PR DESCRIPTION
…processor

* also add missing license doc to some classes

This closes #856

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hortonworks/streamline/857)
<!-- Reviewable:end -->
