### PR TITLE
ISSUE-901 Test mode: Create event file prior to launch actual test process

### DIFF
--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunner.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunner.java
@@ -169,6 +169,9 @@ public class TopologyTestRunner {
                     }
                 }));
 
+        // just create event file before running actual test run process
+        createEventLogFile(eventLogFilePath);
+
         TopologyTestRunHistory history = initializeTopologyTestRunHistory(topology, testCase,
                 expectedOutputRecordsMap, eventLogFilePath);
         catalogService.addTopologyTestRunHistory(history);
@@ -179,6 +182,21 @@ public class TopologyTestRunner {
                 finalDurationSecs), forkJoinPool);
 
         return history;
+    }
+
+    private void createEventLogFile(String eventLogFilePath) throws IOException {
+        File eventLogFile = new File(eventLogFilePath);
+        File parent = eventLogFile.getParentFile();
+
+        if (!parent.exists() && !parent.mkdirs()) {
+            throw new IllegalStateException("Cannot create directory for storing test run event. Path: " +
+                    parent.getCanonicalPath());
+        }
+
+        if (!eventLogFile.exists() && !eventLogFile.createNewFile()) {
+            throw new IllegalStateException("Cannot create event log file for storing test run event. Path: " +
+                    eventLogFile.getCanonicalPath());
+        }
     }
 
     private Void runTestInBackground(TopologyActions topologyActions, Topology topology,


### PR DESCRIPTION
* this change ensures that empty event will be available immediately when UI gets response

This closes #901.

Please refer my comment on #901. Although this doesn't go with suggested way in #901, I guess this patch resolves the origin issue simpler.

@shahsank3t UI can call /events immediately after receiving response of request for test run. It would be empty event indeed.

@arunmahadevan @shahsank3t Please review and comment. Thanks in advance!