### PR TITLE
ISSUE-860 Add timeout option to topology test run

### DIFF
--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/TopologyActions.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/TopologyActions.java
@@ -22,6 +22,7 @@ import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunS
 
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Interface representing options that need to be supported on a topology
@@ -41,7 +42,7 @@ public interface TopologyActions {
     void testRun(TopologyLayout topology, String mavenArtifacts,
                  Map<String, TestRunSource> testRunSourcesForEachSource,
                  Map<String, TestRunProcessor> testRunProcessorsForEachProcessor,
-                 Map<String, TestRunSink> testRunSinksForEachSink) throws Exception;
+                 Map<String, TestRunSink> testRunSinksForEachSink, Optional<Long> durationSecs) throws Exception;
 
     //Kill the artifact that was deployed using deploy
     void kill (TopologyLayout topology, String asUser) throws Exception;

--- a/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunnerTest.java
+++ b/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunnerTest.java
@@ -53,6 +53,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.util.stream.Collectors.toMap;
 import static org.junit.Assert.assertEquals;
@@ -373,12 +374,13 @@ public class TopologyTestRunnerTest {
     private void setSucceedTopologyActionsExpectations() throws Exception {
         new Expectations() {{
             topologyActions.testRun(withInstanceOf(TopologyLayout.class), anyString, withInstanceOf(Map.class),
-                    withInstanceOf(Map.class), withInstanceOf(Map.class));
+                    withInstanceOf(Map.class), withInstanceOf(Map.class), withInstanceOf(Optional.class));
             result = new Delegate<Object>() {
                 Object delegate(TopologyLayout topology, String mavenArtifacts,
                                 Map<String, TestRunSource> testRunSourcesForEachSource,
                                 Map<String, TestRunProcessor> testRunProcessorsForEachProcessor,
-                                Map<String, TestRunSink> testRunSinksForEachSink) throws Exception {
+                                Map<String, TestRunSink> testRunSinksForEachSink,
+                                Optional<Long> durationSecs) throws Exception {
                     Map<String, List<Map<String, Object>>> testOutputRecords =
                             TopologyTestHelper.createTestOutputRecords(testRunSinksForEachSink.keySet());
 
@@ -405,7 +407,7 @@ public class TopologyTestRunnerTest {
     private void setTopologyActionsThrowingExceptionExpectations() throws Exception {
         new Expectations() {{
             topologyActions.testRun(withInstanceOf(TopologyLayout.class), anyString, withInstanceOf(Map.class),
-                    withInstanceOf(Map.class), withInstanceOf(Map.class));
+                    withInstanceOf(Map.class), withInstanceOf(Map.class), withInstanceOf(Optional.class));
             result = new RuntimeException("Topology test run failed!");
         }};
     }


### PR DESCRIPTION
* while requesting topology test run, "durationSecs" is added to config json
  * the config is optional, and default value is 30 secs (up to runner implementation)

@shahsank3t 
This needs UI change that provides feature to let users input test run duration. 
UI can include the KV of config to the JSON: key name is "durationSecs", and unit is second.
(For type of value, you can just pick the same type as what you use to provide `testCaseId`.)
If the config doesn't exist in json, it will be run with default value (same as it is).