### PR TITLE
ISSUE-951: Join bolt does not work in Test mode

### DIFF
--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunner.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunner.java
@@ -32,6 +32,7 @@ import com.hortonworks.streamline.streams.layout.component.StreamlineSink;
 import com.hortonworks.streamline.streams.layout.component.StreamlineSource;
 import com.hortonworks.streamline.streams.layout.component.TopologyLayout;
 import com.hortonworks.streamline.streams.layout.component.impl.RulesProcessor;
+import com.hortonworks.streamline.streams.layout.component.impl.JoinProcessor;
 import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunProcessor;
 import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSink;
 import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSource;
@@ -144,6 +145,10 @@ public class TopologyTestRunner {
 
                         boolean windowed = rulesProcessor.getRules().stream().anyMatch(r -> r.getWindow() != null);
                         TestRunProcessor testRunProcessor = new TestRunProcessor(s, windowed, eventLogFilePath);
+                        testRunProcessor.setName(s.getName());
+                        return testRunProcessor;
+                    } else if (s instanceof JoinProcessor) {
+                        TestRunProcessor testRunProcessor = new TestRunProcessor(s, true, eventLogFilePath);
                         testRunProcessor.setName(s.getName());
                         return testRunProcessor;
                     } else {

--- a/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/topology/component/TopologyComponentFactory.java
+++ b/streams/catalog/src/main/java/com/hortonworks/streamline/streams/catalog/topology/component/TopologyComponentFactory.java
@@ -53,8 +53,7 @@ import com.hortonworks.streamline.streams.layout.component.impl.RulesProcessor;
 import com.hortonworks.streamline.streams.layout.component.impl.model.ModelProcessor;
 import com.hortonworks.streamline.streams.layout.component.impl.normalization.NormalizationConfig;
 import com.hortonworks.streamline.streams.layout.component.impl.normalization.NormalizationProcessor;
-import com.hortonworks.streamline.streams.layout.component.impl.splitjoin.JoinAction;
-import com.hortonworks.streamline.streams.layout.component.impl.splitjoin.JoinProcessor;
+import com.hortonworks.streamline.streams.layout.component.impl.JoinProcessor;
 import com.hortonworks.streamline.streams.layout.component.impl.splitjoin.SplitAction;
 import com.hortonworks.streamline.streams.layout.component.impl.splitjoin.SplitProcessor;
 import com.hortonworks.streamline.streams.layout.component.impl.splitjoin.StageAction;
@@ -228,6 +227,7 @@ public class TopologyComponentFactory {
         builder.put(normalizationProcessorProvider());
         builder.put(multilangProcessorProvider());
         builder.put(modelProcessorProvider());
+        builder.put(joinProcessorProvider());
         return builder.build();
     }
 
@@ -361,17 +361,7 @@ public class TopologyComponentFactory {
         Provider<StreamlineProcessor> provider = new Provider<StreamlineProcessor>() {
             @Override
             public StreamlineProcessor create(TopologyComponent component) {
-                Object joinConfig = component.getConfig().getAny(JoinProcessor.CONFIG_KEY_JOIN);
-                ObjectMapper objectMapper = new ObjectMapper();
-                JoinAction joinAction = objectMapper.convertValue(joinConfig, JoinAction.class);
-                JoinProcessor joinProcessor = new JoinProcessor();
-                if (component instanceof TopologyOutputComponent) {
-                    joinProcessor.addOutputStreams(createOutputStreams((TopologyOutputComponent) component));
-                } else {
-                    throw new IllegalArgumentException("Component " + component + " must be an instance of TopologyOutputComponent");
-                }
-                joinProcessor.setJoinAction(joinAction);
-                return joinProcessor;
+                return new JoinProcessor();
             }
         };
         return new SimpleImmutableEntry<>(JOIN, provider);

--- a/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/JoinProcessor.java
+++ b/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/JoinProcessor.java
@@ -14,30 +14,23 @@
   * limitations under the License.
  **/
 
-package com.hortonworks.streamline.streams.layout.component.impl.splitjoin;
+package com.hortonworks.streamline.streams.layout.component.impl;
 
-import com.hortonworks.streamline.streams.layout.component.impl.RulesProcessor;
-import com.hortonworks.streamline.streams.layout.component.impl.Utils;
-
-import java.util.Collections;
+import com.hortonworks.streamline.streams.layout.component.StreamlineProcessor;
+import com.hortonworks.streamline.streams.layout.component.TopologyDagVisitor;
 
 /**
- * Joins incoming streams and generate a joined event.
+ * Design time component for JOIN
  *
  */
-public class JoinProcessor extends RulesProcessor {
-
-    public static final String CONFIG_KEY_JOIN = "join-config";
-
-    public JoinProcessor() {
-    }
-
-    public void setJoinAction(JoinAction joinAction) {
-        setRules(Collections.singletonList(Utils.createTrueRule(joinAction)));
+public class JoinProcessor extends StreamlineProcessor {
+    @Override
+    public void accept(TopologyDagVisitor visitor) {
+        visitor.visit(this);
     }
 
     @Override
     public String toString() {
-        return "JoinProcessor{}"+super.toString();
+        return "JoinProcessor{ " + super.toString() + " }";
     }
 }

--- a/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/splitjoin/SplitJoinProcessor.java
+++ b/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/splitjoin/SplitJoinProcessor.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.streamline.streams.layout.component.impl.splitjoin;
+
+import com.hortonworks.streamline.streams.layout.component.impl.RulesProcessor;
+import com.hortonworks.streamline.streams.layout.component.impl.Utils;
+
+import java.util.Collections;
+
+/**
+ * Joins incoming streams and generate a joined event.
+ */
+public class SplitJoinProcessor extends RulesProcessor {
+
+    public static final String CONFIG_KEY_JOIN = "join-config";
+
+    public SplitJoinProcessor() {
+    }
+
+    public void setJoinAction(JoinAction joinAction) {
+        setRules(Collections.singletonList(Utils.createTrueRule(joinAction)));
+    }
+
+    @Override
+    public String toString() {
+        return "SplitJoinProcessor{}" + super.toString();
+    }
+}

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/layout/runtime/rule/topology/SplitJoinTopologyTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/layout/runtime/rule/topology/SplitJoinTopologyTest.java
@@ -21,8 +21,8 @@ import com.hortonworks.streamline.streams.layout.Transform;
 import com.hortonworks.streamline.streams.layout.component.Stream;
 import com.hortonworks.streamline.streams.layout.component.impl.RulesProcessor;
 import com.hortonworks.streamline.streams.layout.component.impl.splitjoin.JoinAction;
-import com.hortonworks.streamline.streams.layout.component.impl.splitjoin.JoinProcessor;
 import com.hortonworks.streamline.streams.layout.component.impl.splitjoin.SplitAction;
+import com.hortonworks.streamline.streams.layout.component.impl.splitjoin.SplitJoinProcessor;
 import com.hortonworks.streamline.streams.layout.component.impl.splitjoin.SplitProcessor;
 import com.hortonworks.streamline.streams.layout.component.impl.splitjoin.StageAction;
 import com.hortonworks.streamline.streams.layout.component.impl.splitjoin.StageProcessor;
@@ -141,7 +141,7 @@ public class SplitJoinTopologyTest {
         public RulesProcessor get() {
             JoinAction joinAction = new JoinAction();
             joinAction.setOutputStreams(Collections.singleton(JOIN_OUTPUT_STREAM.getId()));
-            JoinProcessor joinProcessor = new JoinProcessor();
+            SplitJoinProcessor joinProcessor = new SplitJoinProcessor();
             joinProcessor.addOutputStreams(Collections.singleton(JOIN_OUTPUT_STREAM));
             joinProcessor.setJoinAction(joinAction);
             joinProcessor.setName("join-processor-"+System.currentTimeMillis());


### PR DESCRIPTION
Join processor should be recognized as a windowed processor and wrapped in TestRunWindowProcessorBolt.