### PR TITLE
ISSUE-935: Fix intermittent test failures from NotificationServiceImplTest

### DIFF
--- a/streams/notification/src/main/java/com/hortonworks/streamline/streams/notification/service/NotificationQueueHandler.java
+++ b/streams/notification/src/main/java/com/hortonworks/streamline/streams/notification/service/NotificationQueueHandler.java
@@ -75,10 +75,11 @@ public class NotificationQueueHandler {
     }
 
 
-    public void enqueue(Notifier notifier, Notification notification) {
+    public Future<?> enqueue(Notifier notifier, Notification notification) {
         NotificationQueueTask task = new NotificationQueueTask(notifier, notification);
         Future<?> future = executorService.submit(task);
         taskMap.put(notification.getId(), Pair.of(task, future));
+        return future;
     }
 
     /**

--- a/streams/notification/src/main/java/com/hortonworks/streamline/streams/notification/service/NotificationService.java
+++ b/streams/notification/src/main/java/com/hortonworks/streamline/streams/notification/service/NotificationService.java
@@ -25,6 +25,7 @@ import com.hortonworks.streamline.streams.notification.Notifier;
 import com.hortonworks.streamline.streams.notification.NotifierConfig;
 
 import java.util.List;
+import java.util.concurrent.Future;
 
 /**
  * <p>
@@ -55,12 +56,13 @@ public interface NotificationService {
     Notifier remove(String notifierName);
 
     /**
-     * Sends notification to a notifier.
+     * Asynchronously sends a notification to a notifier.
      *
      * @param notifierName the notifier name
      * @param notification the notification object.
+     * @return a {@link Future} that can be used to check the result of the notify operation
      */
-    void notify(String notifierName, Notification notification);
+    Future<?> notify(String notifierName, Notification notification);
 
     /**
      * <p>

--- a/streams/notification/src/main/java/com/hortonworks/streamline/streams/notification/service/NotificationServiceImpl.java
+++ b/streams/notification/src/main/java/com/hortonworks/streamline/streams/notification/service/NotificationServiceImpl.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
 
 /**
  * Notification service implementation.
@@ -113,14 +114,14 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     @Override
-    public void notify(String notifierName, Notification notification) {
+    public Future<?> notify(String notifierName, Notification notification) {
         LOG.debug("Notify notifierName {}, notification {}", notifierName, notification);
         notificationStore.ifPresent(s -> s.store(notification));
         Notifier notifier = notifiers.get(notifierName);
         if (notifier == null) {
             throw new NoSuchNotifierException("Notifier not found for id " + notification.getNotifierName());
         }
-        queueHandler.enqueue(notifier, notification);
+        return queueHandler.enqueue(notifier, notification);
     }
 
     @Override

--- a/streams/notification/src/test/java/com/hortonworks/streamline/streams/notification/service/NotificationServiceImplTest.java
+++ b/streams/notification/src/test/java/com/hortonworks/streamline/streams/notification/service/NotificationServiceImplTest.java
@@ -34,6 +34,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Arrays;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 
@@ -195,7 +197,9 @@ public class NotificationServiceImplTest {
 
         notificationService.register("test_notifier", mockCtx);
 
-        notificationService.notify("test_notifier", mockNotification);
+        Future<?> res = notificationService.notify("test_notifier", mockNotification);
+
+        res.get(5, TimeUnit.SECONDS);
 
         new Verifications() {
             {


### PR DESCRIPTION
Changed NotificationService.notify to return a Future and make the test case wait until the result is returned.

Fixes #935 