### PR TITLE
ISSUE-859: Migration script for UDF/UDAF

### DIFF
--- a/bootstrap/sql/mysql/migrate_udf.sql
+++ b/bootstrap/sql/mysql/migrate_udf.sql
@@ -1,0 +1,18 @@
+update topology_window set parsedRuleStr=REPLACE(parsedRuleStr, '"STDDEV"', '"STDDEV_FN"'), projections=REPLACE(projections, '"STDDEV"', '"STDDEV_FN"');
+update topology_window set parsedRuleStr=REPLACE(parsedRuleStr, '"STDDEVP"', '"STDDEVP_FN"'), projections=REPLACE(projections, '"STDDEVP"', '"STDDEVP_FN"');
+update topology_window set parsedRuleStr=REPLACE(parsedRuleStr, '"VARIANCE"', '"VARIANCE_FN"'), projections=REPLACE(projections, '"VARIANCE"', '"VARIANCE_FN"');
+update topology_window set parsedRuleStr=REPLACE(parsedRuleStr, '"VARIANCEP"', '"VARIANCEP_FN"'), projections=REPLACE(projections, '"VARIANCEP"', '"VARIANCEP_FN"');
+update topology_window set parsedRuleStr=REPLACE(parsedRuleStr, '"MEAN"', '"AVG_FN"'), projections=REPLACE(projections, '"MEAN"', '"AVG_FN"');
+update topology_window set parsedRuleStr=REPLACE(parsedRuleStr, '"NUMBERSUM"', '"SUM_FN"'), projections=REPLACE(projections, '"NUMBERSUM"', '"SUM_FN"');
+update topology_window set parsedRuleStr=REPLACE(parsedRuleStr, '"LONGCOUNT"', '"COUNT_FN"'), projections=REPLACE(projections, '"LONGCOUNT"', '"COUNT_FN"');
+
+update topology_rule set parsedRuleStr=REPLACE(parsedRuleStr, '"CONCAT"', '"CONCAT_FN"'), projections=REPLACE(projections, '"CONCAT"', '"CONCAT_FN"'), `sql`=REPLACE(`sql`, 'CONCAT', 'CONCAT_FN');
+
+delete from udf where name='STDDEV';
+delete from udf where name='STDDEVP';
+delete from udf where name='VARIANCE';
+delete from udf where name='VARIANCEP';
+delete from udf where name='MEAN';
+delete from udf where name='NUMBERSUM';
+delete from udf where name='LONGCOUNT';
+delete from udf where name='CONCAT';

--- a/bootstrap/sql/postgresql/migrate_udf.sql
+++ b/bootstrap/sql/postgresql/migrate_udf.sql
@@ -1,0 +1,19 @@
+update topology_window set "parsedRuleStr"=REPLACE("parsedRuleStr", '"STDDEV"', '"STDDEV_FN"'), "projections"=REPLACE("projections", '"STDDEV"', '"STDDEV_FN"');
+update topology_window set "parsedRuleStr"=REPLACE("parsedRuleStr", '"STDDEVP"', '"STDDEVP_FN"'), "projections"=REPLACE("projections", '"STDDEVP"', '"STDDEVP_FN"');
+update topology_window set "parsedRuleStr"=REPLACE("parsedRuleStr", '"VARIANCE"', '"VARIANCE_FN"'), "projections"=REPLACE("projections", '"VARIANCE"', '"VARIANCE_FN"');
+update topology_window set "parsedRuleStr"=REPLACE("parsedRuleStr", '"VARIANCEP"', '"VARIANCEP_FN"'), "projections"=REPLACE("projections", '"VARIANCEP"', '"VARIANCEP_FN"');
+update topology_window set "parsedRuleStr"=REPLACE("parsedRuleStr", '"MEAN"', '"AVG_FN"'), "projections"=REPLACE("projections", '"MEAN"', '"AVG_FN"');
+update topology_window set "parsedRuleStr"=REPLACE("parsedRuleStr", '"NUMBERSUM"', '"SUM_FN"'), "projections"=REPLACE("projections", '"NUMBERSUM"', '"SUM_FN"');
+update topology_window set "parsedRuleStr"=REPLACE("parsedRuleStr", '"LONGCOUNT"', '"COUNT_FN"'), "projections"=REPLACE("projections", '"LONGCOUNT"', '"COUNT_FN"');
+
+update "topology_rule" set "parsedRuleStr"=REPLACE("parsedRuleStr", '"CONCAT"', '"CONCAT_FN"'), "projections"=REPLACE("projections", '"CONCAT"', '"CONCAT_FN"'), "sql"=REPLACE("sql", 'CONCAT', 'CONCAT_FN');
+
+
+delete from udf where name='STDDEV';
+delete from udf where name='STDDEVP';
+delete from udf where name='VARIANCE';
+delete from udf where name='VARIANCEP';
+delete from udf where name='MEAN';
+delete from udf where name='NUMBERSUM';
+delete from udf where name='LONGCOUNT';
+delete from udf where name='CONCAT';

--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/StormTopologyDependenciesHandler.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/StormTopologyDependenciesHandler.java
@@ -21,8 +21,8 @@ import com.hortonworks.streamline.common.Config;
 import com.hortonworks.streamline.common.QueryParam;
 import com.hortonworks.streamline.streams.catalog.UDF;
 import com.hortonworks.streamline.streams.catalog.processor.CustomProcessorInfo;
-import com.hortonworks.streamline.streams.catalog.topology.TopologyComponentBundle;
 import com.hortonworks.streamline.streams.catalog.service.StreamCatalogService;
+import com.hortonworks.streamline.streams.catalog.topology.TopologyComponentBundle;
 import com.hortonworks.streamline.streams.layout.component.Edge;
 import com.hortonworks.streamline.streams.layout.component.StreamlineComponent;
 import com.hortonworks.streamline.streams.layout.component.StreamlineProcessor;
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -65,8 +64,15 @@ public class StormTopologyDependenciesHandler extends TopologyDagVisitor {
         Set<UDF> udfsToShip = new HashSet<>();
         for (Rule rule : rulesProcessor.getRules()) {
             for (Udf udf : rule.getReferredUdfs()) {
-                List<QueryParam> qps = QueryParam.params(UDF.NAME, udf.getName(), UDF.CLASSNAME, udf.getClassName(),
-                        UDF.TYPE, udf.getType().toString());
+                List<QueryParam> qps = QueryParam.params(UDF.NAME, udf.getName());
+                // The null check for backward compatibility
+                if (udf.getClassName() != null) {
+                    qps.add(new QueryParam(UDF.CLASSNAME, udf.getClassName()));
+                }
+                // The null check for backward compatibility
+                if (udf.getType() != null) {
+                    qps.add(new QueryParam(UDF.TYPE, udf.getType().toString()));
+                }
                 Collection<UDF> udfs = catalogService.listUDFs(qps);
                 if (udfs.size() > 1) {
                     throw new IllegalStateException("Multiple UDF definitions for :" + udf);

--- a/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/rule/expression/Udf.java
+++ b/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/rule/expression/Udf.java
@@ -31,6 +31,11 @@ public class Udf implements Serializable {
     private Udf() {
     }
 
+    // for backward-compatibility
+    public Udf(String name) {
+        this.name = name;
+    }
+
     public Udf(String name, String className, Type type) {
         this.name = name;
         this.className = className;


### PR DESCRIPTION
The internal name for streamline provided UDF/UDAF are now appended with _FN. This is to migrate the data in the DB and support UDFs users may have saved earlier with the older name until they save it again with the new logic.

Fixes #859 