### PR TITLE
ISSUE-899 Test mode: Provide an option to force stop a test run

### DIFF
--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/TopologyActions.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/TopologyActions.java
@@ -15,6 +15,7 @@
  **/
 package com.hortonworks.streamline.streams.actions;
 
+import com.hortonworks.streamline.streams.catalog.TopologyTestRunHistory;
 import com.hortonworks.streamline.streams.layout.component.TopologyLayout;
 import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunProcessor;
 import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSink;
@@ -39,10 +40,19 @@ public interface TopologyActions {
     // Compose and run parameter topology as test mode using the underlying streaming engine.
     // The parameter 'topology' should contain its own topology DAG.
     // Please refer the javadoc of TestRunSource and also TestRunSink to see which information this method requires.
-    void testRun(TopologyLayout topology, String mavenArtifacts,
+    void runTest(TopologyLayout topology, TopologyTestRunHistory testRunHistory, String mavenArtifacts,
                  Map<String, TestRunSource> testRunSourcesForEachSource,
                  Map<String, TestRunProcessor> testRunProcessorsForEachProcessor,
                  Map<String, TestRunSink> testRunSinksForEachSink, Optional<Long> durationSecs) throws Exception;
+
+    // Kill topology running as test mode if exists.
+    // Minimum requirement of this interface method is ensuring current running topology to be killed eventually.
+    // (Whether kill topology immediately or not is up to the implementation detail.)
+    // Querying TopologyTestRunHistory would still give the status of test run, including it is killed or not.
+    // The return value denotes whether killing topology is at least be triggered or not:
+    // it returns true if it succeeds to trigger, false otherwise.
+    // (topology is still not launched, process for topology test completed, etc.)
+    boolean killTest(TopologyTestRunHistory testRunHistory);
 
     //Kill the artifact that was deployed using deploy
     void kill (TopologyLayout topology, String asUser) throws Exception;

--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyActionsService.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyActionsService.java
@@ -126,6 +126,11 @@ public class TopologyActionsService implements ContainingNamespaceAwareContainer
         return topologyTestRunner.runTest(topologyActions, topology, testRunInputJson);
     }
 
+    public boolean killTestRunTopology(Topology topology, TopologyTestRunHistory history) {
+        TopologyActions topologyActions = getTopologyActionsInstance(topology);
+        return topologyTestRunner.killTest(topologyActions, history);
+    }
+
     public void killTopology(Topology topology, String asUser) throws Exception {
         getTopologyContext(topology, asUser).kill();
     }

--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunner.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunner.java
@@ -181,6 +181,10 @@ public class TopologyTestRunner {
         return history;
     }
 
+    public boolean killTest(TopologyActions topologyActions, TopologyTestRunHistory history) {
+        return topologyActions.killTest(history);
+    }
+
     private Void runTestInBackground(TopologyActions topologyActions, Topology topology,
                                      TopologyTestRunHistory history,
                                      Map<String, TestRunSource> testRunSourceMap,
@@ -193,7 +197,7 @@ public class TopologyTestRunner {
             topologyActionsService.setUpClusterArtifacts(topology, topologyActions);
             String mavenArtifacts = topologyActionsService.setUpExtraJars(topology, topologyActions);
 
-            topologyActions.testRun(topologyLayout, mavenArtifacts, testRunSourceMap, testRunProcessorMap,
+            topologyActions.runTest(topologyLayout, history, mavenArtifacts, testRunSourceMap, testRunProcessorMap,
                     testRunSinkMap, durationSecs);
 
             history.finishSuccessfully();

--- a/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunnerTest.java
+++ b/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunnerTest.java
@@ -373,10 +373,11 @@ public class TopologyTestRunnerTest {
 
     private void setSucceedTopologyActionsExpectations() throws Exception {
         new Expectations() {{
-            topologyActions.testRun(withInstanceOf(TopologyLayout.class), anyString, withInstanceOf(Map.class),
+            topologyActions.runTest(withInstanceOf(TopologyLayout.class), withInstanceOf(TopologyTestRunHistory.class),
+                    anyString, withInstanceOf(Map.class),
                     withInstanceOf(Map.class), withInstanceOf(Map.class), withInstanceOf(Optional.class));
             result = new Delegate<Object>() {
-                Object delegate(TopologyLayout topology, String mavenArtifacts,
+                Object delegate(TopologyLayout topology, TopologyTestRunHistory testRunHistory, String mavenArtifacts,
                                 Map<String, TestRunSource> testRunSourcesForEachSource,
                                 Map<String, TestRunProcessor> testRunProcessorsForEachProcessor,
                                 Map<String, TestRunSink> testRunSinksForEachSink,
@@ -406,7 +407,8 @@ public class TopologyTestRunnerTest {
 
     private void setTopologyActionsThrowingExceptionExpectations() throws Exception {
         new Expectations() {{
-            topologyActions.testRun(withInstanceOf(TopologyLayout.class), anyString, withInstanceOf(Map.class),
+            topologyActions.runTest(withInstanceOf(TopologyLayout.class), withInstanceOf(TopologyTestRunHistory.class),
+                    anyString, withInstanceOf(Map.class),
                     withInstanceOf(Map.class), withInstanceOf(Map.class), withInstanceOf(Optional.class));
             result = new RuntimeException("Topology test run failed!");
         }};

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyTestRunResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyTestRunResource.java
@@ -57,6 +57,7 @@ import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -96,6 +97,25 @@ public class TopologyTestRunResource {
         }
 
         throw EntityNotFoundException.byId(topologyId.toString());
+    }
+
+    @POST
+    @Path("/topologies/{topologyId}/actions/killtest/{historyId}")
+    @Timed
+    public Response killTestRunTopology(@Context UriInfo urlInfo,
+                                        @PathParam("topologyId") Long topologyId,
+                                        @PathParam("historyId") Long historyId) throws Exception {
+        Topology topology = catalogService.getTopology(topologyId);
+        TopologyTestRunHistory history = catalogService.getTopologyTestRunHistory(historyId);
+
+        if (topology == null) {
+            throw EntityNotFoundException.byName("Topology with ID " + topologyId.toString());
+        } else if (history == null) {
+            throw EntityNotFoundException.byName("TopologyTestRunHistory with ID " + historyId.toString());
+        }
+
+        boolean flagged = actionsService.killTestRunTopology(topology, history);
+        return WSUtils.respondEntity(Collections.singletonMap("flagged", flagged), OK);
     }
 
     @GET


### PR DESCRIPTION
* add new REST API endpoint: force stop running test
  * /topologies/{topologyId}/actions/killtest/{historyId}
  * it just turns on the flag to force stop, and return immediately
  * response with OK would be {"flagged": true/false}
    * flagged will be 'true' only when process is running now and 'false' otherwise so it doesn't indicate request has been failed
* let 'test run' handles force stop flag and destroy process if flag is turned on

This closes #899 

As I also noted to https://github.com/hortonworks/streamline/issues/899#issuecomment-327700819, please keep it mind that 'force stop' will make test run marked as 'failed'.