### PR TITLE
ISSUE-902 Add a sleep option along with repeat count

### DIFF
--- a/bootstrap/sql/mysql/v003__add_sleep_iteration_to_topology_test_run_case_source.sql
+++ b/bootstrap/sql/mysql/v003__add_sleep_iteration_to_topology_test_run_case_source.sql
@@ -1,0 +1,16 @@
+-- Copyright 2017 Hortonworks.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--    http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- ISSUE-902: Test mode: Add a sleep option along with repeat count
+ALTER TABLE `topology_test_run_case_source` ADD sleepMsPerIteration BIGINT NOT NULL DEFAULT 0;

--- a/bootstrap/sql/postgresql/v003__add_sleep_iteration_to_topology_test_run_case_source.sql
+++ b/bootstrap/sql/postgresql/v003__add_sleep_iteration_to_topology_test_run_case_source.sql
@@ -1,0 +1,16 @@
+-- Copyright 2017 Hortonworks.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--    http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- ISSUE-902: Test mode: Add a sleep option along with repeat count
+ALTER TABLE `topology_test_run_case_source` ADD COLUMN sleepMsPerIteration BIGINT NOT NULL DEFAULT 0;

--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunner.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunner.java
@@ -128,6 +128,7 @@ public class TopologyTestRunner {
 
         Map<Long, Map<String, List<Map<String, Object>>>> testRecordsForEachSources = readTestRecordsFromTestCaseSources(testRunCaseSources);
         Map<Long, Integer> occurrenceForEachSources = readOccurrenceFromTestCaseSources(testRunCaseSources);
+        Map<Long, Long> sleepMsPerRecordsForEachSources = readSleepMsPerIterationFromTestCaseSources(testRunCaseSources);
         Map<String, List<Map<String, Object>>> expectedOutputRecordsMap = readExpectedRecordsFromTestCaseSinks(sinks, testRunCaseSinks);
 
         String eventLogFilePath = getTopologyTestRunEventLog(topology);
@@ -138,6 +139,7 @@ public class TopologyTestRunner {
                             TestRunSource testRunSource = new TestRunSource(s.getOutputStreams(),
                                     testRecordsForEachSources.get(Long.valueOf(s.getId())),
                                     occurrenceForEachSources.get(Long.valueOf(s.getId())),
+                                    sleepMsPerRecordsForEachSources.get(Long.valueOf(s.getId())),
                                     eventLogFilePath);
                             testRunSource.setName(s.getName());
                             return testRunSource;
@@ -232,6 +234,11 @@ public class TopologyTestRunner {
     private Map<Long, Integer> readOccurrenceFromTestCaseSources(List<TopologyTestRunCaseSource> testRunCaseSources) {
         return testRunCaseSources.stream()
                 .collect(toMap(s -> s.getSourceId(), s -> s.getOccurrence()));
+    }
+
+    private Map<Long, Long> readSleepMsPerIterationFromTestCaseSources(List<TopologyTestRunCaseSource> testRunCaseSources) {
+        return testRunCaseSources.stream()
+                .collect(toMap(s -> s.getSourceId(), s -> s.getSleepMsPerIteration()));
     }
 
     private Map<String, List<Map<String, Object>>> readExpectedRecordsFromTestCaseSinks(List<StreamlineSink> sinks,

--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/TopologyTestRunCaseSource.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/TopologyTestRunCaseSource.java
@@ -37,6 +37,7 @@ public class TopologyTestRunCaseSource extends AbstractStorable {
     private Long versionId;
     private String records;
     private Integer occurrence;
+    private Long sleepMsPerIteration;
     private Long timestamp;
 
     public TopologyTestRunCaseSource() {
@@ -50,6 +51,7 @@ public class TopologyTestRunCaseSource extends AbstractStorable {
             setVersionId(other.getVersionId());
             setRecords(other.getRecords());
             setOccurrence(other.getOccurrence());
+            setSleepMsPerIteration(other.getSleepMsPerIteration());
             setTimestamp(other.getTimestamp());
         }
     }
@@ -137,6 +139,17 @@ public class TopologyTestRunCaseSource extends AbstractStorable {
         this.occurrence = occurrence;
     }
 
+    /**
+     * Sleep duration (milliseconds) per every iteration of records.
+     */
+    public Long getSleepMsPerIteration() {
+        return sleepMsPerIteration;
+    }
+
+    public void setSleepMsPerIteration(Long sleepMsPerIteration) {
+        this.sleepMsPerIteration = sleepMsPerIteration;
+    }
+
     public Long getTimestamp() {
         return timestamp;
     }
@@ -162,6 +175,8 @@ public class TopologyTestRunCaseSource extends AbstractStorable {
         if (getRecords() != null ? !getRecords().equals(that.getRecords()) : that.getRecords() != null) return false;
         if (getOccurrence() != null ? !getOccurrence().equals(that.getOccurrence()) : that.getOccurrence() != null)
             return false;
+        if (getSleepMsPerIteration() != null ? !getSleepMsPerIteration().equals(that.getSleepMsPerIteration()) : that.getSleepMsPerIteration() != null)
+            return false;
         return getTimestamp() != null ? getTimestamp().equals(that.getTimestamp()) : that.getTimestamp() == null;
     }
 
@@ -173,6 +188,7 @@ public class TopologyTestRunCaseSource extends AbstractStorable {
         result = 31 * result + (getVersionId() != null ? getVersionId().hashCode() : 0);
         result = 31 * result + (getRecords() != null ? getRecords().hashCode() : 0);
         result = 31 * result + (getOccurrence() != null ? getOccurrence().hashCode() : 0);
+        result = 31 * result + (getSleepMsPerIteration() != null ? getSleepMsPerIteration().hashCode() : 0);
         result = 31 * result + (getTimestamp() != null ? getTimestamp().hashCode() : 0);
         return result;
     }
@@ -186,6 +202,7 @@ public class TopologyTestRunCaseSource extends AbstractStorable {
                 ", versionId=" + versionId +
                 ", records='" + records + '\'' +
                 ", occurrence=" + occurrence +
+                ", sleepMsPerIteration=" + sleepMsPerIteration +
                 ", timestamp=" + timestamp +
                 '}';
     }

--- a/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/testing/TestRunSource.java
+++ b/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/testing/TestRunSource.java
@@ -29,26 +29,29 @@ import java.util.Set;
 public class TestRunSource extends StreamlineSource {
     private final Map<String, List<Map<String, Object>>> testRecordsForEachStream;
     private final int occurrence;
+    private final long sleepMsPerIteration;
     private final String eventLogFilePath;
 
     public TestRunSource() {
-        this(Collections.emptySet(), Collections.emptyMap(), 0, "");
+        this(Collections.emptySet(), Collections.emptyMap(), 0, 0L, "");
     }
 
     /**
      * Constructor.
      *
      * @param outputStreams output streams.
+     * @param sleepMsPerIteration sleep duration per records set. Spout will sleep given time per each iteration.
      * @param testRecordsForEachStream (output stream name) -> list of test record (each map represents a record)
      * @param occurrence
      * @param eventLogFilePath
      */
     public TestRunSource(Set<Stream> outputStreams,
                          Map<String, List<Map<String, Object>>> testRecordsForEachStream,
-                         Integer occurrence, String eventLogFilePath) {
+                         Integer occurrence, Long sleepMsPerIteration, String eventLogFilePath) {
         super(outputStreams);
         this.testRecordsForEachStream = testRecordsForEachStream;
         this.occurrence =  (occurrence != null) ? occurrence : 1;
+        this.sleepMsPerIteration =  (sleepMsPerIteration != null) ? sleepMsPerIteration : 0L;
         this.eventLogFilePath = eventLogFilePath;
     }
 
@@ -58,6 +61,10 @@ public class TestRunSource extends StreamlineSource {
 
     public int getOccurrence() {
         return occurrence;
+    }
+
+    public long getSleepMsPerIteration() {
+        return sleepMsPerIteration;
     }
 
     public String getEventLogFilePath() {
@@ -73,6 +80,7 @@ public class TestRunSource extends StreamlineSource {
         TestRunSource that = (TestRunSource) o;
 
         if (getOccurrence() != that.getOccurrence()) return false;
+        if (getSleepMsPerIteration() != that.getSleepMsPerIteration()) return false;
         if (getTestRecordsForEachStream() != null ? !getTestRecordsForEachStream().equals(that.getTestRecordsForEachStream()) : that.getTestRecordsForEachStream() != null)
             return false;
         return getEventLogFilePath() != null ? getEventLogFilePath().equals(that.getEventLogFilePath()) : that.getEventLogFilePath() == null;
@@ -83,6 +91,7 @@ public class TestRunSource extends StreamlineSource {
         int result = super.hashCode();
         result = 31 * result + (getTestRecordsForEachStream() != null ? getTestRecordsForEachStream().hashCode() : 0);
         result = 31 * result + getOccurrence();
+        result = 31 * result + (int) (getSleepMsPerIteration() ^ (getSleepMsPerIteration() >>> 32));
         result = 31 * result + (getEventLogFilePath() != null ? getEventLogFilePath().hashCode() : 0);
         return result;
     }
@@ -92,6 +101,7 @@ public class TestRunSource extends StreamlineSource {
         return "TestRunSource{" +
                 "testRecordsForEachStream=" + testRecordsForEachStream +
                 ", occurrence=" + occurrence +
+                ", sleepMsPerIteration=" + sleepMsPerIteration +
                 ", eventLogFilePath='" + eventLogFilePath + '\'' +
                 '}';
     }

--- a/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/storm/topology/TestTopologyDagCreatingVisitorTest.java
+++ b/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/storm/topology/TestTopologyDagCreatingVisitorTest.java
@@ -386,7 +386,7 @@ public class TestTopologyDagCreatingVisitorTest {
         for (Stream stream : originSource.getOutputStreams()) {
             testRecordsMap.put(stream.getId(), TopologyTestHelper.createTestRecords());
         }
-        TestRunSource testRunSource = new TestRunSource(originSource.getOutputStreams(), testRecordsMap, 1, "");
+        TestRunSource testRunSource = new TestRunSource(originSource.getOutputStreams(), testRecordsMap, 1, 0L, "");
         testRunSource.setName(originSource.getName());
         return testRunSource;
     }

--- a/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunnerTest.java
+++ b/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunnerTest.java
@@ -485,6 +485,7 @@ public class TopologyTestRunnerTest {
             throw new RuntimeException("Can't serialize test records map into JSON");
         }
         testRunSource.setOccurrence(1);
+        testRunSource.setSleepMsPerIteration(0L);
 
         testRunSource.setTimestamp(System.currentTimeMillis());
 

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRecordsInformation.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRecordsInformation.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.streamline.streams.runtime.storm.testing;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class TestRecordsInformation implements Serializable {
+    private static final Logger LOG = LoggerFactory.getLogger(TestRecordsInformation.class);
+
+    private final int occurrence;
+    private final long sleepPerIteration;
+    private final List<Map<String, Object>> testRecords;
+
+    private transient Iterator<Map<String, Object>> currentIterator;
+
+    private int finishedIteration = 0;
+    private long sleepUntil = -1L;
+    private boolean inSleep = false;
+
+    public TestRecordsInformation(int occurrence, long sleepPerIteration, List<Map<String, Object>> testRecords) {
+        this.occurrence = occurrence;
+        this.sleepPerIteration = sleepPerIteration;
+        this.testRecords = testRecords;
+    }
+
+    public boolean isCompleted() {
+        return currentIterator != null && !currentIterator.hasNext() && (finishedIteration >= occurrence);
+    }
+
+    public boolean needToSleep() {
+        long current = System.currentTimeMillis();
+        LOG.debug("sleep until {} / current time {}", sleepUntil, current);
+        return sleepUntil > current;
+    }
+
+    public Optional<Map<String, Object>> nextRecord() {
+        if (currentIterator == null) {
+            startNewIteration();
+        }
+
+        if (isCompleted() || needToSleep()) {
+            return Optional.empty();
+        }
+
+        if (inSleep) {
+            startNewIteration();
+        }
+
+        // there're remaining records in current iterator
+        if (currentIterator.hasNext()) {
+            return Optional.of(currentIterator.next());
+        } else {
+            finalizeCurrentIteration();
+            return nextRecord();
+        }
+    }
+
+    private void startNewIteration() {
+        sleepUntil = -1L;
+        inSleep = false;
+        currentIterator = testRecords.iterator();
+    }
+
+    private void finalizeCurrentIteration() {
+        sleepUntil = System.currentTimeMillis() + sleepPerIteration;
+        inSleep = true;
+        finishedIteration++;
+    }
+}

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRecordsInformationTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRecordsInformationTest.java
@@ -1,0 +1,162 @@
+package com.hortonworks.streamline.streams.runtime.storm.testing;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+public class TestRecordsInformationTest {
+
+    @Test
+    public void testIterateRecordsWithSleepPerIteration() {
+        List<Map<String, Object>> records = new ArrayList<>();
+        records.add(Collections.singletonMap("A", 1));
+        records.add(Collections.singletonMap("A", 2));
+        records.add(Collections.singletonMap("A", 3));
+
+        TestRecordsInformation testRecordsInformation = new TestRecordsInformation(3, 1000, records);
+
+        // first iteration
+        Optional<Map<String, Object>> recordOptional = testRecordsInformation.nextRecord();
+        assertTrue(recordOptional.isPresent());
+        assertEquals(records.get(0), recordOptional.get());
+
+        recordOptional = testRecordsInformation.nextRecord();
+        assertTrue(recordOptional.isPresent());
+        assertEquals(records.get(1), recordOptional.get());
+
+        recordOptional = testRecordsInformation.nextRecord();
+        assertTrue(recordOptional.isPresent());
+        assertEquals(records.get(2), recordOptional.get());
+
+        // end of first iteration
+        recordOptional = testRecordsInformation.nextRecord();
+        assertFalse(recordOptional.isPresent());
+
+        // sleep 300 ms
+        Uninterruptibles.sleepUninterruptibly(300, TimeUnit.MILLISECONDS);
+
+        // still in sleep
+        recordOptional = testRecordsInformation.nextRecord();
+        assertFalse(recordOptional.isPresent());
+
+        // sleep 700 ms (total 1000 ms)
+        Uninterruptibles.sleepUninterruptibly(700, TimeUnit.MILLISECONDS);
+
+        // second iteration
+        recordOptional = testRecordsInformation.nextRecord();
+        assertTrue(recordOptional.isPresent());
+        assertEquals(records.get(0), recordOptional.get());
+
+        recordOptional = testRecordsInformation.nextRecord();
+        assertTrue(recordOptional.isPresent());
+        assertEquals(records.get(1), recordOptional.get());
+
+        recordOptional = testRecordsInformation.nextRecord();
+        assertTrue(recordOptional.isPresent());
+        assertEquals(records.get(2), recordOptional.get());
+
+        // end of second iteration
+        recordOptional = testRecordsInformation.nextRecord();
+        assertFalse(recordOptional.isPresent());
+
+        // sleep 1000 ms
+        Uninterruptibles.sleepUninterruptibly(1000, TimeUnit.MILLISECONDS);
+
+        // third iteration
+        recordOptional = testRecordsInformation.nextRecord();
+        assertTrue(recordOptional.isPresent());
+        assertEquals(records.get(0), recordOptional.get());
+
+        recordOptional = testRecordsInformation.nextRecord();
+        assertTrue(recordOptional.isPresent());
+        assertEquals(records.get(1), recordOptional.get());
+
+        recordOptional = testRecordsInformation.nextRecord();
+        assertTrue(recordOptional.isPresent());
+        assertEquals(records.get(2), recordOptional.get());
+
+        // end of third iteration (whole iteration)
+        recordOptional = testRecordsInformation.nextRecord();
+        assertFalse(recordOptional.isPresent());
+
+         // sleep 1000 ms
+        Uninterruptibles.sleepUninterruptibly(1000, TimeUnit.MILLISECONDS);
+
+        // whole iterations are completed
+        recordOptional = testRecordsInformation.nextRecord();
+        assertFalse(recordOptional.isPresent());
+
+    }
+
+    @Test
+    public void testIterateRecordsWithoutSleep() {
+        List<Map<String, Object>> records = new ArrayList<>();
+        records.add(Collections.singletonMap("A", 1));
+        records.add(Collections.singletonMap("A", 2));
+        records.add(Collections.singletonMap("A", 3));
+
+        TestRecordsInformation testRecordsInformation = new TestRecordsInformation(3, 0, records);
+
+        // first iteration
+        Optional<Map<String, Object>> recordOptional = testRecordsInformation.nextRecord();
+        assertTrue(recordOptional.isPresent());
+        assertEquals(records.get(0), recordOptional.get());
+
+        recordOptional = testRecordsInformation.nextRecord();
+        assertTrue(recordOptional.isPresent());
+        assertEquals(records.get(1), recordOptional.get());
+
+        recordOptional = testRecordsInformation.nextRecord();
+        assertTrue(recordOptional.isPresent());
+        assertEquals(records.get(2), recordOptional.get());
+
+        // next iteration will be started immediately
+        // second iteration
+        recordOptional = testRecordsInformation.nextRecord();
+        assertTrue(recordOptional.isPresent());
+        assertEquals(records.get(0), recordOptional.get());
+
+        recordOptional = testRecordsInformation.nextRecord();
+        assertTrue(recordOptional.isPresent());
+        assertEquals(records.get(1), recordOptional.get());
+
+        recordOptional = testRecordsInformation.nextRecord();
+        assertTrue(recordOptional.isPresent());
+        assertEquals(records.get(2), recordOptional.get());
+
+        // next iteration will be started immediately
+        // third iteration
+        recordOptional = testRecordsInformation.nextRecord();
+        assertTrue(recordOptional.isPresent());
+        assertEquals(records.get(0), recordOptional.get());
+
+        recordOptional = testRecordsInformation.nextRecord();
+        assertTrue(recordOptional.isPresent());
+        assertEquals(records.get(1), recordOptional.get());
+
+        recordOptional = testRecordsInformation.nextRecord();
+        assertTrue(recordOptional.isPresent());
+        assertEquals(records.get(2), recordOptional.get());
+
+        // end of third iteration (whole iteration)
+        recordOptional = testRecordsInformation.nextRecord();
+        assertFalse(recordOptional.isPresent());
+
+         // sleep 1000 ms
+        Uninterruptibles.sleepUninterruptibly(1000, TimeUnit.MILLISECONDS);
+
+        // whole iterations are completed
+        recordOptional = testRecordsInformation.nextRecord();
+        assertFalse(recordOptional.isPresent());
+
+    }
+
+}


### PR DESCRIPTION
* add option regarding sleep per iteration in TopologyTestRunCaseSource
* apply TestRunSourceSpout to respect sleep per each output stream
* add SQL script to apply the change of table

@shahsank3t 
The change is introduced into TopologyTestRunCaseSource. UI just needs to add `sleepMsPerIteration` when requesting to add/update TopologyTestRunCaseSource. Unit is millisecond.
No new API endpoint, and default value is 0L.

@arunmahadevan Please take a look and comment. Thanks in advance.