### PR TITLE
ISSUE-856 Event logging for test runner should log output events for …

### DIFF
--- a/streams/runners/storm/common/src/main/java/com/hortonworks/streamline/streams/storm/common/StormTopologyUtil.java
+++ b/streams/runners/storm/common/src/main/java/com/hortonworks/streamline/streams/storm/common/StormTopologyUtil.java
@@ -15,6 +15,7 @@
  **/
 package com.hortonworks.streamline.streams.storm.common;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -68,5 +69,15 @@ public class StormTopologyUtil {
             actualTopologyName = generateStormTopologyName(topologyId, topologyName);
         }
         return actualTopologyName;
+    }
+
+    public static String extractStreamlineComponentName(String stormComponentId) {
+        String[] splitted = stormComponentId.split("-");
+        if (splitted.length <= 1) {
+            throw new IllegalArgumentException("Invalid Storm component ID for Streamline: " + stormComponentId);
+        }
+
+        List<String> splittedList = Arrays.asList(splitted);
+        return String.join("-", splittedList.subList(1, splittedList.size()));
     }
 }

--- a/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/TestRunProcessorBoltFluxComponent.java
+++ b/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/TestRunProcessorBoltFluxComponent.java
@@ -47,7 +47,6 @@ public class TestRunProcessorBoltFluxComponent extends AbstractFluxComponent {
         String underlyingBoltComponentId = addUnderlyingBoltComponent();
 
         List<Object> constructorArgs = new ArrayList<>();
-        constructorArgs.add(testRunProcessor.getName());
         constructorArgs.add(getRefYaml(underlyingBoltComponentId));
         constructorArgs.add(testRunProcessor.getEventLogFilePath());
         component = createComponent(boltId, boltClassName, null, constructorArgs, null);

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/EventLoggingOutputCollector.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/EventLoggingOutputCollector.java
@@ -17,6 +17,7 @@
 package com.hortonworks.streamline.streams.runtime.storm.testing;
 
 import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.utils.Utils;
 
@@ -27,12 +28,13 @@ public class EventLoggingOutputCollector extends OutputCollector {
     private final OutputCollector delegate;
     private final OutputCollectorStreamlineEventLogger outputCollectorEventLogger;
 
-    public EventLoggingOutputCollector(OutputCollector delegate, String componentName, TestRunEventLogger eventLogger) {
+    public EventLoggingOutputCollector(TopologyContext topologyContext, OutputCollector delegate,
+                                       TestRunEventLogger eventLogger) {
         // we simply ignore the _delegate in OutputCollector and override all of the methods
         // this will work with subclass of OutputCollector since we only expose methods what we know about
         super(null);
         this.delegate = delegate;
-        this.outputCollectorEventLogger = new OutputCollectorStreamlineEventLogger(eventLogger, componentName);
+        this.outputCollectorEventLogger = new OutputCollectorStreamlineEventLogger(topologyContext, eventLogger);
     }
 
     @Override
@@ -67,32 +69,32 @@ public class EventLoggingOutputCollector extends OutputCollector {
 
     @Override
     public void emitDirect(int taskId, String streamId, Tuple anchor, List<Object> tuple) {
-        outputCollectorEventLogger.emitDirectWithLoggingEvent(streamId, tuple, t -> delegate.emitDirect(taskId, streamId, anchor, t));
+        outputCollectorEventLogger.emitDirectWithLoggingEvent(taskId, streamId, tuple, t -> delegate.emitDirect(taskId, streamId, anchor, t));
     }
 
     @Override
     public void emitDirect(int taskId, String streamId, List<Object> tuple) {
-        outputCollectorEventLogger.emitDirectWithLoggingEvent(streamId, tuple, t -> delegate.emitDirect(taskId, streamId, t));
+        outputCollectorEventLogger.emitDirectWithLoggingEvent(taskId, streamId, tuple, t -> delegate.emitDirect(taskId, streamId, t));
     }
 
     @Override
     public void emitDirect(int taskId, Collection<Tuple> anchors, List<Object> tuple) {
-        outputCollectorEventLogger.emitDirectWithLoggingEvent(Utils.DEFAULT_STREAM_ID, tuple, t -> delegate.emitDirect(taskId, anchors, t));
+        outputCollectorEventLogger.emitDirectWithLoggingEvent(taskId, Utils.DEFAULT_STREAM_ID, tuple, t -> delegate.emitDirect(taskId, anchors, t));
     }
 
     @Override
     public void emitDirect(int taskId, Tuple anchor, List<Object> tuple) {
-        outputCollectorEventLogger.emitDirectWithLoggingEvent(Utils.DEFAULT_STREAM_ID, tuple, t -> delegate.emitDirect(taskId, anchor, t));
+        outputCollectorEventLogger.emitDirectWithLoggingEvent(taskId, Utils.DEFAULT_STREAM_ID, tuple, t -> delegate.emitDirect(taskId, anchor, t));
     }
 
     @Override
     public void emitDirect(int taskId, List<Object> tuple) {
-        outputCollectorEventLogger.emitDirectWithLoggingEvent(Utils.DEFAULT_STREAM_ID, tuple, t -> delegate.emitDirect(taskId, t));
+        outputCollectorEventLogger.emitDirectWithLoggingEvent(taskId, Utils.DEFAULT_STREAM_ID, tuple, t -> delegate.emitDirect(taskId, t));
     }
 
     @Override
     public void emitDirect(int taskId, String streamId, Collection<Tuple> anchors, List<Object> tuple) {
-        outputCollectorEventLogger.emitDirectWithLoggingEvent(streamId, tuple, t -> delegate.emitDirect(taskId, streamId, anchors, t));
+        outputCollectorEventLogger.emitDirectWithLoggingEvent(taskId, streamId, tuple, t -> delegate.emitDirect(taskId, streamId, anchors, t));
     }
 
     @Override

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/EventLoggingSpoutOutputCollector.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/EventLoggingSpoutOutputCollector.java
@@ -17,6 +17,7 @@
 package com.hortonworks.streamline.streams.runtime.storm.testing;
 
 import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
 import org.apache.storm.utils.Utils;
 
 import java.util.List;
@@ -25,12 +26,13 @@ public class EventLoggingSpoutOutputCollector extends SpoutOutputCollector {
     private final SpoutOutputCollector delegate;
     private final OutputCollectorStreamlineEventLogger outputCollectorEventLogger;
 
-    public EventLoggingSpoutOutputCollector(SpoutOutputCollector delegate, String componentName, TestRunEventLogger eventLogger) {
+    public EventLoggingSpoutOutputCollector(TopologyContext topologyContext, SpoutOutputCollector delegate,
+                                            TestRunEventLogger eventLogger) {
         // we simply ignore the _delegate in SpoutOutputCollector and override all of the methods
         // this will work with subclass of SpoutOutputCollector since we only expose methods what we know about
         super(null);
         this.delegate = delegate;
-        this.outputCollectorEventLogger = new OutputCollectorStreamlineEventLogger(eventLogger, componentName);
+        this.outputCollectorEventLogger = new OutputCollectorStreamlineEventLogger(topologyContext, eventLogger);
     }
 
     @Override
@@ -55,22 +57,22 @@ public class EventLoggingSpoutOutputCollector extends SpoutOutputCollector {
 
     @Override
     public void emitDirect(int taskId, String streamId, List<Object> tuple) {
-        outputCollectorEventLogger.emitDirectWithLoggingEvent(streamId, tuple, t -> delegate.emitDirect(taskId, streamId, t));
+        outputCollectorEventLogger.emitDirectWithLoggingEvent(taskId, streamId, tuple, t -> delegate.emitDirect(taskId, streamId, t));
     }
 
     @Override
     public void emitDirect(int taskId, List<Object> tuple) {
-        outputCollectorEventLogger.emitDirectWithLoggingEvent(Utils.DEFAULT_STREAM_ID, tuple, t -> delegate.emitDirect(taskId, t));
+        outputCollectorEventLogger.emitDirectWithLoggingEvent(taskId, Utils.DEFAULT_STREAM_ID, tuple, t -> delegate.emitDirect(taskId, t));
     }
 
     @Override
     public void emitDirect(int taskId, String streamId, List<Object> tuple, Object messageId) {
-        outputCollectorEventLogger.emitDirectWithLoggingEvent(streamId, tuple, t -> delegate.emitDirect(taskId, streamId, t, messageId));
+        outputCollectorEventLogger.emitDirectWithLoggingEvent(taskId, streamId, tuple, t -> delegate.emitDirect(taskId, streamId, t, messageId));
     }
 
     @Override
     public void emitDirect(int taskId, List<Object> tuple, Object messageId) {
-        outputCollectorEventLogger.emitDirectWithLoggingEvent(Utils.DEFAULT_STREAM_ID, tuple, t -> delegate.emitDirect(taskId, t, messageId));
+        outputCollectorEventLogger.emitDirectWithLoggingEvent(taskId, Utils.DEFAULT_STREAM_ID, tuple, t -> delegate.emitDirect(taskId, t, messageId));
     }
 
     @Override

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/OutputCollectorStreamlineEventLogger.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/OutputCollectorStreamlineEventLogger.java
@@ -17,33 +17,51 @@
 package com.hortonworks.streamline.streams.runtime.storm.testing;
 
 import com.hortonworks.streamline.streams.StreamlineEvent;
+import com.hortonworks.streamline.streams.storm.common.StormTopologyUtil;
+import org.apache.storm.generated.GlobalStreamId;
+import org.apache.storm.generated.Grouping;
+import org.apache.storm.task.TopologyContext;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 public class OutputCollectorStreamlineEventLogger {
+    private final TopologyContext topologyContext;
     private final TestRunEventLogger eventLogger;
     private final String componentName;
 
-    public OutputCollectorStreamlineEventLogger(TestRunEventLogger eventLogger, String componentName) {
+    public OutputCollectorStreamlineEventLogger(TopologyContext topologyContext, TestRunEventLogger eventLogger) {
+        this.topologyContext = topologyContext;
         this.eventLogger = eventLogger;
-        this.componentName = componentName;
+        this.componentName = StormTopologyUtil.extractStreamlineComponentName(topologyContext.getThisComponentId());
     }
 
     public List<Integer> emitWithLoggingEvent(String streamId, List<Object> tuple, Function<List<Object>, List<Integer>> emitFunc) {
-        List<Integer> ret = emitFunc.apply(tuple);
-        StreamlineEvent streamlineEvent = (StreamlineEvent) tuple.get(0);
-        eventLogger.writeEvent(System.currentTimeMillis(), TestRunEventLogger.EventType.OUTPUT, componentName,
-                streamId, streamlineEvent);
-        return ret;
+        List<Integer> tasks = emitFunc.apply(tuple);
+        logEvent(streamId, tasks, tuple);
+        return tasks;
     }
 
-    public void emitDirectWithLoggingEvent(String streamId, List<Object> tuple, Consumer<List<Object>> emitFunc) {
+    public void emitDirectWithLoggingEvent(int taskId, String streamId, List<Object> tuple, Consumer<List<Object>> emitFunc) {
         emitFunc.accept(tuple);
-        StreamlineEvent streamlineEvent = (StreamlineEvent) tuple.get(0);
-        eventLogger.writeEvent(System.currentTimeMillis(), TestRunEventLogger.EventType.OUTPUT, componentName,
-                streamId, streamlineEvent);
+        logEvent(streamId, Collections.singletonList(taskId), tuple);
     }
+
+    private void logEvent(String streamId, List<Integer> taskIds, List<Object> tuple) {
+        StreamlineEvent streamlineEvent = (StreamlineEvent) tuple.get(0);
+        for (int taskId : taskIds) {
+            String targetComponentId = topologyContext.getComponentId(taskId);
+            String targetStreamlineComponentName = StormTopologyUtil.extractStreamlineComponentName(targetComponentId);
+            eventLogger.writeEvent(System.currentTimeMillis(), TestRunEventLogger.EventType.OUTPUT, componentName,
+                    streamId, targetStreamlineComponentName, streamlineEvent);
+        }
+    }
+
 
 }

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunEventLogger.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunEventLogger.java
@@ -59,11 +59,12 @@ public class TestRunEventLogger {
     // Writing event to file should be mutually exclusive.
     // We don't need to worry about performance since it's just for testing topology locally.
     public synchronized void writeEvent(long timestamp, EventType eventType, String componentName,
-                                        String streamId, StreamlineEvent event) {
+                                        String streamId, String targetComponentName, StreamlineEvent event) {
         try (FileWriter fw = new FileWriter(eventLogFilePath, true)) {
             LOG.debug("writing event to file " + eventLogFilePath);
 
-            EventInformation eventInfo = new EventInformation(timestamp, eventType, componentName, streamId, event);
+            EventInformation eventInfo = new EventInformation(timestamp, eventType, componentName, streamId,
+                    targetComponentName, event);
             fw.write(objectMapper.writeValueAsString(eventInfo) + "\n");
             fw.flush();
         } catch (FileNotFoundException e) {
@@ -84,13 +85,16 @@ public class TestRunEventLogger {
         private EventType eventType;
         private String componentName;
         private String streamId;
+        private String targetComponentName;
         private StreamlineEvent streamlineEvent;
 
-        public EventInformation(long timestamp, EventType eventType, String componentName, String streamId, StreamlineEvent streamlineEvent) {
+        public EventInformation(long timestamp, EventType eventType, String componentName, String streamId,
+                                String targetComponentName, StreamlineEvent streamlineEvent) {
             this.timestamp = timestamp;
             this.eventType = eventType;
             this.componentName = componentName;
             this.streamId = streamId;
+            this.targetComponentName = targetComponentName;
             this.streamlineEvent = streamlineEvent;
         }
 
@@ -108,6 +112,10 @@ public class TestRunEventLogger {
 
         public String getStreamId() {
             return streamId;
+        }
+
+        public String getTargetComponentName() {
+            return targetComponentName;
         }
 
         public StreamlineEvent getStreamlineEvent() {

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunProcessorBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunProcessorBolt.java
@@ -25,20 +25,18 @@ import org.apache.storm.tuple.Tuple;
 import java.util.Map;
 
 public class TestRunProcessorBolt extends BaseRichBolt {
-    private final String componentName;
     private final BaseRichBolt processorBolt;
     private final String eventLogFilePath;
 
-    public TestRunProcessorBolt(String componentName, BaseRichBolt processorBolt, String eventLogFilePath) {
-        this.componentName = componentName;
+    public TestRunProcessorBolt(BaseRichBolt processorBolt, String eventLogFilePath) {
         this.processorBolt = processorBolt;
         this.eventLogFilePath = eventLogFilePath;
     }
 
     @Override
     public void prepare(Map map, TopologyContext topologyContext, OutputCollector outputCollector) {
-        EventLoggingOutputCollector collector = new EventLoggingOutputCollector(outputCollector, componentName,
-                TestRunEventLogger.getEventLogger(eventLogFilePath));
+        EventLoggingOutputCollector collector = new EventLoggingOutputCollector(topologyContext,
+                outputCollector, TestRunEventLogger.getEventLogger(eventLogFilePath));
         processorBolt.prepare(map, topologyContext, collector);
     }
 

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunSinkBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunSinkBolt.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hortonworks.streamline.common.util.Utils;
 import com.hortonworks.streamline.streams.StreamlineEvent;
 import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSink;
+import com.hortonworks.streamline.streams.storm.common.StormTopologyUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
@@ -78,11 +79,12 @@ public class TestRunSinkBolt extends BaseRichBolt {
     @Override
     public void execute(Tuple input) {
         Object value = input.getValueByField(StreamlineEvent.STREAMLINE_EVENT);
+        String sourceComponentId = input.getSourceComponent();
         String streamId = input.getSourceStreamId();
         StreamlineEvent event = (StreamlineEvent) value;
 
         eventLogger.writeEvent(System.currentTimeMillis(), TestRunEventLogger.EventType.INPUT, testRunSink.getName(),
-                streamId, event);
+                streamId, StormTopologyUtil.extractStreamlineComponentName(sourceComponentId), event);
 
         String outputFilePath = testRunSink.getOutputFilePath();
         try (FileWriter fw = new FileWriter(outputFilePath, true)) {

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunSourceSpout.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunSourceSpout.java
@@ -71,7 +71,7 @@ public class TestRunSourceSpout extends BaseRichSpout {
             throw new RuntimeException("testRunSource cannot be null");
         }
 
-        this.collector = new EventLoggingSpoutOutputCollector(collector, testRunSource.getName(),
+        this.collector = new EventLoggingSpoutOutputCollector(context, collector,
                 TestRunEventLogger.getEventLogger(testRunSource.getEventLogFilePath()));
     }
 

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunWindowProcessorBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunWindowProcessorBolt.java
@@ -25,12 +25,10 @@ import org.apache.storm.windowing.TupleWindow;
 import java.util.Map;
 
 public class TestRunWindowProcessorBolt extends BaseWindowedBolt {
-    private final String componentName;
     private final BaseWindowedBolt processorBolt;
     private final String eventLogFilePath;
 
-    public TestRunWindowProcessorBolt(String componentName, BaseWindowedBolt processorBolt, String eventLogFilePath) {
-        this.componentName = componentName;
+    public TestRunWindowProcessorBolt(BaseWindowedBolt processorBolt, String eventLogFilePath) {
         this.processorBolt = processorBolt;
         this.eventLogFilePath = eventLogFilePath;
     }
@@ -42,7 +40,7 @@ public class TestRunWindowProcessorBolt extends BaseWindowedBolt {
 
     @Override
     public void prepare(Map stormConf, TopologyContext context, OutputCollector collector) {
-        EventLoggingOutputCollector outputCollector = new EventLoggingOutputCollector(collector, componentName,
+        EventLoggingOutputCollector outputCollector = new EventLoggingOutputCollector(context, collector,
                 TestRunEventLogger.getEventLogger(eventLogFilePath));
         processorBolt.prepare(stormConf, context, outputCollector);
     }


### PR DESCRIPTION
…processor

* also include 'target component ID' after 'stream ID' to event info

Change-Id: I8b8114689fac7bc50df37acbee38b83acac45bcb

@shahsank3t 
Please test with this patch. Thanks in advance!
