### PR TITLE
ISSUE-933: SAM Processors/Sinks/Rules need to update when its upstream components are updated

### DIFF
--- a/bootstrap/sql/mysql/v005__add_reconfigure_flag.sql
+++ b/bootstrap/sql/mysql/v005__add_reconfigure_flag.sql
@@ -1,0 +1,22 @@
+-- Copyright 2017 Hortonworks.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--    http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Add reconfigure flag to components
+ALTER TABLE `topology_source` ADD reconfigure BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE `topology_processor` ADD reconfigure BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE `topology_sink` ADD reconfigure BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE `topology_rule` ADD reconfigure BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE `topology_branchrule` ADD reconfigure BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE `topology_window` ADD reconfigure BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE `topology_component` ADD reconfigure BOOLEAN NOT NULL DEFAULT false;

--- a/bootstrap/sql/postgresql/v005_add_reconfigure_flag.sql
+++ b/bootstrap/sql/postgresql/v005_add_reconfigure_flag.sql
@@ -1,0 +1,22 @@
+-- Copyright 2017 Hortonworks.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--    http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Add reconfigure flag to components
+ALTER TABLE "topology_source" ADD COLUMN "reconfigure" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "topology_processor" ADD COLUMN "reconfigure" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "topology_sink" ADD COLUMN "reconfigure" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "topology_rule" ADD COLUMN "reconfigure" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "topology_branchrule" ADD COLUMN "reconfigure" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "topology_window" ADD COLUMN "reconfigure" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "topology_component" ADD COLUMN "reconfigure" BOOLEAN NOT NULL DEFAULT false;

--- a/common/src/main/java/com/hortonworks/streamline/common/ComponentTypes.java
+++ b/common/src/main/java/com/hortonworks/streamline/common/ComponentTypes.java
@@ -20,6 +20,11 @@ package com.hortonworks.streamline.common;
  */
 public class ComponentTypes {
 
+    // generic types SOURCE, PROCESSOR and SINK
+    public static final String SOURCE = "SOURCE";
+    public static final String PROCESSOR = "PROCESSOR";
+    public static final String SINK = "SINK";
+
     public static final String KAFKA = "KAFKA";
     public static final String KINESIS = "KINESIS";
     public static final String EVENTHUB = "EVENTHUB";

--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/BaseTopologyRule.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/BaseTopologyRule.java
@@ -17,12 +17,23 @@ package com.hortonworks.streamline.streams.catalog;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hortonworks.registries.common.Schema;
+import com.hortonworks.streamline.storage.Storable;
 import com.hortonworks.streamline.storage.catalog.AbstractStorable;
 import com.hortonworks.streamline.streams.layout.component.rule.Rule;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public abstract class BaseTopologyRule extends AbstractStorable {
+    public static final String RECONFIGURE = "reconfigure";
+
+    // if the upstream changed, the component may need reconfiguration
+    private Boolean reconfigure = false;
+
+
     @JsonIgnore
     protected abstract String getParsedRuleStr();
 
@@ -35,4 +46,27 @@ public abstract class BaseTopologyRule extends AbstractStorable {
         }
         return rule;
     }
+
+    @Override
+    public Storable fromMap(Map<String, Object> map) {
+        setReconfigure((Boolean) map.get(RECONFIGURE));
+        return this;
+    }
+
+    @JsonIgnore
+    @Override
+    public Schema getSchema() {
+        return Schema.of(Schema.Field.of(RECONFIGURE, Schema.Type.BOOLEAN));
+    }
+
+    public Boolean getReconfigure() {
+        return reconfigure;
+    }
+
+    public void setReconfigure(Boolean reconfigure) {
+        this.reconfigure = reconfigure;
+    }
+
+    @JsonIgnore
+    public abstract Set<String> getInputStreams();
 }

--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/TopologyBranchRule.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/TopologyBranchRule.java
@@ -20,19 +20,20 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import com.hortonworks.streamline.storage.annotation.StorableEntity;
-import org.apache.commons.lang3.StringUtils;
 import com.hortonworks.registries.common.Schema;
 import com.hortonworks.streamline.storage.PrimaryKey;
 import com.hortonworks.streamline.storage.Storable;
+import com.hortonworks.streamline.storage.annotation.StorableEntity;
 import com.hortonworks.streamline.streams.layout.component.rule.action.Action;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -212,18 +213,20 @@ public class TopologyBranchRule extends BaseTopologyRule {
     @JsonIgnore
     @Override
     public Schema getSchema() {
-        return Schema.of(
-                Schema.Field.of(ID, Schema.Type.LONG),
-                Schema.Field.of(VERSION_ID, Schema.Type.LONG),
-                Schema.Field.of(TOPOLOGY_ID, Schema.Type.LONG),
-                Schema.Field.of(NAME, Schema.Type.STRING),
-                Schema.Field.of(DESCRIPTION, Schema.Type.STRING),
-                Schema.Field.of(STREAM, Schema.Type.STRING),
-                Schema.Field.of(OUTPUT_STREAMS, Schema.Type.STRING),
-                Schema.Field.of(CONDITION, Schema.Type.STRING),
-                Schema.Field.of(PARSED_RULE_STR, Schema.Type.STRING),
-                Schema.Field.of(ACTIONS, Schema.Type.STRING)
-        );
+        return Schema.unionOf(
+                super.getSchema(),
+                Schema.of(
+                        Schema.Field.of(ID, Schema.Type.LONG),
+                        Schema.Field.of(VERSION_ID, Schema.Type.LONG),
+                        Schema.Field.of(TOPOLOGY_ID, Schema.Type.LONG),
+                        Schema.Field.of(NAME, Schema.Type.STRING),
+                        Schema.Field.of(DESCRIPTION, Schema.Type.STRING),
+                        Schema.Field.of(STREAM, Schema.Type.STRING),
+                        Schema.Field.of(OUTPUT_STREAMS, Schema.Type.STRING),
+                        Schema.Field.of(CONDITION, Schema.Type.STRING),
+                        Schema.Field.of(PARSED_RULE_STR, Schema.Type.STRING),
+                        Schema.Field.of(ACTIONS, Schema.Type.STRING)
+                ));
     }
 
     @Override
@@ -242,6 +245,7 @@ public class TopologyBranchRule extends BaseTopologyRule {
 
     @Override
     public Storable fromMap(Map<String, Object> map) {
+        super.fromMap(map);
         setId((Long) map.get(ID));
         setVersionId((Long) map.get(VERSION_ID));
         setTopologyId((Long) map.get(TOPOLOGY_ID));
@@ -268,6 +272,11 @@ public class TopologyBranchRule extends BaseTopologyRule {
             throw new RuntimeException(e);
         }
         return this;
+    }
+
+    @Override
+    public Set<String> getInputStreams() {
+        return Collections.singleton(stream);
     }
 
     @Override

--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/TopologyComponent.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/TopologyComponent.java
@@ -42,6 +42,7 @@ public class TopologyComponent extends AbstractStorable {
     public static final String DESCRIPTION = "description";
     public static final String CONFIG = "config";
     public static final String CONFIG_DATA = "configData";
+    public static final String RECONFIGURE = "reconfigure";
 
     private Long id;
     private Long topologyId = -1L;
@@ -52,6 +53,9 @@ public class TopologyComponent extends AbstractStorable {
     private Config config;
     // this is not saved in storage but REST apis includes version timestamp here
     private Long versionTimestamp;
+
+    // if the upstream changed the component may need reconfiguration
+    private Boolean reconfigure = false;
 
     public TopologyComponent() {
 
@@ -94,7 +98,9 @@ public class TopologyComponent extends AbstractStorable {
                 Schema.Field.of(TOPOLOGY_COMPONENT_BUNDLE_ID, Schema.Type.LONG),
                 Schema.Field.of(NAME, Schema.Type.STRING),
                 Schema.Field.of(DESCRIPTION, Schema.Type.STRING),
-                Schema.Field.of(CONFIG_DATA, Schema.Type.STRING));
+                Schema.Field.of(CONFIG_DATA, Schema.Type.STRING),
+                Schema.Field.of(RECONFIGURE, Schema.Type.BOOLEAN)
+        );
     }
 
     @Override
@@ -196,6 +202,14 @@ public class TopologyComponent extends AbstractStorable {
         this.versionTimestamp = timestamp;
     }
 
+    public Boolean getReconfigure() {
+        return reconfigure;
+    }
+
+    public void setReconfigure(Boolean reconfigure) {
+        this.reconfigure = reconfigure;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -213,5 +227,10 @@ public class TopologyComponent extends AbstractStorable {
         int result = id != null ? id.hashCode() : 0;
         result = 31 * result + (versionId != null ? versionId.hashCode() : 0);
         return result;
+    }
+
+    @Override
+    public String toString() {
+        return name;
     }
 }

--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/TopologyRule.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/TopologyRule.java
@@ -21,19 +21,22 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hortonworks.streamline.storage.annotation.StorableEntity;
-import org.apache.commons.lang3.StringUtils;
 import com.hortonworks.registries.common.Schema;
 import com.hortonworks.streamline.storage.PrimaryKey;
 import com.hortonworks.streamline.storage.Storable;
+import com.hortonworks.streamline.storage.annotation.StorableEntity;
 import com.hortonworks.streamline.streams.layout.component.rule.action.Action;
 import com.hortonworks.streamline.streams.layout.component.rule.expression.Window;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -252,21 +255,24 @@ public class TopologyRule extends BaseTopologyRule {
     @JsonIgnore
     @Override
     public Schema getSchema() {
-        return Schema.of(
-                Schema.Field.of(ID, Schema.Type.LONG),
-                Schema.Field.of(VERSIONID, Schema.Type.LONG),
-                Schema.Field.of(TOPOLOGY_ID, Schema.Type.LONG),
-                Schema.Field.of(NAME, Schema.Type.STRING),
-                Schema.Field.of(DESCRIPTION, Schema.Type.STRING),
-                Schema.Field.of(STREAMS, Schema.Type.STRING),
-                Schema.Field.of(OUTPUT_STREAMS, Schema.Type.STRING),
-                Schema.Field.of(PROJECTIONS, Schema.Type.STRING),
-                Schema.Field.of(CONDITION, Schema.Type.STRING),
-                Schema.Field.of(SQL, Schema.Type.STRING),
-                Schema.Field.of(PARSED_RULE_STR, Schema.Type.STRING),
-                Schema.Field.of(WINDOW, Schema.Type.STRING),
-                Schema.Field.of(ACTIONS, Schema.Type.STRING)
-        );
+        return Schema.unionOf(
+                super.getSchema(),
+                Schema.of(
+                        Schema.Field.of(ID, Schema.Type.LONG),
+                        Schema.Field.of(VERSIONID, Schema.Type.LONG),
+                        Schema.Field.of(TOPOLOGY_ID, Schema.Type.LONG),
+                        Schema.Field.of(NAME, Schema.Type.STRING),
+                        Schema.Field.of(DESCRIPTION, Schema.Type.STRING),
+                        Schema.Field.of(STREAMS, Schema.Type.STRING),
+                        Schema.Field.of(OUTPUT_STREAMS, Schema.Type.STRING),
+                        Schema.Field.of(PROJECTIONS, Schema.Type.STRING),
+                        Schema.Field.of(CONDITION, Schema.Type.STRING),
+                        Schema.Field.of(SQL, Schema.Type.STRING),
+                        Schema.Field.of(PARSED_RULE_STR, Schema.Type.STRING),
+                        Schema.Field.of(WINDOW, Schema.Type.STRING),
+                        Schema.Field.of(ACTIONS, Schema.Type.STRING),
+                        Schema.Field.of(RECONFIGURE, Schema.Type.BOOLEAN)
+                ));
     }
 
     @Override
@@ -295,6 +301,7 @@ public class TopologyRule extends BaseTopologyRule {
 
     @Override
     public Storable fromMap(Map<String, Object> map) {
+        super.fromMap(map);
         setId((Long) map.get(ID));
         setVersionId((Long) map.get(VERSIONID));
         setTopologyId((Long) map.get(TOPOLOGY_ID));
@@ -336,6 +343,11 @@ public class TopologyRule extends BaseTopologyRule {
             throw new RuntimeException(e);
         }
         return this;
+    }
+
+    @Override
+    public Set<String> getInputStreams() {
+        return new HashSet<>(streams);
     }
 
     @Override

--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/TopologyWindow.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/TopologyWindow.java
@@ -21,9 +21,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hortonworks.registries.common.Schema;
-import com.hortonworks.streamline.storage.annotation.StorableEntity;
 import com.hortonworks.streamline.storage.PrimaryKey;
 import com.hortonworks.streamline.storage.Storable;
+import com.hortonworks.streamline.storage.annotation.StorableEntity;
 import com.hortonworks.streamline.streams.layout.component.rule.action.Action;
 import com.hortonworks.streamline.streams.layout.component.rule.expression.Window;
 import org.apache.commons.lang3.StringUtils;
@@ -31,8 +31,10 @@ import org.apache.commons.lang3.StringUtils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @StorableEntity
@@ -243,21 +245,23 @@ public class TopologyWindow extends BaseTopologyRule {
     @JsonIgnore
     @Override
     public Schema getSchema() {
-        return Schema.of(
-                Schema.Field.of(ID, Schema.Type.LONG),
-                Schema.Field.of(VERSIONID, Schema.Type.LONG),
-                Schema.Field.of(TOPOLOGY_ID, Schema.Type.LONG),
-                Schema.Field.of(NAME, Schema.Type.STRING),
-                Schema.Field.of(DESCRIPTION, Schema.Type.STRING),
-                Schema.Field.of(STREAMS, Schema.Type.STRING),
-                Schema.Field.of(OUTPUT_STREAMS, Schema.Type.STRING),
-                Schema.Field.of(CONDITION, Schema.Type.STRING),
-                Schema.Field.of(PARSED_RULE_STR, Schema.Type.STRING),
-                Schema.Field.of(WINDOW, Schema.Type.STRING),
-                Schema.Field.of(ACTIONS, Schema.Type.STRING),
-                Schema.Field.of(PROJECTIONS, Schema.Type.STRING),
-                Schema.Field.of(GROUPBYKEYS, Schema.Type.STRING)
-        );
+        return Schema.unionOf(
+                super.getSchema(),
+                Schema.of(
+                        Schema.Field.of(ID, Schema.Type.LONG),
+                        Schema.Field.of(VERSIONID, Schema.Type.LONG),
+                        Schema.Field.of(TOPOLOGY_ID, Schema.Type.LONG),
+                        Schema.Field.of(NAME, Schema.Type.STRING),
+                        Schema.Field.of(DESCRIPTION, Schema.Type.STRING),
+                        Schema.Field.of(STREAMS, Schema.Type.STRING),
+                        Schema.Field.of(OUTPUT_STREAMS, Schema.Type.STRING),
+                        Schema.Field.of(CONDITION, Schema.Type.STRING),
+                        Schema.Field.of(PARSED_RULE_STR, Schema.Type.STRING),
+                        Schema.Field.of(WINDOW, Schema.Type.STRING),
+                        Schema.Field.of(ACTIONS, Schema.Type.STRING),
+                        Schema.Field.of(PROJECTIONS, Schema.Type.STRING),
+                        Schema.Field.of(GROUPBYKEYS, Schema.Type.STRING)
+                ));
     }
 
     @Override
@@ -280,6 +284,7 @@ public class TopologyWindow extends BaseTopologyRule {
 
     @Override
     public Storable fromMap(Map<String, Object> map) {
+        super.fromMap(map);
         setId((Long) map.get(ID));
         setVersionId((Long) map.get(VERSIONID));
         setTopologyId((Long) map.get(TOPOLOGY_ID));
@@ -331,6 +336,11 @@ public class TopologyWindow extends BaseTopologyRule {
     }
 
     @Override
+    public Set<String> getInputStreams() {
+        return new HashSet<>(streams);
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
@@ -347,5 +357,25 @@ public class TopologyWindow extends BaseTopologyRule {
         int result = id != null ? id.hashCode() : 0;
         result = 31 * result + (versionId != null ? versionId.hashCode() : 0);
         return result;
+    }
+
+    @Override
+    public String toString() {
+        return "TopologyWindow{" +
+                "id=" + id +
+                ", versionId=" + versionId +
+                ", topologyId=" + topologyId +
+                ", name='" + name + '\'' +
+                ", description='" + description + '\'' +
+                ", streams=" + streams +
+                ", condition='" + condition + '\'' +
+                ", parsedRuleStr='" + parsedRuleStr + '\'' +
+                ", window=" + window +
+                ", actions=" + actions +
+                ", projections=" + projections +
+                ", groupbykeys=" + groupbykeys +
+                ", versionTimestamp=" + versionTimestamp +
+                ", outputStreams=" + outputStreams +
+                "}";
     }
 }

--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/service/StreamCatalogService.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/service/StreamCatalogService.java
@@ -1310,6 +1310,26 @@ public class StreamCatalogService {
         return topologyStreams;
     }
 
+    /**
+     * Returns the list of components to be re-configured for a given topology.
+     *
+     * @param topology the topology
+     * @return the collection of components that have the reconfigure flag set or empty if no such component exists
+     */
+    public Map<String, Set<Long>> getComponentsToReconfigure(Topology topology) {
+        Map<String, Set<Long>> components = new HashMap<>();
+        List<QueryParam> qps = QueryParam.params(
+                TopologyComponent.TOPOLOGYID, String.valueOf(topology.getId()),
+                TopologyComponent.VERSIONID, String.valueOf(topology.getVersionId()),
+                TopologyComponent.RECONFIGURE, String.valueOf(true));
+        components.put(ComponentTypes.PROCESSOR, listTopologyProcessors(qps).stream().map(TopologyComponent::getId).collect(Collectors.toSet()));
+        components.put(ComponentTypes.SINK, listTopologySinks(qps).stream().map(TopologyComponent::getId).collect(Collectors.toSet()));
+        components.put(ComponentTypes.RULE, listRules(qps).stream().map(TopologyRule::getId).collect(Collectors.toSet()));
+        components.put(ComponentTypes.BRANCH, listBranchRules(qps).stream().map(TopologyBranchRule::getId).collect(Collectors.toSet()));
+        components.put(ComponentTypes.WINDOW, listWindows(qps).stream().map(TopologyWindow::getId).collect(Collectors.toSet()));
+        return components;
+    }
+
     public TopologySource addOrUpdateTopologySource(Long topologyId, Long sourceId, TopologySource topologySource) {
         Long currentTopologyVersionId = getCurrentVersionId(topologyId);
         topologySource.setId(sourceId);
@@ -2161,7 +2181,7 @@ public class StreamCatalogService {
         return dao.list(TOPOLOGY_RULEINFO_NAMESPACE);
     }
 
-    public Collection<TopologyRule> listRules(List<QueryParam> params) throws Exception {
+    public Collection<TopologyRule> listRules(List<QueryParam> params) {
         return dao.find(TOPOLOGY_RULEINFO_NAMESPACE, params);
     }
 
@@ -2233,7 +2253,7 @@ public class StreamCatalogService {
         return dao.list(TOPOLOGY_WINDOWINFO_NAMESPACE);
     }
 
-    public Collection<TopologyWindow> listWindows(List<QueryParam> params) throws Exception {
+    public Collection<TopologyWindow> listWindows(List<QueryParam> params) {
         return dao.find(TOPOLOGY_WINDOWINFO_NAMESPACE, params);
     }
 
@@ -2241,7 +2261,7 @@ public class StreamCatalogService {
         return dao.list(TOPOLOGY_BRANCHRULEINFO_NAMESPACE);
     }
 
-    public Collection<TopologyBranchRule> listBranchRules(List<QueryParam> params) throws Exception {
+    public Collection<TopologyBranchRule> listBranchRules(List<QueryParam> params) {
         return dao.find(TOPOLOGY_BRANCHRULEINFO_NAMESPACE, params);
     }
 

--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/topology/component/TopologyComponentFactory.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/topology/component/TopologyComponentFactory.java
@@ -154,6 +154,9 @@ public class TopologyComponentFactory {
 
     private <T extends StreamlineComponent> T getStreamlineComponent(Class<T> clazz,
                                                                      TopologyComponent topologyComponent) {
+        if (topologyComponent.getReconfigure()) {
+            throw new IllegalStateException("Topology component " + topologyComponent + " must be reconfigured");
+        }
         TopologyComponentBundle topologyComponentBundle = getTopologyComponentBundle(topologyComponent);
         StreamlineComponent component = getProvider(clazz, topologyComponentBundle.getSubType())
                 .create(topologyComponent);
@@ -423,6 +426,8 @@ public class TopologyComponentFactory {
                 TopologyRule topologyRule = catalogService.getRule(topologyId, ruleId, versionId);
                 if (topologyRule == null) {
                     throw new IllegalArgumentException("Cannot find rule with id " + ruleId);
+                } else if (topologyRule.getReconfigure()) {
+                    throw new IllegalStateException("Rule " + topologyRule.getName() + " must be reconfigured");
                 }
                 return topologyRule.getRule();
             }
@@ -434,11 +439,13 @@ public class TopologyComponentFactory {
         return new SimpleImmutableEntry<>(BRANCH, createRulesProcessorProvider(new RuleExtractor() {
             @Override
             public Rule getRule(Long topologyId, Long ruleId, Long versionId) throws Exception {
-                TopologyBranchRule brRuleInfo = catalogService.getBranchRule(topologyId, ruleId, versionId);
-                if (brRuleInfo == null) {
+                TopologyBranchRule topologyBranchRule = catalogService.getBranchRule(topologyId, ruleId, versionId);
+                if (topologyBranchRule == null) {
                     throw new IllegalArgumentException("Cannot find branch rule with id " + ruleId);
+                } else if (topologyBranchRule.getReconfigure()) {
+                    throw new IllegalStateException("Rule " + topologyBranchRule.getName() + " must be reconfigured");
                 }
-                return brRuleInfo.getRule();
+                return topologyBranchRule.getRule();
             }
         }));
     }
@@ -450,6 +457,8 @@ public class TopologyComponentFactory {
                 TopologyWindow topologyWindow = catalogService.getWindow(topologyId, ruleId, versionId);
                 if (topologyWindow == null) {
                     throw new IllegalArgumentException("Cannot find window rule with id " + ruleId);
+                } else if (topologyWindow.getReconfigure()) {
+                    throw new IllegalStateException("Window " + topologyWindow.getName() + " must be reconfigured");
                 }
                 return topologyWindow.getRule();
             }

--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/topology/component/TopologyDagBuilder.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/topology/component/TopologyDagBuilder.java
@@ -25,7 +25,10 @@ import com.hortonworks.streamline.streams.catalog.TopologyProcessor;
 import com.hortonworks.streamline.streams.catalog.TopologySink;
 import com.hortonworks.streamline.streams.catalog.TopologySource;
 import com.hortonworks.streamline.streams.catalog.service.StreamCatalogService;
+import com.hortonworks.streamline.streams.layout.component.StreamlineProcessor;
 import com.hortonworks.streamline.streams.layout.component.TopologyDag;
+import com.hortonworks.streamline.streams.layout.component.impl.RulesProcessor;
+import com.hortonworks.streamline.streams.layout.component.rule.Rule;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyCatalogResource.java
@@ -683,6 +683,20 @@ public class TopologyCatalogResource {
         return WSUtils.respondEntity(importedTopology, OK);
     }
 
+    @GET
+    @Path("/topologies/{topologyId}/reconfigure")
+    @Timed
+    public Response getComponentsToReconfigure(@PathParam("topologyId") Long topologyId,
+                                  @Context SecurityContext securityContext) throws Exception {
+        SecurityUtil.checkRoleOrPermissions(authorizer, securityContext, Roles.ROLE_TOPOLOGY_USER,
+                NAMESPACE, topologyId, READ);
+        Topology topology = catalogService.getTopology(topologyId);
+        if (topology != null) {
+            return WSUtils.respondEntity(catalogService.getComponentsToReconfigure(topology), OK);
+        }
+        throw EntityNotFoundException.byId(topologyId.toString());
+    }
+
     private List<CatalogResourceUtil.TopologyDetailedResponse> enrichTopologies(Collection<Topology> topologies, String asUser, String sortType, Boolean ascending, Integer latencyTopN) {
         LOG.debug("[START] enrichTopologies");
         Stopwatch stopwatch = Stopwatch.createStarted();

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyEdgeCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyEdgeCatalogResource.java
@@ -221,7 +221,7 @@ public class TopologyEdgeCatalogResource {
                                     @Context SecurityContext securityContext) {
         SecurityUtil.checkRoleOrPermissions(authorizer, securityContext, Roles.ROLE_TOPOLOGY_SUPER_ADMIN,
                 Topology.NAMESPACE, topologyId, WRITE);
-        TopologyEdge createdEdge = catalogService.addTopologyEdge(topologyId, edge);
+        TopologyEdge createdEdge = catalogService.addTopologyEdge(topologyId, edge, true);
         return WSUtils.respondEntity(createdEdge, CREATED);
     }
 


### PR DESCRIPTION
Whenever an edge or an output stream is updated or deleted, the downstream processor/sink/rule to which it is connected will be marked for 'reconfiguration' by the backend. UI can use this field to prompt the user to reconfigure the component. Once the user takes some action and saves the updated component, the reconfigure flag is reset by the backend.

During deployment if any component or rule has 'reconfigure' set, the deployment will fail.