### PR TITLE
ISSUE-917 Test mode: Validate test case data on clicking OK

### DIFF
--- a/common/src/main/java/com/hortonworks/streamline/common/SchemaValueConverter.java
+++ b/common/src/main/java/com/hortonworks/streamline/common/SchemaValueConverter.java
@@ -17,6 +17,7 @@
 package com.hortonworks.streamline.common;
 
 import com.hortonworks.registries.common.Schema;
+import com.hortonworks.streamline.common.exception.SchemaValidationFailedException;
 
 import java.util.List;
 import java.util.Map;
@@ -61,12 +62,12 @@ public final class SchemaValueConverter {
                 .filter(f -> !(value.containsKey(f.getName()))).collect(toList());
 
         if (!fieldsNotFoundInSchema.isEmpty()) {
-            throw new IllegalArgumentException("The value has fields which are not defined in schema: "
-                    + fieldsNotFoundInSchema);
+            throw SchemaValidationFailedException.fieldsNotFoundInSchema(fieldsNotFoundInSchema);
         }
 
         if (!requiredFieldsNotFoundInValue.isEmpty()) {
-            throw new IllegalArgumentException("The value doesn't have required fields: " + requiredFieldsNotFoundInValue);
+            throw SchemaValidationFailedException.requiredFieldsNotFoundInValue(
+                    requiredFieldsNotFoundInValue.stream().map(Schema.Field::getName).collect(toList()));
         }
 
         return value.entrySet().stream()

--- a/common/src/main/java/com/hortonworks/streamline/common/exception/SchemaValidationFailedException.java
+++ b/common/src/main/java/com/hortonworks/streamline/common/exception/SchemaValidationFailedException.java
@@ -1,0 +1,17 @@
+package com.hortonworks.streamline.common.exception;
+
+import java.util.List;
+
+public class SchemaValidationFailedException extends RuntimeException {
+    private SchemaValidationFailedException(String message) {
+        super(message);
+    }
+
+    public static SchemaValidationFailedException fieldsNotFoundInSchema(List<String> fields) {
+        return new SchemaValidationFailedException("The value has fields which are not defined in schema: " + fields);
+    }
+
+    public static SchemaValidationFailedException requiredFieldsNotFoundInValue(List<String> fields) {
+        return new SchemaValidationFailedException("The value doesn't have required fields: " + fields);
+    }
+}

--- a/common/src/test/java/com/hortonworks/streamline/common/SchemaValueConverterTest.java
+++ b/common/src/test/java/com/hortonworks/streamline/common/SchemaValueConverterTest.java
@@ -2,6 +2,7 @@ package com.hortonworks.streamline.common;
 
 import com.hortonworks.registries.common.Schema;
 import com.hortonworks.registries.common.exception.ParserException;
+import com.hortonworks.streamline.common.exception.SchemaValidationFailedException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -69,7 +70,7 @@ public class SchemaValueConverterTest {
 
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = SchemaValidationFailedException.class)
     public void convertMapValueDoesNotHaveRequiredField() {
         Schema schema = Schema.of(
                 Schema.Field.of("a", Schema.Type.BINARY),
@@ -83,7 +84,7 @@ public class SchemaValueConverterTest {
         SchemaValueConverter.convertMap(schema, value);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = SchemaValidationFailedException.class)
     public void convertMapValueHasUndefinedField() {
         Schema schema = Schema.of(
                 Schema.Field.of("a", Schema.Type.BINARY),

--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyActionsService.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyActionsService.java
@@ -26,6 +26,7 @@ import com.hortonworks.streamline.streams.actions.topology.state.TopologyState;
 import com.hortonworks.streamline.streams.actions.topology.state.TopologyStateFactory;
 import com.hortonworks.streamline.streams.actions.topology.state.TopologyStates;
 import com.hortonworks.streamline.streams.catalog.CatalogToLayoutConverter;
+import com.hortonworks.streamline.streams.catalog.TopologyTestRunCase;
 import com.hortonworks.streamline.streams.cluster.catalog.Namespace;
 import com.hortonworks.streamline.streams.cluster.catalog.NamespaceServiceClusterMapping;
 import com.hortonworks.streamline.streams.cluster.catalog.Service;
@@ -117,13 +118,13 @@ public class TopologyActionsService implements ContainingNamespaceAwareContainer
         return null;
     }
 
-    public TopologyTestRunHistory testRunTopology(Topology topology, String testRunInputJson) throws Exception {
+    public TopologyTestRunHistory testRunTopology(Topology topology, TopologyTestRunCase testCase, Long durationSecs) throws Exception {
         TopologyDag dag = topologyDagBuilder.getDag(topology);
         topology.setTopologyDag(dag);
         ensureValid(dag);
         TopologyActions topologyActions = getTopologyActionsInstance(topology);
         LOG.debug("Running topology {} in test mode", topology);
-        return topologyTestRunner.runTest(topologyActions, topology, testRunInputJson);
+        return topologyTestRunner.runTest(topologyActions, topology, testCase, durationSecs);
     }
 
     public boolean killTestRunTopology(Topology topology, TopologyTestRunHistory history) {

--- a/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunnerTest.java
+++ b/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunnerTest.java
@@ -100,9 +100,6 @@ public class TopologyTestRunnerTest {
 
         Long topologyId = topology.getId();
         Long testCaseId = 1L;
-        Map<String, Object> testRunInputMap = new HashMap<>();
-        testRunInputMap.put("testCaseId", testCaseId);
-
         TopologyTestRunCase testCase = new TopologyTestRunCase();
         testCase.setId(testCaseId);
         testCase.setTopologyId(topology.getId());
@@ -124,7 +121,7 @@ public class TopologyTestRunnerTest {
                 .count();
 
         TopologyTestRunHistory resultHistory = topologyTestRunner.runTest(topologyActions, topology,
-                objectMapper.writeValueAsString(testRunInputMap));
+                testCase, null);
 
         waitForTopologyTestRunToFinish(resultHistory);
 
@@ -133,9 +130,6 @@ public class TopologyTestRunnerTest {
         assertTrue(resultHistory.getSuccess());
 
         new VerificationsInOrder() {{
-            catalogService.getTopologyTestRunCase(topologyId, testCaseId);
-            times = 1;
-
             catalogService.getTopologyTestRunCaseSourceBySourceId(testCaseId, anyLong);
             times = (int) sourceCount;
 
@@ -162,33 +156,12 @@ public class TopologyTestRunnerTest {
         }};
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void runTest_withNotExistingTestCaseId() throws Exception {
-        Topology topology = createSimpleDAGInjectedTestTopology();
-
-        Long topologyId = topology.getId();
-        Long testCaseId = 1L;
-        Map<String, Object> testRunInputMap = new HashMap<>();
-        testRunInputMap.put("testCaseId", testCaseId);
-
-        new Expectations() {{
-            catalogService.getTopologyTestRunCase(topologyId, testCaseId);
-            result = null;
-        }};
-
-        topologyTestRunner.runTest(topologyActions, topology,
-                objectMapper.writeValueAsString(testRunInputMap));
-    }
-
     @Test
     public void runTest_topologyActionsTestRunFails() throws Exception {
         Topology topology = createSimpleDAGInjectedTestTopology();
 
         Long topologyId = topology.getId();
         Long testCaseId = 1L;
-        Map<String, Object> testRunInputMap = new HashMap<>();
-        testRunInputMap.put("testCaseId", testCaseId);
-
         TopologyTestRunCase testCase = new TopologyTestRunCase();
         testCase.setId(testCaseId);
         testCase.setTopologyId(topology.getId());
@@ -210,16 +183,13 @@ public class TopologyTestRunnerTest {
                 .count();
 
         TopologyTestRunHistory resultHistory = topologyTestRunner.runTest(topologyActions, topology,
-                objectMapper.writeValueAsString(testRunInputMap));
+                testCase, null);
 
         assertNotNull(resultHistory);
 
         waitForTopologyTestRunToFinish(resultHistory);
 
         new VerificationsInOrder() {{
-            catalogService.getTopologyTestRunCase(topologyId, testCaseId);
-            times = 1;
-
             catalogService.getTopologyTestRunCaseSourceBySourceId(testCaseId, anyLong);
             times = (int) sourceCount;
 
@@ -251,9 +221,6 @@ public class TopologyTestRunnerTest {
         Topology topology = createSimpleDAGInjectedTestTopology();
 
         Long testCaseId = 1L;
-        Map<String, Object> testRunInputMap = new HashMap<>();
-        testRunInputMap.put("testCaseId", testCaseId);
-
         TopologyTestRunCase testCase = new TopologyTestRunCase();
         testCase.setId(testCaseId);
         testCase.setTopologyId(topology.getId());
@@ -266,8 +233,7 @@ public class TopologyTestRunnerTest {
         setTopologyTestRunHistoryExpectations();
         setSucceedTopologyActionsExpectations();
 
-        TopologyTestRunHistory resultHistory = topologyTestRunner.runTest(topologyActions, topology,
-                objectMapper.writeValueAsString(testRunInputMap));
+        TopologyTestRunHistory resultHistory = topologyTestRunner.runTest(topologyActions, topology, testCase, null);
 
         assertNotNull(resultHistory);
 
@@ -299,9 +265,6 @@ public class TopologyTestRunnerTest {
         Topology topology = createSimpleDAGInjectedTestTopology();
 
         Long testCaseId = 1L;
-        Map<String, Object> testRunInputMap = new HashMap<>();
-        testRunInputMap.put("testCaseId", testCaseId);
-
         TopologyTestRunCase testCase = new TopologyTestRunCase();
         testCase.setId(testCaseId);
         testCase.setTopologyId(topology.getId());
@@ -314,8 +277,7 @@ public class TopologyTestRunnerTest {
         setTopologyTestRunHistoryExpectations();
         setSucceedTopologyActionsExpectations();
 
-        TopologyTestRunHistory resultHistory = topologyTestRunner.runTest(topologyActions, topology,
-                objectMapper.writeValueAsString(testRunInputMap));
+        TopologyTestRunHistory resultHistory = topologyTestRunner.runTest(topologyActions, topology, testCase, null);
 
         assertNotNull(resultHistory);
 
@@ -426,9 +388,6 @@ public class TopologyTestRunnerTest {
 
     private void setTopologyTestRunCaseExpectations(Topology topology, TopologyTestRunCase testCase) {
         new Expectations() {{
-            catalogService.getTopologyTestRunCase(topology.getId(), testCase.getId());
-            result = testCase;
-
             topology.getTopologyDag().getOutputComponents().stream()
                     .filter(c -> c instanceof StreamlineSource)
                     .forEach(source -> {


### PR DESCRIPTION
* address backend support: introduce new API endpoint for validating topology test case source
  * /api/v1/catalog/topologies/{topologyId}/testcases/{testCaseId}/sources/validate
    * for verifying data before requesting to add test case source
    * same payload as endpoint for adding test case source
  * /topologies/{topologyId}/testcases/{testCaseId}/sources/validate
    * for verifying data before requesting topology test run
    * ideal to request for all topology test case sources

@shahsank3t 
I added description for new API endpoint. It responds with HTTP status 200 when verification passes, and 400 when verification fails.
Please let me know if you have any questions regarding new endpoint.
Two new API endpoints are having different usages. For latter thing backend may be able to just retrieve all test sources and verify just before running test. Please let me know if you think this approach is better than let UI requests for that.

I'll not set auto close to #917 since UI work is necessary.

@arunmahadevan @shahsank3t Please have a look and comment. Thanks in advance.