### PR TITLE
ISSUE-949: Disallow null values in test mode data

### DIFF
--- a/common/src/main/java/com/hortonworks/streamline/common/SchemaValueConverter.java
+++ b/common/src/main/java/com/hortonworks/streamline/common/SchemaValueConverter.java
@@ -19,6 +19,7 @@ package com.hortonworks.streamline.common;
 import com.hortonworks.registries.common.Schema;
 import com.hortonworks.streamline.common.exception.SchemaValidationFailedException;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -70,8 +71,14 @@ public final class SchemaValueConverter {
                     requiredFieldsNotFoundInValue.stream().map(Schema.Field::getName).collect(toList()));
         }
 
-        return value.entrySet().stream()
-                .collect(toMap(Map.Entry::getKey, e -> convert(fieldToType.get(e.getKey()), e.getValue())));
+        Map<String, Object> result = new HashMap<>();
+        value.forEach((k, v) -> {
+            if (v == null) {
+                throw SchemaValidationFailedException.nullValueForField(k);
+            }
+            result.put(k, convert(fieldToType.get(k), v));
+        });
+        return result;
     }
 
     /**

--- a/common/src/main/java/com/hortonworks/streamline/common/exception/SchemaValidationFailedException.java
+++ b/common/src/main/java/com/hortonworks/streamline/common/exception/SchemaValidationFailedException.java
@@ -14,4 +14,8 @@ public class SchemaValidationFailedException extends RuntimeException {
     public static SchemaValidationFailedException requiredFieldsNotFoundInValue(List<String> fields) {
         return new SchemaValidationFailedException("The value doesn't have required fields: " + fields);
     }
+
+    public static SchemaValidationFailedException nullValueForField(String field) {
+        return new SchemaValidationFailedException("Null value for field: " + field);
+    }
 }

--- a/common/src/test/java/com/hortonworks/streamline/common/SchemaValueConverterTest.java
+++ b/common/src/test/java/com/hortonworks/streamline/common/SchemaValueConverterTest.java
@@ -48,6 +48,19 @@ public class SchemaValueConverterTest {
         Assert.assertEquals(123.456d, (double) converted.get("e"), 0.001);
     }
 
+    @Test (expected = SchemaValidationFailedException.class)
+    public void convertMapHavingNull() throws Exception {
+        Schema schema = Schema.of(
+                Schema.Field.of("a", Schema.Type.STRING),
+                Schema.Field.of("b", Schema.Type.LONG));
+
+        Map<String, Object> value = new HashMap<>();
+        value.put("a", null);
+        value.put("b", 1234);
+
+        SchemaValueConverter.convertMap(schema, value);
+    }
+
     @Test
     public void convertMapValueDoesNotHaveOptionalField() throws ParserException {
         Schema schema = Schema.of(


### PR DESCRIPTION
Null values are not supported in the runtime. Keeping the same behavior in test mode for now.