### PR TITLE
ISSUE-942: SAM Kafka source crashes when target component has parallelism > 1

### DIFF
--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/grouping/FieldsGroupingAsCustomGrouping.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/grouping/FieldsGroupingAsCustomGrouping.java
@@ -53,7 +53,7 @@ public class FieldsGroupingAsCustomGrouping implements CustomStreamGrouping {
         for (String groupingField: groupingFields) {
             groupByObjects.add(StreamlineRuntimeUtil.getFieldValue(streamlineEvent, groupingField));
         }
-        int taskIndex = Arrays.deepHashCode(groupByObjects.toArray()) % targetTasks.size();
+        int taskIndex = (Arrays.deepHashCode(groupByObjects.toArray()) & 0x7FFFFFFF) % targetTasks.size();
         result.add(targetTasks.get(taskIndex));
         return result;
     }

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/grouping/FieldsGroupingAsCustomGroupingTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/grouping/FieldsGroupingAsCustomGroupingTest.java
@@ -1,0 +1,28 @@
+package com.hortonworks.streamline.streams.runtime.storm.grouping;
+
+import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for {@link FieldsGroupingAsCustomGrouping}
+ */
+public class FieldsGroupingAsCustomGroupingTest {
+    @Test
+    public void chooseTasksNegativeHashcode() throws Exception {
+        FieldsGroupingAsCustomGrouping fg = new FieldsGroupingAsCustomGrouping(Collections.singletonList("A"));
+        Map<String, Object> keyValues = Collections.singletonMap("A", "PUFPaY9KxDAcGqfsorJp1R");
+        fg.prepare(null, null, Arrays.asList(0, 1));
+        List<Integer> res = fg.chooseTasks(0, Collections.singletonList(new StreamlineEventImpl(keyValues, "srcID")));
+        Assert.assertEquals(1, res.size());
+        Assert.assertTrue(res.get(0) == 0 || res.get(0) == 1);
+    }
+
+}


### PR DESCRIPTION
Mask the hashcode in FieldsGroupingAsCustomGrouping to always return positive values.