### PR TITLE
ISSUE-907 Test Mode: Deleting a topology source node after a test sou…

### DIFF
--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/service/StreamCatalogService.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/service/StreamCatalogService.java
@@ -424,12 +424,12 @@ public class StreamCatalogService {
 
             // remove topology test run case source
             for (TopologyTestRunCaseSource runCaseSource : runCaseSources) {
-                removeTestRunCaseSource(runCaseSource.getId());
+                removeTopologyTestRunCaseSource(runCaseSource.getId());
             }
 
             // remove topology test run case sink
             for (TopologyTestRunCaseSink runCaseSink : runCaseSinks) {
-                removeTestRunCaseSink(runCaseSink.getId());
+                removeTopologyTestRunCaseSink(runCaseSink.getId());
             }
 
             removeTestRunCase(topologyId, runCase.getId());
@@ -1355,6 +1355,7 @@ public class StreamCatalogService {
                 removeAllEdges(topologySource);
             }
             removeSourceStreamMapping(topologySource);
+            removeAllTopologyTestSources(topologySource);
             topologySource = dao.<TopologySource>remove(new StorableKey(TOPOLOGY_SOURCE_NAMESPACE, topologySource.getPrimaryKey()));
             topologySource.setVersionTimestamp(updateVersionTimestamp(versionId).getTimestamp());
         }
@@ -1376,6 +1377,14 @@ public class StreamCatalogService {
         } catch (Exception ex) {
             LOG.error("Got exception while removing edge", ex);
             throw new RuntimeException(ex);
+        }
+    }
+
+    private void removeAllTopologyTestSources(TopologySource topologySource) {
+        QueryParam sourceIdQuery = new QueryParam("sourceId", String.valueOf(topologySource.getId()));
+        Collection<TopologyTestRunCaseSource> sources = listTopologyTestRunCaseSource(Collections.singletonList(sourceIdQuery));
+        if (sources != null) {
+            sources.forEach(s -> removeTopologyTestRunCaseSource(s.getId()));
         }
     }
 
@@ -1567,12 +1576,6 @@ public class StreamCatalogService {
         return topologySink;
     }
 
-    public TopologySink removeTopologySink(Long id) {
-        TopologySink topologySink = new TopologySink();
-        topologySink.setId(id);
-        return dao.remove(new StorableKey(TOPOLOGY_SINK_NAMESPACE, topologySink.getPrimaryKey()));
-    }
-
     public TopologySink removeTopologySink(Long topologyId, Long sinkId, boolean removeEdges) {
         return removeTopologySink(topologyId, sinkId, getCurrentVersionId(topologyId), removeEdges);
     }
@@ -1583,10 +1586,19 @@ public class StreamCatalogService {
             if (removeEdges) {
                 removeAllEdges(topologySink);
             }
+            removeAllTopologyTestSinks(topologySink);
             topologySink = dao.<TopologySink>remove(new StorableKey(TOPOLOGY_SINK_NAMESPACE, topologySink.getPrimaryKey()));
             topologySink.setVersionTimestamp(updateVersionTimestamp(versionId).getTimestamp());
         }
         return topologySink;
+    }
+
+    private void removeAllTopologyTestSinks(TopologySink topologySink) {
+        QueryParam sinkIdQuery = new QueryParam("sinkId", String.valueOf(topologySink.getId()));
+        Collection<TopologyTestRunCaseSink> sinks = listTopologyTestRunCaseSink(Collections.singletonList(sinkIdQuery));
+        if (sinks != null) {
+            sinks.forEach(s -> removeTopologyTestRunCaseSink(s.getId()));
+        }
     }
 
     public Collection<TopologySink> listTopologySinks() {
@@ -2647,7 +2659,7 @@ public class StreamCatalogService {
         return testCaseSource;
     }
 
-    public TopologyTestRunCaseSource removeTestRunCaseSourceBySourceId(Long testcaseId, Long sourceId) {
+    public TopologyTestRunCaseSource removeTopologyTestRunCaseSourceBySourceId(Long testcaseId, Long sourceId) {
         TopologyTestRunCaseSource testcase = getTopologyTestRunCaseSourceBySourceId(testcaseId, sourceId);
         if (testcase != null) {
             testcase = dao.remove(testcase.getStorableKey());
@@ -2656,7 +2668,7 @@ public class StreamCatalogService {
         return testcase;
     }
 
-    public TopologyTestRunCaseSource removeTestRunCaseSource(Long id) {
+    public TopologyTestRunCaseSource removeTopologyTestRunCaseSource(Long id) {
         TopologyTestRunCaseSource testcaseSource = new TopologyTestRunCaseSource();
         testcaseSource.setId(id);
 
@@ -2731,7 +2743,7 @@ public class StreamCatalogService {
         return testCaseSink;
     }
 
-    public TopologyTestRunCaseSink removeTestRunCaseSinkBySinkId(Long testcaseId, Long sinkId) {
+    public TopologyTestRunCaseSink removeTopologyTestRunCaseSinkBySinkId(Long testcaseId, Long sinkId) {
         TopologyTestRunCaseSink testcase = getTopologyTestRunCaseSinkBySinkId(testcaseId, sinkId);
         if (testcase != null) {
             testcase = dao.remove(testcase.getStorableKey());
@@ -2740,7 +2752,7 @@ public class StreamCatalogService {
         return testcase;
     }
 
-    public TopologyTestRunCaseSink removeTestRunCaseSink(Long id) {
+    public TopologyTestRunCaseSink removeTopologyTestRunCaseSink(Long id) {
         TopologyTestRunCaseSink testcaseSink = new TopologyTestRunCaseSink();
         testcaseSink.setId(id);
 

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyTestRunResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyTestRunResource.java
@@ -346,12 +346,12 @@ public class TopologyTestRunResource {
 
         Collection<TopologyTestRunCaseSource> sources = catalogService.listTopologyTestRunCaseSource(testCaseId);
         if (sources != null) {
-            sources.forEach(s -> catalogService.removeTestRunCaseSource(s.getId()));
+            sources.forEach(s -> catalogService.removeTopologyTestRunCaseSource(s.getId()));
         }
 
         Collection<TopologyTestRunCaseSink> sinks = catalogService.listTopologyTestRunCaseSink(testCaseId);
         if (sinks != null) {
-            sinks.forEach(s -> catalogService.removeTestRunCaseSink(s.getId()));
+            sinks.forEach(s -> catalogService.removeTopologyTestRunCaseSink(s.getId()));
         }
 
         TopologyTestRunCase testRunCase = catalogService.removeTestRunCase(topologyId, testCaseId);


### PR DESCRIPTION
…rce node is configured throws exception

* remove associated test source before removing topology source
* remove associated test sink before removing topology sink

This closes #907 

@shahsank3t Could you verify the patch to see it resolves #907?

@arunmahadevan Please review and comment. Thanks in advance!