### PR TITLE
ISSUE-964 Inject correlation information to event

### DIFF
--- a/streams/common/pom.xml
+++ b/streams/common/pom.xml
@@ -31,6 +31,11 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/streams/common/src/main/java/com/hortonworks/streamline/streams/common/event/EventInformation.java
+++ b/streams/common/src/main/java/com/hortonworks/streamline/streams/common/event/EventInformation.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.common.event;
+
+import java.util.Map;
+import java.util.Set;
+
+public class EventInformation {
+    private long timestamp;
+    private String componentName;
+    private String streamId;
+    private String targetComponentName;
+    private String eventId;
+    private Set<String> rootIds;
+    private Set<String> parentIds;
+    private Map<String, Object> fieldsAndValues;
+
+    // jackson
+    public EventInformation() {
+    }
+
+    public EventInformation(long timestamp, String componentName, String streamId, String targetComponentName,
+                            String eventId, Set<String> rootIds,
+                            Set<String> parentIds, Map<String, Object> fieldsAndValues) {
+        this.timestamp = timestamp;
+        this.componentName = componentName;
+        this.streamId = streamId;
+        this.targetComponentName = targetComponentName;
+        this.eventId = eventId;
+        this.rootIds = rootIds;
+        this.parentIds = parentIds;
+        this.fieldsAndValues = fieldsAndValues;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public String getComponentName() {
+        return componentName;
+    }
+
+    public String getStreamId() {
+        return streamId;
+    }
+
+    public String getTargetComponentName() {
+        return targetComponentName;
+    }
+
+    public String getEventId() {
+        return eventId;
+    }
+
+    public Set<String> getRootIds() {
+        return rootIds;
+    }
+
+    public Set<String> getParentIds() {
+        return parentIds;
+    }
+
+    public Map<String, Object> getFieldsAndValues() {
+        return fieldsAndValues;
+    }
+}

--- a/streams/common/src/main/java/com/hortonworks/streamline/streams/common/event/EventInformationBuilder.java
+++ b/streams/common/src/main/java/com/hortonworks/streamline/streams/common/event/EventInformationBuilder.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.common.event;
+
+import com.hortonworks.streamline.streams.StreamlineEvent;
+import com.hortonworks.streamline.streams.common.event.correlation.EventCorrelationInjector;
+
+public class EventInformationBuilder {
+    public EventInformation build(long timestamp, String componentName, String streamId, String targetComponentName, StreamlineEvent event) {
+        String sourceComponentName = EventCorrelationInjector.getSourceComponentName(event);
+        if (!componentName.equals(sourceComponentName)) {
+            throw new IllegalStateException("component name in event correlation is different from provided component name");
+        }
+        return new EventInformation(timestamp, componentName, streamId, targetComponentName, event.getId(),
+                EventCorrelationInjector.getRootIds(event), EventCorrelationInjector.getParentIds(event),
+                event);
+    }
+}

--- a/streams/common/src/main/java/com/hortonworks/streamline/streams/common/event/EventLogFileReader.java
+++ b/streams/common/src/main/java/com/hortonworks/streamline/streams/common/event/EventLogFileReader.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.common.event;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
+public class EventLogFileReader {
+    public static final Charset ENCODING_UTF_8 = Charset.forName("UTF-8");
+
+    private final ObjectMapper objectMapper;
+
+    public EventLogFileReader() {
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public List<EventInformation> loadEventLogFile(File eventLogFile) throws IOException {
+        return loadEventLogFileAsStream(eventLogFile).collect(toList());
+    }
+
+    public Stream<EventInformation> loadEventLogFileAsStream(File eventLogFile) throws IOException {
+        Stream<String> lines = Files.lines(eventLogFile.toPath(), ENCODING_UTF_8);
+        return lines.map(line -> {
+            try {
+                return (EventInformation) objectMapper.readValue(line, new TypeReference<EventInformation>() {});
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public String readFileAsString(File eventLogFile) throws IOException {
+        return FileUtils.readFileToString(eventLogFile, ENCODING_UTF_8);
+    }
+}

--- a/streams/common/src/main/java/com/hortonworks/streamline/streams/common/event/correlation/CorrelatedEventsGrouper.java
+++ b/streams/common/src/main/java/com/hortonworks/streamline/streams/common/event/correlation/CorrelatedEventsGrouper.java
@@ -29,7 +29,7 @@ public class CorrelatedEventsGrouper {
         this.events = events;
     }
 
-    public Map<String, List<EventInformation>> groupByComponent(String rootEventId) {
+    public GroupedCorrelationEvents groupByComponent(String rootEventId) {
         Map<String, EventInformation> allEventsMap = events.stream()
                 .collect(toMap(EventInformation::getEventId, e -> e));
 
@@ -44,18 +44,7 @@ public class CorrelatedEventsGrouper {
 
         addNonExistingParents(allEventsMap, relatedEventsMap);
 
-        Map<String, List<EventInformation>> eventsGroupByComponent = new HashMap<>();
-
-        relatedEventsMap.values().forEach(event -> {
-            List<EventInformation> events = eventsGroupByComponent.getOrDefault(event.getComponentName(), new ArrayList<>());
-            if (events.isEmpty()) {
-                // the list is newly created, so not from the map
-                eventsGroupByComponent.put(event.getComponentName(), events);
-            }
-            events.add(event);
-        });
-
-        return eventsGroupByComponent;
+        return new GroupedCorrelationEvents(relatedEventsMap);
     }
 
     private void addNonExistingParents(Map<String, EventInformation> allEventsMap,

--- a/streams/common/src/main/java/com/hortonworks/streamline/streams/common/event/correlation/CorrelatedEventsGrouper.java
+++ b/streams/common/src/main/java/com/hortonworks/streamline/streams/common/event/correlation/CorrelatedEventsGrouper.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2017 Hortonworks.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.common.event.correlation;
+
+import com.hortonworks.streamline.streams.common.event.EventInformation;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toMap;
+
+public class CorrelatedEventsGrouper {
+    private final List<EventInformation> events;
+
+    public CorrelatedEventsGrouper(List<EventInformation> events) {
+        this.events = events;
+    }
+
+    public Map<String, List<EventInformation>> groupByComponent(String rootEventId) {
+        Map<String, EventInformation> allEventsMap = events.stream()
+                .collect(toMap(EventInformation::getEventId, e -> e));
+
+        Stream<EventInformation> eventsAssociatedToRootEventStream = events.stream().filter(e -> {
+            boolean isRootEvent = e.getEventId().equals(rootEventId);
+            boolean containsRootEvent = e.getRootIds() != null && e.getRootIds().contains(rootEventId);
+            return isRootEvent || containsRootEvent;
+        });
+
+        Map<String, EventInformation> relatedEventsMap = eventsAssociatedToRootEventStream.collect(
+                toMap(EventInformation::getEventId, e -> e));
+
+        addNonExistingParents(allEventsMap, relatedEventsMap);
+
+        Map<String, List<EventInformation>> eventsGroupByComponent = new HashMap<>();
+
+        relatedEventsMap.values().forEach(event -> {
+            List<EventInformation> events = eventsGroupByComponent.getOrDefault(event.getComponentName(), new ArrayList<>());
+            if (events.isEmpty()) {
+                // the list is newly created, so not from the map
+                eventsGroupByComponent.put(event.getComponentName(), events);
+            }
+            events.add(event);
+        });
+
+        return eventsGroupByComponent;
+    }
+
+    private void addNonExistingParents(Map<String, EventInformation> allEventsMap,
+                                       Map<String, EventInformation> relatedEventsMap) {
+        Map<String, EventInformation> eventsToAddMap = new HashMap<>();
+
+        relatedEventsMap.forEach((eventId, event) ->
+                findAndAddParentsIfNecessary(allEventsMap, relatedEventsMap, eventsToAddMap, event));
+
+        // add all the events we newly found
+        relatedEventsMap.putAll(eventsToAddMap);
+    }
+
+    private void findAndAddParentsIfNecessary(Map<String, EventInformation> allEventsMap,
+                                              Map<String, EventInformation> relatedEventsMap,
+                                              Map<String, EventInformation> eventsToAddMap,
+                                              EventInformation event) {
+        Set<String> parentIds = event.getParentIds();
+
+        for (String parentId : parentIds) {
+            if (!relatedEventsMap.containsKey(parentId) && !eventsToAddMap.containsKey(parentId)) {
+                // find and add parent to relatedEventsMap
+                EventInformation parent = allEventsMap.get(parentId);
+                if (parent == null) {
+                    throw new RuntimeException("Failed to find parent event: logged event information may be corrupted.");
+                }
+                eventsToAddMap.put(parent.getEventId(), parent);
+
+                // newly found parent event may have parent event(s) as well... find them as well
+                findAndAddParentsIfNecessary(allEventsMap, relatedEventsMap, eventsToAddMap, parent);
+            }
+        }
+    }
+
+}

--- a/streams/common/src/main/java/com/hortonworks/streamline/streams/common/event/correlation/EventCorrelationInjector.java
+++ b/streams/common/src/main/java/com/hortonworks/streamline/streams/common/event/correlation/EventCorrelationInjector.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.common.event.correlation;
+
+import com.google.common.collect.ImmutableMap;
+import com.hortonworks.streamline.streams.StreamlineEvent;
+import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class EventCorrelationInjector {
+
+    public static final String HEADER_KEY_ROOT_IDS = "rootIds";
+    public static final String HEADER_KEY_PARENT_IDS = "parentIds";
+    public static final String HEADER_KEY_SOURCE_COMPONENT_NAME = "sourceComponentName";
+
+    public StreamlineEvent injectCorrelationInformation(StreamlineEvent event,
+                                                        List<StreamlineEvent> parentEvents, String componentName) {
+        Set<String> rootIds = new HashSet<>();
+        Set<String> parentIds = new HashSet<>();
+
+        if (!parentEvents.isEmpty()) {
+            parentEvents.forEach(parentEvent -> {
+                Set<String> rootIdsForParent = EventCorrelationInjector.getRootIds(parentEvent);
+                if (rootIdsForParent != null && !rootIdsForParent.isEmpty()) {
+                    rootIds.addAll(rootIdsForParent);
+                } else {
+                    rootIds.add(parentEvent.getId());
+                }
+
+                parentIds.add(parentEvent.getId());
+            });
+        }
+
+        // adding correlation and parent events information
+        Map<String, Object> header = new HashMap<>();
+        header.putAll(event.getHeader());
+        header.put(HEADER_KEY_ROOT_IDS, rootIds);
+        header.put(HEADER_KEY_PARENT_IDS, parentIds);
+        header.put(HEADER_KEY_SOURCE_COMPONENT_NAME, componentName);
+
+        return StreamlineEventImpl.builder()
+                .from(event)
+                .header(header)
+                .build();
+    }
+
+    public static Set<String> getRootIds(StreamlineEvent event) {
+        if (!event.getHeader().containsKey(HEADER_KEY_ROOT_IDS)) {
+            throw new IllegalArgumentException("Root ID list is not in header.");
+        }
+        return (Set<String>) event.getHeader().get(HEADER_KEY_ROOT_IDS);
+    }
+
+    public static Set<String> getParentIds(StreamlineEvent event) {
+        if (!event.getHeader().containsKey(HEADER_KEY_PARENT_IDS)) {
+            throw new IllegalArgumentException("Parent ID list is not in header.");
+        }
+        return (Set<String>) event.getHeader().get(HEADER_KEY_PARENT_IDS);
+    }
+
+    public static String getSourceComponentName(StreamlineEvent event) {
+        if (!event.getHeader().containsKey(HEADER_KEY_SOURCE_COMPONENT_NAME)) {
+            throw new IllegalArgumentException("Source component name is not in header.");
+        }
+        return (String) event.getHeader().get(HEADER_KEY_SOURCE_COMPONENT_NAME);
+    }
+}

--- a/streams/common/src/main/java/com/hortonworks/streamline/streams/common/event/correlation/GroupedCorrelationEvents.java
+++ b/streams/common/src/main/java/com/hortonworks/streamline/streams/common/event/correlation/GroupedCorrelationEvents.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2017 Hortonworks.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.common.event.correlation;
+
+import com.hortonworks.streamline.streams.common.event.EventInformation;
+
+import java.util.*;
+
+public class GroupedCorrelationEvents {
+    private Map<String, EventInformation> allEvents;
+    private Map<String, ComponentGroupedEvents> componentGroupedEvents;
+
+    public GroupedCorrelationEvents(Map<String, EventInformation> correlatedEvents) {
+        this.allEvents = correlatedEvents;
+
+        this.componentGroupedEvents = new HashMap<>();
+
+        correlatedEvents.values().forEach(event -> {
+            String sourceComponentName = event.getComponentName();
+            String targetComponentName = event.getTargetComponentName();
+
+            ComponentGroupedEvents groupedEvents = componentGroupedEvents.get(sourceComponentName);
+            if (groupedEvents == null) {
+                groupedEvents = new ComponentGroupedEvents(sourceComponentName);
+                componentGroupedEvents.put(sourceComponentName, groupedEvents);
+            }
+            groupedEvents.addOutputEventId(event.getEventId());
+
+            groupedEvents = componentGroupedEvents.get(targetComponentName);
+            if (groupedEvents == null) {
+                groupedEvents = new ComponentGroupedEvents(targetComponentName);
+                componentGroupedEvents.put(targetComponentName, groupedEvents);
+            }
+            groupedEvents.addInputEventId(event.getEventId());
+        });
+    }
+
+    public Map<String, EventInformation> getAllEvents() {
+        return allEvents;
+    }
+
+    public Map<String, ComponentGroupedEvents> getComponentGroupedEvents() {
+        return componentGroupedEvents;
+    }
+
+    private static class ComponentGroupedEvents {
+        private String componentName;
+        private Set<String> inputEventIds;
+        private Set<String> outputEventIds;
+
+        public ComponentGroupedEvents(String componentName) {
+            this.componentName = componentName;
+            this.inputEventIds = new HashSet<>();
+            this.outputEventIds = new HashSet<>();
+        }
+
+        public ComponentGroupedEvents addInputEventId(String eventId) {
+            inputEventIds.add(eventId);
+            return this;
+        }
+
+        public ComponentGroupedEvents addOutputEventId(String eventId) {
+            outputEventIds.add(eventId);
+            return this;
+        }
+
+        public String getComponentName() {
+            return componentName;
+        }
+
+        public Set<String> getInputEventIds() {
+            return inputEventIds;
+        }
+
+        public Set<String> getOutputEventIds() {
+            return outputEventIds;
+        }
+    }
+}

--- a/streams/common/src/main/java/com/hortonworks/streamline/streams/common/event/tree/EventInformationTreeBuilder.java
+++ b/streams/common/src/main/java/com/hortonworks/streamline/streams/common/event/tree/EventInformationTreeBuilder.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2017 Hortonworks.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.common.event.tree;
+
+import com.hortonworks.streamline.streams.common.event.EventInformation;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toMap;
+
+public class EventInformationTreeBuilder {
+    private final List<EventInformation> events;
+
+    public EventInformationTreeBuilder(List<EventInformation> events) {
+        this.events = events;
+    }
+
+    public EventInformationTreeNode constructEventTree(String rootEventId) {
+        Map<String, EventInformationTreeNode> nodes = constructEventTreeAsMap(rootEventId);
+        return nodes.get(rootEventId);
+    }
+
+    public EventInformationTreeNode constructEventTree(String rootEventId, String subRootEventId) {
+        Map<String, EventInformationTreeNode> nodes = constructEventTreeAsMap(rootEventId);
+        return nodes.get(subRootEventId);
+    }
+
+    public Map<String, EventInformationTreeNode> constructEventTreeAsMap(String rootEventId) {
+        Stream<EventInformation> eventsAssociatedToRootEventStream = events.stream().filter(e -> {
+            boolean isRootEvent = e.getEventId().equals(rootEventId);
+            boolean containsRootEvent = e.getRootIds() != null && e.getRootIds().contains(rootEventId);
+            return isRootEvent || containsRootEvent;
+        });
+
+        Map<String, EventInformationTreeNode> nodes = eventsAssociatedToRootEventStream.collect(
+                toMap(EventInformation::getEventId, EventInformationTreeNode::new));
+
+        nodes.forEach((eventId, node) -> {
+            Set<String> parentIds = node.getEventInformation().getParentIds();
+            parentIds.forEach(parentId -> {
+                EventInformationTreeNode parentNode = nodes.get(parentId);
+                // parent will not be in nodes when parent is originated to another root event
+                // if it's the case, just ignore it
+                if (parentNode != null) {
+                    parentNode.addChild(node);
+                }
+            });
+        });
+        return nodes;
+    }
+
+}

--- a/streams/common/src/main/java/com/hortonworks/streamline/streams/common/event/tree/EventInformationTreeNode.java
+++ b/streams/common/src/main/java/com/hortonworks/streamline/streams/common/event/tree/EventInformationTreeNode.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2017 Hortonworks.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.common.event.tree;
+
+import com.hortonworks.streamline.streams.common.event.EventInformation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EventInformationTreeNode {
+    private final EventInformation eventInformation;
+    private final List<EventInformationTreeNode> children;
+
+    public EventInformationTreeNode(EventInformation eventInformation) {
+        this.eventInformation = eventInformation;
+        this.children = new ArrayList<>();
+    }
+
+    public EventInformation getEventInformation() {
+        return eventInformation;
+    }
+
+    public void addChild(EventInformationTreeNode child) {
+        this.children.add(child);
+    }
+
+    public List<EventInformationTreeNode> getChildren() {
+        return children;
+    }
+}

--- a/streams/common/src/test/java/com/hortonworks/streamline/streams/common/StreamlineEventImplTest.java
+++ b/streams/common/src/test/java/com/hortonworks/streamline/streams/common/StreamlineEventImplTest.java
@@ -42,8 +42,7 @@ public class StreamlineEventImplTest {
         map.put("b", "bval");
 
 
-        StreamlineEvent event = new StreamlineEventImpl(map, StringUtils.EMPTY);
-
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(map).build();
         assertEquals(map, event);
     }
 
@@ -53,9 +52,7 @@ public class StreamlineEventImplTest {
         map.put("a", "aval");
         map.put("b", "bval");
 
-
-        StreamlineEvent event = new StreamlineEventImpl(map, org.apache.commons.lang.StringUtils.EMPTY);
-
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(map).build();
         assertNotNull(UUID.fromString(event.getId()));
     }
 
@@ -65,9 +62,7 @@ public class StreamlineEventImplTest {
         map.put("a", "aval");
         map.put("b", "bval");
 
-
-        StreamlineEvent event = new StreamlineEventImpl(map, "1");
-
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(map).dataSourceId("1").build();
         assertEquals("1", event.getDataSourceId());
 
     }
@@ -75,39 +70,10 @@ public class StreamlineEventImplTest {
     @Test
     public void testGetSourceStream() throws Exception {
         String sourceStream = "stream";
-        StreamlineEvent event = new StreamlineEventImpl(new HashMap<String, Object>(), "1");
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(Collections.emptyMap()).dataSourceId("1").build();
         assertEquals(StreamlineEventImpl.DEFAULT_SOURCE_STREAM, event.getSourceStream());
-        event = new StreamlineEventImpl(new HashMap<String, Object>(), "1", "1", new HashMap<String, Object>(), sourceStream);
+        event = StreamlineEventImpl.builder().fieldsAndValues(Collections.emptyMap()).dataSourceId("1").sourceStream(sourceStream).build();
         assertEquals(sourceStream, event.getSourceStream());
-    }
-
-    @Test
-    public void testEquals() throws Exception {
-
-        Map<String, Object> map = new HashMap<>();
-        map.put("a", "aval");
-        map.put("b", "bval");
-
-
-        StreamlineEvent event1 = new StreamlineEventImpl(map, StringUtils.EMPTY);
-
-        StreamlineEvent event2 = new StreamlineEventImpl(map, StringUtils.EMPTY, event1.getId());
-
-        assertEquals(event1, event2);
-    }
-
-    @Test
-    public void testHashcode() throws Exception {
-        Map<String, Object> map = new HashMap<>();
-        map.put("a", "aval");
-        map.put("b", "bval");
-
-
-        StreamlineEvent event1 = new StreamlineEventImpl(map, StringUtils.EMPTY);
-
-        StreamlineEvent event2 = new StreamlineEventImpl(map, StringUtils.EMPTY, event1.getId());
-
-        assertEquals(event1.hashCode(), event2.hashCode());
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -115,7 +81,7 @@ public class StreamlineEventImplTest {
         Map<String, Object> map = new HashMap<>();
         map.put("foo", "bar");
 
-        StreamlineEvent event = new StreamlineEventImpl(map, StringUtils.EMPTY);
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(map).build();
         event.put("key", "val");
     }
 
@@ -124,7 +90,7 @@ public class StreamlineEventImplTest {
         Map<String, Object> map = new HashMap<>();
         map.put("foo", "bar");
 
-        StreamlineEvent event = new StreamlineEventImpl(map, StringUtils.EMPTY);
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(map).build();
         event.clear();
     }
 
@@ -133,7 +99,7 @@ public class StreamlineEventImplTest {
         Map<String, Object> map = new HashMap<>();
         map.put("foo", "bar");
 
-        StreamlineEvent event = new StreamlineEventImpl(Collections.emptyMap(), StringUtils.EMPTY);
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(Collections.emptyMap()).build();
         event.putAll(map);
     }
 
@@ -142,7 +108,7 @@ public class StreamlineEventImplTest {
         Map<String, Object> map = new HashMap<>();
         map.put("foo", "bar");
 
-        StreamlineEvent event = new StreamlineEventImpl(Collections.emptyMap(), StringUtils.EMPTY);
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(Collections.emptyMap()).build();
         event.remove("foo");
     }
 
@@ -151,7 +117,7 @@ public class StreamlineEventImplTest {
         Map<String, Object> map = new HashMap<>();
         map.put("foo", "bar");
 
-        StreamlineEvent event = new StreamlineEventImpl(map, StringUtils.EMPTY);
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(map).build();
         Iterator<Map.Entry<String, Object>> it = event.entrySet().iterator();
         while(it.hasNext()) {
             it.next();

--- a/streams/common/src/test/java/com/hortonworks/streamline/streams/common/event/EventInformationBuilderTest.java
+++ b/streams/common/src/test/java/com/hortonworks/streamline/streams/common/event/EventInformationBuilderTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.common.event;
+
+import com.hortonworks.streamline.streams.StreamlineEvent;
+import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
+import com.hortonworks.streamline.streams.common.event.correlation.EventCorrelationInjector;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+import static org.junit.Assert.*;
+
+public class EventInformationBuilderTest {
+    private static final String TEST_COMPONENT_NAME = "testComponent";
+    public static final String TEST_TARGET_COMPONENT_NAME = "targetComponentName";
+    public static final String TEST_STREAM_ID = "streamId";
+
+    private EventInformationBuilder sut;
+
+    @Before
+    public void setUp() throws Exception {
+        sut = new EventInformationBuilder();
+    }
+
+    public static final StreamlineEventImpl INPUT_STREAMLINE_EVENT = StreamlineEventImpl.builder()
+            .fieldsAndValues(new HashMap<String, Object>() {{
+                put("illuminance", 70);
+                put("temp", 104);
+                put("foo", 100);
+                put("humidity", "40h");
+            }})
+            .dataSourceId("ds-" + System.currentTimeMillis())
+            .header(Collections.singletonMap("A", 1))
+            .build();
+
+    @Test
+    public void testBuild() throws Exception {
+        long timestamp = System.currentTimeMillis();
+
+        EventCorrelationInjector injector = new EventCorrelationInjector();
+
+        StreamlineEvent parentEvent = copyEventWithNewID();
+
+        // use same component name for parent and ancestor for easy testing
+        // this line is covered via `testNoParent()`
+        parentEvent = injector.injectCorrelationInformation(parentEvent, Collections.emptyList(), TEST_COMPONENT_NAME);
+
+        StreamlineEvent injectedEvent = injector.injectCorrelationInformation(
+                INPUT_STREAMLINE_EVENT, Collections.singletonList(parentEvent), TEST_COMPONENT_NAME);
+
+        EventInformation information = sut.build(timestamp, TEST_COMPONENT_NAME, TEST_STREAM_ID,
+                TEST_TARGET_COMPONENT_NAME, injectedEvent);
+        assertEquals(timestamp, information.getTimestamp());
+        assertEquals(injectedEvent.getId(), information.getEventId());
+        assertEquals(EventCorrelationInjector.getRootIds(injectedEvent), information.getRootIds());
+        assertEquals(EventCorrelationInjector.getParentIds(injectedEvent), information.getParentIds());
+        assertEquals(EventCorrelationInjector.getSourceComponentName(injectedEvent), information.getComponentName());
+        assertEquals(TEST_COMPONENT_NAME, information.getComponentName());
+        assertEquals(TEST_STREAM_ID, information.getStreamId());
+        assertEquals(TEST_TARGET_COMPONENT_NAME, information.getTargetComponentName());
+    }
+
+    private StreamlineEventImpl copyEventWithNewID() {
+        return StreamlineEventImpl.builder().from(INPUT_STREAMLINE_EVENT).build();
+    }
+
+}

--- a/streams/common/src/test/java/com/hortonworks/streamline/streams/common/event/correlation/EventCorrelationInjectorTest.java
+++ b/streams/common/src/test/java/com/hortonworks/streamline/streams/common/event/correlation/EventCorrelationInjectorTest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.streamline.streams.common.event.correlation;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.hortonworks.streamline.streams.StreamlineEvent;
+import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
+import com.hortonworks.streamline.streams.common.event.util.StreamlineEventTestUtil;
+import mockit.integration.junit4.JMockit;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+import static org.junit.Assert.*;
+
+@RunWith(JMockit.class)
+public class EventCorrelationInjectorTest {
+
+    private static final String TEST_COMPONENT_NAME = "testComponent";
+
+    private EventCorrelationInjector sut = new EventCorrelationInjector();
+
+    public static final StreamlineEventImpl INPUT_STREAMLINE_EVENT = StreamlineEventImpl.builder()
+            .fieldsAndValues(new HashMap<String, Object>() {{
+                put("illuminance", 70);
+                put("temp", 104);
+                put("foo", 100);
+                put("humidity", "40h");
+            }})
+            .dataSourceId("ds-" + System.currentTimeMillis())
+            .header(Collections.singletonMap("A", 1))
+            .build();
+
+    @Test
+    public void eventArgsTestNoParent() throws Exception {
+        StreamlineEvent injectedEvent = sut.injectCorrelationInformation(
+                INPUT_STREAMLINE_EVENT, Collections.emptyList(), TEST_COMPONENT_NAME);
+
+        StreamlineEventTestUtil.assertEventIsProperlyCopied(injectedEvent, INPUT_STREAMLINE_EVENT);
+
+        // added headers
+        // if rootIds is empty itself is the root event
+        assertEquals(Collections.emptySet(), EventCorrelationInjector.getRootIds(injectedEvent));
+        assertEquals(Collections.emptySet(), EventCorrelationInjector.getParentIds(injectedEvent));
+        assertEquals(TEST_COMPONENT_NAME, EventCorrelationInjector.getSourceComponentName(injectedEvent));
+    }
+
+    @Test
+    public void eventArgsTestWithAParentWhichIsRootEvent() throws Exception {
+        StreamlineEvent parentEvent = copyEventWithNewID();
+
+        // use same component name for parent and ancestor for easy testing
+        // this line is covered via `testNoParent()`
+        parentEvent = sut.injectCorrelationInformation(parentEvent, Collections.emptyList(), TEST_COMPONENT_NAME);
+
+        StreamlineEvent injectedEvent = sut.injectCorrelationInformation(
+                INPUT_STREAMLINE_EVENT, Collections.singletonList(parentEvent), TEST_COMPONENT_NAME);
+
+        StreamlineEventTestUtil.assertEventIsProperlyCopied(injectedEvent, INPUT_STREAMLINE_EVENT);
+
+        // added headers
+        assertEquals(Collections.singleton(parentEvent.getId()), EventCorrelationInjector.getRootIds(injectedEvent));
+        assertEquals(Collections.singleton(parentEvent.getId()), EventCorrelationInjector.getParentIds(injectedEvent));
+        assertEquals(TEST_COMPONENT_NAME, EventCorrelationInjector.getSourceComponentName(injectedEvent));
+    }
+
+    @Test
+    public void eventArgsTestWithTwoParentsWhichAreRootEvents() throws Exception {
+        StreamlineEvent parentEvent1 = copyEventWithNewID();
+        // this line is covered via `testNoParent()`
+        parentEvent1 = sut.injectCorrelationInformation(parentEvent1, Collections.emptyList(), TEST_COMPONENT_NAME);
+
+        StreamlineEvent parentEvent2 = copyEventWithNewID();
+        // this line is covered via `testNoParent()`
+        parentEvent2 = sut.injectCorrelationInformation(parentEvent2, Collections.emptyList(), TEST_COMPONENT_NAME);
+
+        StreamlineEvent injectedEvent = sut.injectCorrelationInformation(
+                INPUT_STREAMLINE_EVENT, Lists.newArrayList(parentEvent1, parentEvent2), TEST_COMPONENT_NAME);
+
+        StreamlineEventTestUtil.assertEventIsProperlyCopied(injectedEvent, INPUT_STREAMLINE_EVENT);
+
+        // added headers
+        assertEquals(Sets.newHashSet(parentEvent1.getId(), parentEvent2.getId()), EventCorrelationInjector.getRootIds(injectedEvent));
+        assertEquals(Sets.newHashSet(parentEvent1.getId(), parentEvent2.getId()), EventCorrelationInjector.getParentIds(injectedEvent));
+        assertEquals(TEST_COMPONENT_NAME, EventCorrelationInjector.getSourceComponentName(injectedEvent));
+    }
+
+    @Test
+    public void eventArgsTestWithTwoParentsWhichOneIsRootEventAndAnotherOneIsNonRootEvent() throws Exception {
+        StreamlineEvent parentEvent1 = copyEventWithNewID();
+        // this line is covered via `testNoParent()`
+        parentEvent1 = sut.injectCorrelationInformation(parentEvent1, Collections.emptyList(), TEST_COMPONENT_NAME);
+
+        StreamlineEvent parentOfParentEvent2 = copyEventWithNewID();
+        // this line is covered via `testNoParent()`
+        parentOfParentEvent2 = sut.injectCorrelationInformation(parentOfParentEvent2, Collections.emptyList(), TEST_COMPONENT_NAME);
+
+        StreamlineEvent parentEvent2 = copyEventWithNewID();
+        // this line is covered via `testWithAParentWhichIsRootEvent()`
+        parentEvent2 = sut.injectCorrelationInformation(parentEvent2, Collections.singletonList(parentOfParentEvent2), TEST_COMPONENT_NAME);
+
+        StreamlineEvent injectedEvent = sut.injectCorrelationInformation(INPUT_STREAMLINE_EVENT,
+                Lists.newArrayList(parentEvent1, parentEvent2), TEST_COMPONENT_NAME);
+
+        StreamlineEventTestUtil.assertEventIsProperlyCopied(injectedEvent, INPUT_STREAMLINE_EVENT);
+
+        // added headers
+        assertEquals(Sets.newHashSet(parentEvent1.getId(), parentOfParentEvent2.getId()), EventCorrelationInjector.getRootIds(injectedEvent));
+        assertEquals(Sets.newHashSet(parentEvent1.getId(), parentEvent2.getId()), EventCorrelationInjector.getParentIds(injectedEvent));
+        assertEquals(TEST_COMPONENT_NAME, EventCorrelationInjector.getSourceComponentName(injectedEvent));
+    }
+
+    private StreamlineEventImpl copyEventWithNewID() {
+        return StreamlineEventImpl.builder().from(INPUT_STREAMLINE_EVENT).build();
+    }
+
+}

--- a/streams/common/src/test/java/com/hortonworks/streamline/streams/common/event/util/StreamlineEventTestUtil.java
+++ b/streams/common/src/test/java/com/hortonworks/streamline/streams/common/event/util/StreamlineEventTestUtil.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.common.event.util;
+
+import com.hortonworks.streamline.streams.StreamlineEvent;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public final class StreamlineEventTestUtil {
+
+    public static void assertEventIsProperlyCopied(StreamlineEvent newEvent, StreamlineEvent sourceEvent) {
+        // key-value
+        assertEquals(newEvent.entrySet(), sourceEvent.entrySet());
+
+        // header
+        sourceEvent.getHeader().forEach((k, v) -> {
+            assertTrue(newEvent.getHeader().containsKey(k));
+            assertEquals(v, newEvent.getHeader().get(k));
+        });
+
+        // other fields
+        assertEquals(newEvent.getDataSourceId(), sourceEvent.getDataSourceId());
+        assertEquals(newEvent.getSourceStream(), sourceEvent.getSourceStream());
+        assertEquals(newEvent.getAuxiliaryFieldsAndValues(), sourceEvent.getAuxiliaryFieldsAndValues());
+
+        // id should be different
+        assertNotEquals(newEvent.getId(), sourceEvent.getId());
+    }
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/StreamlineWindowedBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/StreamlineWindowedBolt.java
@@ -16,7 +16,7 @@
 package com.hortonworks.streamline.streams.runtime.storm.bolt;
 
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.storm.topology.base.BaseWindowedBolt;
 import com.hortonworks.streamline.streams.layout.component.rule.expression.Window;
 

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/StreamsShellBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/StreamsShellBolt.java
@@ -95,8 +95,7 @@ public class StreamsShellBolt extends AbstractProcessorBolt {
     @Override
     protected void process(Tuple input, StreamlineEvent event) {
         //just need an id
-        String genId = Long.toString(rand.nextLong());
-        StreamlineEvent eventWithStream = getStreamlineEventWithStream(event, input, genId);
+        StreamlineEvent eventWithStream = getStreamlineEventWithStream(event, input);
         try {
             for (Result result : processorRuntime.process(eventWithStream)) {
                 for (StreamlineEvent e : result.events) {
@@ -108,10 +107,8 @@ public class StreamsShellBolt extends AbstractProcessorBolt {
         }
     }
 
-    private StreamlineEvent getStreamlineEventWithStream(StreamlineEvent event, Tuple tuple, String genId) {
-        return new StreamlineEventImpl(event,
-                event.getDataSourceId(), genId,
-                event.getHeader(), tuple.getSourceStreamId(), event.getAuxiliaryFieldsAndValues());
+    private StreamlineEvent getStreamlineEventWithStream(StreamlineEvent event, Tuple tuple) {
+        return StreamlineEventImpl.builder().from(event).sourceStream(tuple.getSourceStreamId()).build();
     }
 
     @Override

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/normalization/NormalizationBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/normalization/NormalizationBolt.java
@@ -67,8 +67,10 @@ public class NormalizationBolt extends AbstractProcessorBolt {
     public void process(Tuple inputTuple, StreamlineEvent event) throws Exception {
         LOG.debug("Normalizing received StreamlineEvent: [{}] with tuple: [{}]", event, inputTuple);
         //todo this bolt will be replaced with custom baseprocessor bolt.
-        StreamlineEventImpl eventWithStream = new StreamlineEventImpl(event, event.getDataSourceId(),
-                event.getId(), event.getHeader(), inputTuple.getSourceStreamId());
+        StreamlineEventImpl eventWithStream = StreamlineEventImpl.builder()
+                .from(event)
+                .sourceStream(inputTuple.getSourceStreamId())
+                .build();
         List<Result> outputEvents = normalizationProcessorRuntime.process(eventWithStream);
         LOG.debug("Emitting events to collector: [{}]", outputEvents);
         for (Result outputEvent : outputEvents) {

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/RulesBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/RulesBolt.java
@@ -93,9 +93,7 @@ public class RulesBolt extends AbstractProcessorBolt {
     }
 
     private StreamlineEvent getStreamlineEventWithStream(StreamlineEvent event, Tuple tuple) {
-        return new StreamlineEventImpl(event,
-                event.getDataSourceId(), event.getId(),
-                event.getHeader(), tuple.getSourceStreamId(), event.getAuxiliaryFieldsAndValues());
+        return StreamlineEventImpl.builder().from(event).sourceStream(tuple.getSourceStreamId()).build();
     }
 
     @Override

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/WindowRulesBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/WindowRulesBolt.java
@@ -157,9 +157,7 @@ public class WindowRulesBolt extends StreamlineWindowedBolt {
     }
 
     private StreamlineEvent getStreamlineEventWithStream(StreamlineEvent event, Tuple tuple) {
-        return new StreamlineEventImpl(event,
-                event.getDataSourceId(), event.getId(),
-                event.getHeader(), tuple.getSourceStreamId(), event.getAuxiliaryFieldsAndValues());
+        return StreamlineEventImpl.builder().from(event).sourceStream(tuple.getSourceStreamId()).build();
     }
 
     @Override

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/EventCorrelatingOutputCollector.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/EventCorrelatingOutputCollector.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.streamline.streams.runtime.storm.testing;
+
+import com.hortonworks.streamline.streams.StreamlineEvent;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.Values;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public class EventCorrelatingOutputCollector extends OutputCollector {
+    private final TopologyContext topologyContext;
+    private final OutputCollector delegate;
+    private final StormEventCorrelationInjector eventCorrelationInjector;
+
+    public EventCorrelatingOutputCollector(TopologyContext topologyContext, OutputCollector delegate) {
+        // we simply ignore the _delegate in OutputCollector and override all of the methods
+        // this will work with subclass of OutputCollector since we only expose methods what we know about
+        super(null);
+        this.topologyContext = topologyContext;
+        this.delegate = delegate;
+        this.eventCorrelationInjector = new StormEventCorrelationInjector();
+    }
+
+    @Override
+    public List<Integer> emit(String streamId, Tuple anchor, List<Object> tuple) {
+        StreamlineEvent newEvent = injectCorrelationInformation(anchor, tuple);
+        return delegate.emit(streamId, anchor, new Values(newEvent));
+    }
+
+    @Override
+    public List<Integer> emit(Tuple anchor, List<Object> tuple) {
+        StreamlineEvent newEvent = injectCorrelationInformation(anchor, tuple);
+        return delegate.emit(anchor, new Values(newEvent));
+    }
+
+    @Override
+    public List<Integer> emit(String streamId, List<Object> tuple) {
+        StreamlineEvent newEvent = injectCorrelationInformation(tuple);
+        return delegate.emit(streamId, new Values(newEvent));
+    }
+
+    @Override
+    public List<Integer> emit(List<Object> tuple) {
+        StreamlineEvent newEvent = injectCorrelationInformation(tuple);
+        return delegate.emit(new Values(newEvent));
+    }
+
+    @Override
+    public List<Integer> emit(Collection<Tuple> anchors, List<Object> tuple) {
+        StreamlineEvent newEvent = injectCorrelationInformation(anchors, tuple);
+        return delegate.emit(anchors, new Values(newEvent));
+    }
+
+    @Override
+    public List<Integer> emit(String streamId, Collection<Tuple> anchors, List<Object> tuple) {
+        StreamlineEvent newEvent = injectCorrelationInformation(anchors, tuple);
+        return delegate.emit(streamId, anchors, new Values(newEvent));
+    }
+
+    @Override
+    public void emitDirect(int taskId, String streamId, Tuple anchor, List<Object> tuple) {
+        StreamlineEvent newEvent = injectCorrelationInformation(anchor, tuple);
+        delegate.emitDirect(taskId, streamId, anchor, new Values(newEvent));
+    }
+
+    @Override
+    public void emitDirect(int taskId, String streamId, List<Object> tuple) {
+        StreamlineEvent newEvent = injectCorrelationInformation(tuple);
+        delegate.emitDirect(taskId, streamId, new Values(newEvent));
+    }
+
+    @Override
+    public void emitDirect(int taskId, Collection<Tuple> anchors, List<Object> tuple) {
+        StreamlineEvent newEvent = injectCorrelationInformation(anchors, tuple);
+        delegate.emitDirect(taskId, anchors, new Values(newEvent));
+    }
+
+    @Override
+    public void emitDirect(int taskId, Tuple anchor, List<Object> tuple) {
+        StreamlineEvent newEvent = injectCorrelationInformation(anchor, tuple);
+        delegate.emitDirect(taskId, anchor, new Values(newEvent));
+    }
+
+    @Override
+    public void emitDirect(int taskId, List<Object> tuple) {
+        StreamlineEvent newEvent = injectCorrelationInformation(tuple);
+        delegate.emitDirect(taskId, new Values(newEvent));
+    }
+
+    @Override
+    public void emitDirect(int taskId, String streamId, Collection<Tuple> anchors, List<Object> tuple) {
+        StreamlineEvent newEvent = injectCorrelationInformation(anchors, tuple);
+        delegate.emitDirect(taskId, streamId, anchors, new Values(newEvent));
+    }
+
+    @Override
+    public void ack(Tuple tuple) {
+        delegate.ack(tuple);
+    }
+
+    @Override
+    public void fail(Tuple tuple) {
+        delegate.fail(tuple);
+    }
+
+    @Override
+    public void resetTimeout(Tuple tuple) {
+        delegate.resetTimeout(tuple);
+    }
+
+    @Override
+    public void reportError(Throwable throwable) {
+        delegate.reportError(throwable);
+    }
+
+    private StreamlineEvent injectCorrelationInformation(Tuple anchor, List<Object> tuple) {
+        return eventCorrelationInjector.injectCorrelationInformation(tuple,
+                Collections.singletonList(anchor), topologyContext.getThisComponentId());
+    }
+
+    private StreamlineEvent injectCorrelationInformation(List<Object> tuple) {
+        return eventCorrelationInjector.injectCorrelationInformation(tuple,
+                Collections.emptyList(), topologyContext.getThisComponentId());
+    }
+
+    private StreamlineEvent injectCorrelationInformation(Collection<Tuple> anchors, List<Object> tuple) {
+        return eventCorrelationInjector.injectCorrelationInformation(tuple,
+                new ArrayList<>(anchors), topologyContext.getThisComponentId());
+    }
+
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/EventCorrelatingSpoutOutputCollector.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/EventCorrelatingSpoutOutputCollector.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.streamline.streams.runtime.storm.testing;
+
+import com.hortonworks.streamline.streams.StreamlineEvent;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.tuple.Values;
+
+import java.util.Collections;
+import java.util.List;
+
+public class EventCorrelatingSpoutOutputCollector extends SpoutOutputCollector {
+    private final TopologyContext topologyContext;
+    private final SpoutOutputCollector delegate;
+    private final StormEventCorrelationInjector eventCorrelationInjector;
+
+    public EventCorrelatingSpoutOutputCollector(TopologyContext topologyContext, SpoutOutputCollector delegate) {
+        // we simply ignore the _delegate in OutputCollector and override all of the methods
+        // this will work with subclass of OutputCollector since we only expose methods what we know about
+        super(null);
+        this.topologyContext = topologyContext;
+        this.delegate = delegate;
+        this.eventCorrelationInjector = new StormEventCorrelationInjector();
+    }
+
+
+    @Override
+    public List<Integer> emit(String streamId, List<Object> tuple) {
+        StreamlineEvent newEvent = injectCorrelationInformation(tuple);
+        return delegate.emit(streamId, new Values(newEvent));
+    }
+
+    @Override
+    public List<Integer> emit(List<Object> tuple) {
+        StreamlineEvent newEvent = injectCorrelationInformation(tuple);
+        return delegate.emit(new Values(newEvent));
+    }
+
+    @Override
+    public List<Integer> emit(String streamId, List<Object> tuple, Object messageId) {
+        StreamlineEvent newEvent = injectCorrelationInformation(tuple);
+        return delegate.emit(streamId, new Values(newEvent), messageId);
+    }
+
+    @Override
+    public List<Integer> emit(List<Object> tuple, Object messageId) {
+        StreamlineEvent newEvent = injectCorrelationInformation(tuple);
+        return delegate.emit(new Values(newEvent), messageId);
+    }
+
+    @Override
+    public void emitDirect(int taskId, String streamId, List<Object> tuple) {
+        StreamlineEvent newEvent = injectCorrelationInformation(tuple);
+        delegate.emitDirect(taskId, streamId, new Values(newEvent));
+    }
+
+    @Override
+    public void emitDirect(int taskId, List<Object> tuple) {
+        StreamlineEvent newEvent = injectCorrelationInformation(tuple);
+        delegate.emitDirect(taskId, new Values(newEvent));
+    }
+
+    @Override
+    public void emitDirect(int taskId, String streamId, List<Object> tuple, Object messageId) {
+        StreamlineEvent newEvent = injectCorrelationInformation(tuple);
+        delegate.emitDirect(taskId, streamId, new Values(newEvent), messageId);
+    }
+
+    @Override
+    public void emitDirect(int taskId, List<Object> tuple, Object messageId) {
+        StreamlineEvent newEvent = injectCorrelationInformation(tuple);
+        delegate.emitDirect(taskId, new Values(newEvent), messageId);
+    }
+
+    @Override
+    public void reportError(Throwable throwable) {
+        delegate.reportError(throwable);
+    }
+
+    @Override
+    public long getPendingCount() {
+        return delegate.getPendingCount();
+    }
+
+    private StreamlineEvent injectCorrelationInformation(List<Object> tuple) {
+        return eventCorrelationInjector.injectCorrelationInformation(tuple, Collections.emptyList(),
+                topologyContext.getThisComponentId());
+    }
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/NotificationsTestBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/NotificationsTestBolt.java
@@ -82,7 +82,11 @@ public class NotificationsTestBolt extends BaseTickTupleAwareRichBolt {
             header.put(AddHeaderTransformRuntime.HEADER_FIELD_RULE_ID, 1L);
             header.put(AddHeaderTransformRuntime.HEADER_FIELD_TIMESTAMP, System.currentTimeMillis());
 
-            StreamlineEvent streamlineEvent = new StreamlineEventImpl(fieldsMap, "notificationsTestBolt", header);
+            StreamlineEvent streamlineEvent = StreamlineEventImpl.builder()
+                    .fieldsAndValues(fieldsMap)
+                    .dataSourceId("notificationsTestBolt")
+                    .header(header)
+                    .build();
             collector.emit(consoleNotificationStream, new Values(streamlineEvent));
         }
 
@@ -98,8 +102,11 @@ public class NotificationsTestBolt extends BaseTickTupleAwareRichBolt {
                 header.put(AddHeaderTransformRuntime.HEADER_FIELD_RULE_ID, 1L);
                 header.put(AddHeaderTransformRuntime.HEADER_FIELD_TIMESTAMP, System.currentTimeMillis());
 
-                StreamlineEvent streamlineEvent = new StreamlineEventImpl(fieldsMap, "notificationsTestBolt", header);
-
+                StreamlineEvent streamlineEvent = StreamlineEventImpl.builder()
+                        .fieldsAndValues(fieldsMap)
+                        .dataSourceId("notificationsTestBolt")
+                        .header(header)
+                        .build();
                 collector.emit(emailNotificationStream, new Values(streamlineEvent));
             }
         }

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/OutputCollectorStreamlineEventLogger.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/OutputCollectorStreamlineEventLogger.java
@@ -54,14 +54,13 @@ public class OutputCollectorStreamlineEventLogger {
     }
 
     private void logEvent(String streamId, List<Integer> taskIds, List<Object> tuple) {
+        long now = System.currentTimeMillis();
         StreamlineEvent streamlineEvent = (StreamlineEvent) tuple.get(0);
         for (int taskId : taskIds) {
             String targetComponentId = topologyContext.getComponentId(taskId);
             String targetStreamlineComponentName = StormTopologyUtil.extractStreamlineComponentName(targetComponentId);
-            eventLogger.writeEvent(System.currentTimeMillis(), TestRunEventLogger.EventType.OUTPUT, componentName,
+            eventLogger.writeEvent(now, componentName,
                     streamId, targetStreamlineComponentName, streamlineEvent);
         }
     }
-
-
 }

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/StormEventCorrelationInjector.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/StormEventCorrelationInjector.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.runtime.storm.testing;
+
+import com.hortonworks.streamline.streams.StreamlineEvent;
+import com.hortonworks.streamline.streams.common.event.correlation.EventCorrelationInjector;
+import com.hortonworks.streamline.streams.storm.common.StormTopologyUtil;
+import org.apache.storm.tuple.Tuple;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class StormEventCorrelationInjector {
+
+    public StreamlineEvent injectCorrelationInformation(List<Object> tuple, List<Tuple> parentTuples, String componentName) {
+        EventCorrelationInjector eventCorrelationInjector = new EventCorrelationInjector();
+        return eventCorrelationInjector.injectCorrelationInformation(
+                getStreamlineEventFromValues(tuple),
+                parentTuples.stream().map(this::getStreamlineEventFromTuple).collect(Collectors.toList()),
+                StormTopologyUtil.extractStreamlineComponentName(componentName));
+    }
+
+    private StreamlineEvent getStreamlineEventFromTuple(Tuple tuple) {
+        final Object event = tuple.getValueByField(StreamlineEvent.STREAMLINE_EVENT);
+        if (event instanceof StreamlineEvent) {
+            return (StreamlineEvent) event;
+        }
+
+        throw new IllegalArgumentException("Invalid tuple received. Tuple [" + tuple + "] Event [" + event + "]");
+    }
+
+    private StreamlineEvent getStreamlineEventFromValues(List<Object> tuple) {
+        final Object eventObj = tuple.get(0);
+
+        if (eventObj instanceof StreamlineEvent) {
+            return (StreamlineEvent) eventObj;
+        }
+
+        throw new IllegalArgumentException("Invalid Values received. Values [" + tuple + "] Event [" + eventObj + "]");
+    }
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunEventLogger.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunEventLogger.java
@@ -18,6 +18,9 @@ package com.hortonworks.streamline.streams.runtime.storm.testing;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hortonworks.streamline.streams.StreamlineEvent;
+import com.hortonworks.streamline.streams.common.event.EventInformation;
+import com.hortonworks.streamline.streams.common.event.EventInformationBuilder;
+import com.hortonworks.streamline.streams.common.event.correlation.EventCorrelationInjector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +28,7 @@ import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class TestRunEventLogger {
@@ -58,12 +62,13 @@ public class TestRunEventLogger {
 
     // Writing event to file should be mutually exclusive.
     // We don't need to worry about performance since it's just for testing topology locally.
-    public synchronized void writeEvent(long timestamp, EventType eventType, String componentName,
+    public synchronized void writeEvent(long timestamp, String componentName,
                                         String streamId, String targetComponentName, StreamlineEvent event) {
         try (FileWriter fw = new FileWriter(eventLogFilePath, true)) {
             LOG.debug("writing event to file " + eventLogFilePath);
 
-            EventInformation eventInfo = new EventInformation(timestamp, eventType, componentName, streamId,
+            EventInformationBuilder informationBuilder = new EventInformationBuilder();
+            EventInformation eventInfo = informationBuilder.build(timestamp, componentName, streamId,
                     targetComponentName, event);
             fw.write(objectMapper.writeValueAsString(eventInfo) + "\n");
             fw.flush();
@@ -76,50 +81,4 @@ public class TestRunEventLogger {
         }
     }
 
-    public static enum EventType {
-        INPUT, OUTPUT
-    }
-
-    public static class EventInformation {
-        private long timestamp;
-        private EventType eventType;
-        private String componentName;
-        private String streamId;
-        private String targetComponentName;
-        private StreamlineEvent streamlineEvent;
-
-        public EventInformation(long timestamp, EventType eventType, String componentName, String streamId,
-                                String targetComponentName, StreamlineEvent streamlineEvent) {
-            this.timestamp = timestamp;
-            this.eventType = eventType;
-            this.componentName = componentName;
-            this.streamId = streamId;
-            this.targetComponentName = targetComponentName;
-            this.streamlineEvent = streamlineEvent;
-        }
-
-        public long getTimestamp() {
-            return timestamp;
-        }
-
-        public EventType getEventType() {
-            return eventType;
-        }
-
-        public String getComponentName() {
-            return componentName;
-        }
-
-        public String getStreamId() {
-            return streamId;
-        }
-
-        public String getTargetComponentName() {
-            return targetComponentName;
-        }
-
-        public StreamlineEvent getStreamlineEvent() {
-            return streamlineEvent;
-        }
-    }
 }

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunProcessorBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunProcessorBolt.java
@@ -35,8 +35,10 @@ public class TestRunProcessorBolt extends BaseRichBolt {
 
     @Override
     public void prepare(Map map, TopologyContext topologyContext, OutputCollector outputCollector) {
-        EventLoggingOutputCollector collector = new EventLoggingOutputCollector(topologyContext,
-                outputCollector, TestRunEventLogger.getEventLogger(eventLogFilePath));
+        EventCorrelatingOutputCollector collector = new EventCorrelatingOutputCollector(topologyContext,
+                new EventLoggingOutputCollector(topologyContext, outputCollector,
+                        TestRunEventLogger.getEventLogger(eventLogFilePath))
+        );
         processorBolt.prepare(map, topologyContext, collector);
     }
 

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunWindowProcessorBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunWindowProcessorBolt.java
@@ -23,9 +23,11 @@ import org.apache.storm.topology.base.BaseWindowedBolt;
 import org.apache.storm.windowing.TimestampExtractor;
 import org.apache.storm.windowing.TupleWindow;
 
+import java.lang.reflect.Field;
 import java.util.Map;
 
 public class TestRunWindowProcessorBolt extends BaseWindowedBolt {
+    public static final String OUTPUT_COLLECTOR_FIELD_NAME_DELEGATE = "_delegate";
     private final BaseWindowedBolt processorBolt;
     private final String eventLogFilePath;
 
@@ -41,9 +43,27 @@ public class TestRunWindowProcessorBolt extends BaseWindowedBolt {
 
     @Override
     public void prepare(Map stormConf, TopologyContext context, OutputCollector collector) {
-        EventLoggingOutputCollector outputCollector = new EventLoggingOutputCollector(context, collector,
-                TestRunEventLogger.getEventLogger(eventLogFilePath));
-        processorBolt.prepare(stormConf, context, outputCollector);
+        // we're going with hack
+        wrapEventCorrelatingOutputCollectorIntoDelegateCollector(context, collector);
+        processorBolt.prepare(stormConf, context, collector);
+    }
+
+    private void wrapEventCorrelatingOutputCollectorIntoDelegateCollector(TopologyContext context,
+        OutputCollector collector) {
+        try {
+            Field delegateField = OutputCollector.class.getDeclaredField(OUTPUT_COLLECTOR_FIELD_NAME_DELEGATE);
+            delegateField.setAccessible(true);
+            OutputCollector delegateCollector = (OutputCollector) delegateField.get(collector);
+
+            EventCorrelatingOutputCollector newCollector = new EventCorrelatingOutputCollector(context,
+                new EventLoggingOutputCollector(context, delegateCollector,
+                    TestRunEventLogger.getEventLogger(eventLogFilePath))
+            );
+
+            delegateField.set(collector, newCollector);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/CustomProcessorBoltTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/CustomProcessorBoltTest.java
@@ -140,7 +140,7 @@ public class CustomProcessorBoltTest {
         customProcessorBolt.inputSchema(inputSchema);
         Map<String, Object> data = new HashMap<>();
         data.put("key", "value");
-        final StreamlineEvent event = new StreamlineEventImpl(data, "dsrcid");
+        final StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(data).dataSourceId("dsrcid").build();
         final List<StreamlineEvent> result =  Arrays.asList(event);
         final ProcessingException pe = new ProcessingException("Test");
         new Expectations() {{

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/StreamsShellBoltTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/StreamsShellBoltTest.java
@@ -111,7 +111,7 @@ public class StreamsShellBoltTest {
             mockContext.getCodeDir();
             result = "/tmp";
             mockContext.getThisComponentId();
-            result = "dsrid";
+            result = "dsrid"; minTimes = 0;
         }};
     }
 
@@ -121,7 +121,9 @@ public class StreamsShellBoltTest {
     }
 
     private Tuple getNextTuple(int i) {
-        StreamlineEvent event = new StreamlineEventImpl(ImmutableMap.<String, Object>of("sentence", "THIS IS RANDOM SENTENCE"+ i), "dsrcid");
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(
+                ImmutableMap.of("sentence", "THIS IS RANDOM SENTENCE"+ i)
+        ).dataSourceId("dsrcid").build();
         return new TupleImpl(mockContext, new Values(event), 1, "inputstream");
     }
 

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/kafka/StreamlineEventSerializerTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/kafka/StreamlineEventSerializerTest.java
@@ -73,12 +73,12 @@ public class StreamlineEventSerializerTest {
         }
         expected.put("fixed", new GenericData.Fixed(Schema.createFixed("fixedSchema", null, null, 10), "bytes".getBytes()));
         expected.put("array", new GenericData.Array<Integer>(Schema.createArray(Schema.create(Schema.Type.INT)), integerList));
-        StreamlineEvent streamlineEvent = new StreamlineEventImpl(data, "dataSourceId");
+        StreamlineEvent streamlineEvent = StreamlineEventImpl.builder().fieldsAndValues(data).dataSourceId("dataSourceId").build();
         Assert.assertEquals(expected, StreamlineEventSerializer.getAvroRecord(streamlineEvent, schema));
     }
 
     private void runPrimitiveTest (Map data, Schema schema, Object expectedValue) {
-        StreamlineEvent streamlineEvent = new StreamlineEventImpl(data, "dataSourceId");
+        StreamlineEvent streamlineEvent = StreamlineEventImpl.builder().fieldsAndValues(data).dataSourceId("dataSourceId").build();
         Assert.assertEquals(expectedValue, StreamlineEventSerializer.getAvroRecord(streamlineEvent, schema));
     }
 

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/notification/NotificationBoltTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/notification/NotificationBoltTest.java
@@ -162,7 +162,10 @@ public class NotificationBoltTest {
         Map<String, Object> fieldsAndValues = new HashMap<>();
         fieldsAndValues.put("foo", "100");
         fieldsAndValues.put("bar", "200");
-        final StreamlineEvent event = new StreamlineEventImpl(fieldsAndValues, "srcid");
+        final StreamlineEvent event = StreamlineEventImpl.builder()
+                .fieldsAndValues(fieldsAndValues)
+                .dataSourceId("srcid")
+                .build();
         NotificationBolt consoleNotificationBolt = new NotificationBolt(new NotificationSink() {
             @Override
             public String getNotifierName() {
@@ -227,7 +230,10 @@ public class NotificationBoltTest {
 
         Map<String, Object> fieldsAndValues = new HashMap<>();
         fieldsAndValues.put("temperature", "100");
-        final StreamlineEvent event = new StreamlineEventImpl(fieldsAndValues, "srcid");
+        final StreamlineEvent event = StreamlineEventImpl.builder()
+                .fieldsAndValues(fieldsAndValues)
+                .dataSourceId("srcid")
+                .build();
         final Notification notification = new StreamlineEventAdapter(event);
         new MockUp<NotificationQueueHandler>() {
             @Mock
@@ -267,7 +273,10 @@ public class NotificationBoltTest {
 
         Map<String, Object> fieldsAndValues = new HashMap<>();
         fieldsAndValues.put("foobar", "100");
-        final StreamlineEvent event = new StreamlineEventImpl(fieldsAndValues, "srcid");
+        final StreamlineEvent event = StreamlineEventImpl.builder()
+                .fieldsAndValues(fieldsAndValues)
+                .dataSourceId("srcid")
+                .build();
         final Notification notification = new StreamlineEventAdapter(event);
 
         new MockUp<NotificationQueueHandler>() {

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/TestRealtimeJoinBolt.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/TestRealtimeJoinBolt.java
@@ -18,12 +18,16 @@
 
 package com.hortonworks.streamline.streams.runtime.storm.bolt.query;
 
+import clojure.lang.Atom;
 import com.hortonworks.streamline.streams.StreamlineEvent;
 import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
 import com.hortonworks.streamline.streams.runtime.storm.bolt.query.RealtimeJoinBolt.StreamKind;
 import org.apache.storm.Constants;
+import org.apache.storm.generated.StormTopology;
+import org.apache.storm.metric.api.IMetric;
 import org.apache.storm.task.GeneralTopologyContext;
 import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.base.BaseWindowedBolt;
 import org.apache.storm.tuple.*;
 import org.junit.Assert;
@@ -72,8 +76,9 @@ public class TestRealtimeJoinBolt {
                 .innerJoin("ads", 10, false, Cmp.equal("userId", "orders:userId") )
                 .select("ads:id,orders:id,ads:userId,ads:product,orders:product,price");
 
+        MockTopologyContext context = new MockTopologyContext(bolt.getOutputFields());
         MockCollector collector = new MockCollector(bolt.getOutputFields());
-        bolt.prepare(null, null, collector);
+        bolt.prepare(null, context, collector);
 
         for (Tuple tuple : adImpressionStream) {
             bolt.execute(tuple);
@@ -96,8 +101,9 @@ public class TestRealtimeJoinBolt {
                 .innerJoin("ads", Duration.ofSeconds(2), false, Cmp.equal("userId", "orders:userId"))
                 .select("ads:id,orders:id,userId,ads:product,orders:product,price");
 
+        MockTopologyContext context = new MockTopologyContext(bolt.getOutputFields());
         MockCollector collector = new MockCollector(bolt.getOutputFields());
-        bolt.prepare(null, null, collector);
+        bolt.prepare(null, context, collector);
 
         for (Tuple tuple : adImpressionStream) {
             bolt.execute(tuple);
@@ -125,8 +131,9 @@ public class TestRealtimeJoinBolt {
                 .innerJoin("ads", Duration.ofSeconds(2), true, Cmp.equal("userId", "orders:userId"))
                 .select("ads:id,orders:id,userId,ads:product,orders:product,price");
 
+        MockTopologyContext context = new MockTopologyContext(bolt.getOutputFields());
         MockCollector collector = new MockCollector(bolt.getOutputFields());
-        bolt.prepare(null, null, collector);
+        bolt.prepare(null, context, collector);
 
         for (Tuple tuple : adImpressionStream) {
             bolt.execute(tuple);
@@ -147,7 +154,7 @@ public class TestRealtimeJoinBolt {
 
     // adds rec to streamRecs
     private static void appendToStream(ArrayList<Tuple> streamRecs, Object[] rec, String[] fieldNames, String streamName) {
-        streamRecs.add( new TupleImpl(new MockContext(fieldNames), Arrays.asList(rec), 0, streamName) );
+        streamRecs.add( new TupleImpl(new MockTopologyContext(fieldNames), Arrays.asList(rec), 0, streamName) );
     }
 
     @Test
@@ -160,8 +167,9 @@ public class TestRealtimeJoinBolt {
                 .leftJoin("orders", 12, false,  Cmp.equal("userId", "ads:userId"))
                 .select("ads:id, orders:id , ads:userId , ads:product , orders:product , price");
 
+        MockTopologyContext context = new MockTopologyContext(bolt.getOutputFields());
         MockCollector collector = new MockCollector(bolt.getOutputFields());
-        bolt.prepare(null, null, collector);
+        bolt.prepare(null, context, collector);
 
         for (Tuple tuple : orderStream) {
             bolt.execute(tuple);
@@ -184,8 +192,9 @@ public class TestRealtimeJoinBolt {
                 .leftJoin("orders", Duration.ofSeconds(2), false,  Cmp.equal("userId", "ads:userId"))
                 .select("ads:id, orders:id , ads:userId , ads:product , orders:product , price");
 
+        MockTopologyContext context = new MockTopologyContext(bolt.getOutputFields());
         MockCollector collector = new MockCollector(bolt.getOutputFields());
-        bolt.prepare(null, null, collector);
+        bolt.prepare(null, context, collector);
 
         for (Tuple tuple : orderStream) {
             bolt.execute(tuple);
@@ -211,8 +220,9 @@ public class TestRealtimeJoinBolt {
                 .rightJoin("orders", Duration.ofSeconds(1), false, Cmp.equal("userId", "ads:userId"))
                 .select(" orders:id, ads:userId, ads:product, orders:product, price ");
 
+        MockTopologyContext context = new MockTopologyContext(bolt.getOutputFields());
         MockCollector collector = new MockCollector(bolt.getOutputFields());
-        bolt.prepare(null, null, collector);
+        bolt.prepare(null, context, collector);
 
         for (Tuple tuple : orderStream) {
             bolt.execute(tuple);
@@ -245,8 +255,9 @@ public class TestRealtimeJoinBolt {
                 // extra spaces in arg to select() are to test FieldDescriptor
                 .select(" ads:id, orders:id as orderId, ads:userId  as  userId ,ads:product, orders:product, price ");
 
+        MockTopologyContext context = new MockTopologyContext(bolt.getOutputFields());
         MockCollector collector = new MockCollector(bolt.getOutputFields());
-        bolt.prepare(null, null, collector);
+        bolt.prepare(null, context, collector);
 
         for (Tuple tuple : orderStream) {
             bolt.execute(tuple);
@@ -276,8 +287,9 @@ public class TestRealtimeJoinBolt {
                                            , Cmp.ignoreCase("ads:product","orders:product"))
                 .select("orders:id,ads:userId,ads:product,orders:product,price");
 
+        MockTopologyContext context = new MockTopologyContext(bolt.getOutputFields());
         MockCollector collector = new MockCollector(bolt.getOutputFields());
-        bolt.prepare(null, null, collector);
+        bolt.prepare(null, context, collector);
 
         for (Tuple tuple : adImpressionStream) {
             bolt.execute(tuple);
@@ -301,8 +313,9 @@ public class TestRealtimeJoinBolt {
                                                               , Cmp.ignoreCase("ads:product","orders:product") )
                 .select("orders:id,ads:userId,product,price");
 
+        MockTopologyContext context = new MockTopologyContext(bolt.getOutputFields());
         MockCollector collector = new MockCollector(bolt.getOutputFields());
-        bolt.prepare(null, null, collector);
+        bolt.prepare(null, context, collector);
 
         for (Tuple tuple : adImpressionStream) {
             bolt.execute(tuple);
@@ -328,8 +341,9 @@ public class TestRealtimeJoinBolt {
                                                               , SLCmp.ignoreCase("ads:product","orders:product") )
                 .select("orders:id,ads:userId,product,price");
 
+        MockTopologyContext context = new MockTopologyContext(bolt.getOutputFields());
         MockCollector collector = new MockCollector(bolt.getOutputFields());
-        bolt.prepare(null, null, collector);
+        bolt.prepare(null, context, collector);
 
         for (Tuple tuple : adImpressionStream) {
             bolt.execute(tuple);
@@ -347,7 +361,7 @@ public class TestRealtimeJoinBolt {
 
     private static ArrayList<Tuple> makeStream(String streamName, String[] fieldNames, Object[][] data) {
         ArrayList<Tuple> result = new ArrayList<>();
-        MockContext mockContext = new MockContext(fieldNames);
+        MockTopologyContext mockContext = new MockTopologyContext(fieldNames);
 
         for (Object[] record : data) {
             TupleImpl rec = new TupleImpl(mockContext, Arrays.asList(record), 0, streamName);
@@ -360,7 +374,7 @@ public class TestRealtimeJoinBolt {
     // NOTE: Streamline Specific
     private static ArrayList<Tuple> makeStreamLineEventStream (String streamName, String[] fieldNames, Object[][] records) {
 
-        MockContext mockContext = new MockContext(new String[]{StreamlineEvent.STREAMLINE_EVENT} );
+        MockTopologyContext mockContext = new MockTopologyContext(new String[]{StreamlineEvent.STREAMLINE_EVENT} );
         ArrayList<Tuple> result = new ArrayList<>(records.length);
 
         // convert each record into a HashMap using fieldNames as keys
@@ -369,7 +383,10 @@ public class TestRealtimeJoinBolt {
             for (int i = 0; i < fieldNames.length; i++) {
                 recordMap.put(fieldNames[i], record[i]);
             }
-            StreamlineEvent streamLineEvent = new StreamlineEventImpl(recordMap, "multiple sources");
+            StreamlineEvent streamLineEvent = StreamlineEventImpl.builder()
+                    .fieldsAndValues(recordMap)
+                    .dataSourceId("multiple sources")
+                    .build();
             ArrayList<Object> tupleValues = new ArrayList<>(1);
             tupleValues.add(streamLineEvent);
             TupleImpl tuple = new TupleImpl(mockContext, tupleValues, 0, streamName);
@@ -439,22 +456,28 @@ public class TestRealtimeJoinBolt {
         }
     } // class MockCollector
 
-    static class MockContext extends GeneralTopologyContext {
+    static class MockTopologyContext extends TopologyContext {
 
         private final Fields fields;
         private String srcComponentId = "component";
 
-        public MockContext(String[] fieldNames) {
-            super(null, null, null, null, null, null);
+        public MockTopologyContext(String[] fieldNames) {
+            super(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
             this.fields = new Fields(fieldNames);
         }
 
-        public MockContext(String[] fieldNames, String srcComponentId) {
-            super(null, null, null, null, null, null);
+        public MockTopologyContext(String[] fieldNames, String srcComponentId) {
+            super(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
             this.fields = new Fields(fieldNames);
             this.srcComponentId = srcComponentId;
         }
 
+        @Override
+        public String getThisComponentId() {
+            return srcComponentId;
+        }
+
+        @Override
         public String getComponentId(int taskId) {
             return srcComponentId;
         }
@@ -462,11 +485,10 @@ public class TestRealtimeJoinBolt {
         public Fields getComponentOutputFields(String componentId, String streamId) {
             return fields;
         }
-
     }
 
     public Tuple makeTickTuple() {
-        MockContext context = new MockContext(new String[]{StreamlineEvent.STREAMLINE_EVENT}, Constants.SYSTEM_COMPONENT_ID );
+        MockTopologyContext context = new MockTopologyContext(new String[]{StreamlineEvent.STREAMLINE_EVENT}, Constants.SYSTEM_COMPONENT_ID );
 
         return new TupleImpl(context, new Values(1000), (int) Constants.SYSTEM_TASK_ID, Constants.SYSTEM_TICK_STREAM_ID);
     }

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/FunctionsTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/FunctionsTest.java
@@ -45,6 +45,8 @@ public class FunctionsTest {
             result = new Fields(StreamlineEvent.STREAMLINE_EVENT);
             mockContext.getComponentId(anyInt);
             result = "componentid";
+            mockContext.getThisComponentId();
+            result = "componentid"; minTimes = 0;
         }};
     }
 
@@ -176,7 +178,7 @@ public class FunctionsTest {
         map.put("stringfield4", "aaaa");
         map.put("negativefield", -1.0);
         map.put("doublefield", 1.41);
-        StreamlineEvent event = new StreamlineEventImpl(map, "dsrcid");
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(map).dataSourceId("dsrcid").build();
         return new TupleImpl(mockContext, new Values(event), 1, "inputstream");
     }
 

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/RulesBoltConditionTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/RulesBoltConditionTest.java
@@ -58,6 +58,8 @@ public class RulesBoltConditionTest {
             result = new Fields(StreamlineEvent.STREAMLINE_EVENT);
             mockContext.getComponentId(anyInt);
             result = "componentid";
+            mockContext.getThisComponentId();
+            result = "componentid"; minTimes = 0;
         }};
     }
 
@@ -109,7 +111,10 @@ public class RulesBoltConditionTest {
 
     @Test
     public void testSimpleRuleStringLiteral() throws Exception {
-        StreamlineEvent event = new StreamlineEventImpl(ImmutableMap.<String, Object>of("foo", "Normal", "bar", "abc", "baz", 200), "dsrcid");
+        StreamlineEvent event = StreamlineEventImpl.builder()
+                .fieldsAndValues(ImmutableMap.<String, Object>of("foo", "Normal", "bar", "abc", "baz", 200))
+                .dataSourceId("dsrcid")
+                .build();
         Tuple tuple = new TupleImpl(mockContext, new Values(event), 1, "inputstream");
 
         doTest(readFile("/simple-rule-string-literal.json"), tuple);
@@ -172,7 +177,10 @@ public class RulesBoltConditionTest {
     }
 
     private Tuple getTuple(int i) {
-        StreamlineEvent event = new StreamlineEventImpl(ImmutableMap.<String, Object>of("foo", i, "bar", 100, "baz", 200), "dsrcid");
+        StreamlineEvent event = StreamlineEventImpl.builder()
+                .fieldsAndValues(ImmutableMap.of("foo", i, "bar", 100, "baz", 200))
+                .dataSourceId("dsrcid")
+                .build();
         return new TupleImpl(mockContext, new Values(event), 1, "inputstream");
     }
 

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/RulesBoltTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/RulesBoltTest.java
@@ -29,6 +29,7 @@ import mockit.Tested;
 import mockit.VerificationsInOrder;
 import mockit.integration.junit4.JMockit;
 import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
 import org.junit.Assert;
@@ -58,33 +59,42 @@ public abstract class RulesBoltTest extends RulesTopologyTest {
     };
 
     // Only one rule triggers with these values for temperature, humidity
-    private static final StreamlineEvent STREAMLINE_EVENT_MATCHES_TUPLE = new StreamlineEventImpl(new HashMap<String, Object>() {{
-        put(RulesProcessorMock.TEMPERATURE, 101);
-        put(RulesProcessorMock.HUMIDITY, 51);
-    }}, "dataSrcId_1", "1");
+    private static final StreamlineEvent STREAMLINE_EVENT_MATCHES_TUPLE = StreamlineEventImpl.builder()
+            .fieldsAndValues(new HashMap<String, Object>() {{
+                put(RulesProcessorMock.TEMPERATURE, 101);
+                put(RulesProcessorMock.HUMIDITY, 51);
+            }})
+            .dataSourceId("dataSrcId_1")
+            .build();
 
     private static final Values STREAMLINE_EVENT_MATCHES_TUPLE_VALUES = new Values(STREAMLINE_EVENT_MATCHES_TUPLE);
 
-    private static final StreamlineEvent STREAMLINE_EVENT_NO_MATCH_TUPLE = new StreamlineEventImpl(new HashMap<String, Object>() {{
-        put("non_existent_field1", 101);
-        put("non_existent_field2", 51);
-        put("non_existent_field3", 23);
-    }}, "dataSrcId_2", "2");
+    private static final StreamlineEvent STREAMLINE_EVENT_NO_MATCH_TUPLE = StreamlineEventImpl.builder()
+            .fieldsAndValues(new HashMap<String, Object>() {{
+                put("non_existent_field1", 101);
+                put("non_existent_field2", 51);
+                put("non_existent_field3", 23);
+            }})
+            .dataSourceId("dataSrcId_2")
+            .build();
 
     // Only one rule triggers with these values for temperature, humidity. Other fields are disregarded
-    private static final StreamlineEvent STREAMLINE_EVENT_MATCH_AND_NO_MATCH_TUPLE = new StreamlineEventImpl(new HashMap<String, Object>() {{
-        put("non_existent_field1", 101);
-        put(RulesProcessorMock.TEMPERATURE, 101);
-        put("non_existent_field2", 51);
-        put(RulesProcessorMock.HUMIDITY, 51);
-        put("non_existent_field3", 23);
-    }}, "dataSrcId_2", "3");
+    private static final StreamlineEvent STREAMLINE_EVENT_MATCH_AND_NO_MATCH_TUPLE = StreamlineEventImpl.builder()
+            .fieldsAndValues(new HashMap<String, Object>() {{
+                put("non_existent_field1", 101);
+                put(RulesProcessorMock.TEMPERATURE, 101);
+                put("non_existent_field2", 51);
+                put(RulesProcessorMock.HUMIDITY, 51);
+                put("non_existent_field3", 23);
+            }}).dataSourceId("dataSrcId_2")
+            .build();
 
     private static final Values STREAMLINE_EVENT_MATCH_AND_NO_MATCH_TUPLE_VALUES = new Values(STREAMLINE_EVENT_MATCH_AND_NO_MATCH_TUPLE);
 
-    protected  @Tested RulesBolt rulesBolt;
-    protected  @Injectable OutputCollector mockOutputCollector;
-    protected  @Injectable Tuple mockTuple;
+    protected @Tested RulesBolt rulesBolt;
+    protected @Injectable OutputCollector mockOutputCollector;
+    protected @Injectable Tuple mockTuple;
+    protected @Injectable TopologyContext mockContext;
     protected RulesProcessor rulesProcessor;
 
     @Before

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/WindowRulesBoltTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/WindowRulesBoltTest.java
@@ -68,6 +68,8 @@ public class WindowRulesBoltTest {
             result = new Fields(StreamlineEvent.STREAMLINE_EVENT);
             mockContext.getComponentId(anyInt);
             result = "componentid";
+            mockContext.getThisComponentId();
+            result = "componentid"; minTimes = 0;
         }};
     }
 
@@ -259,12 +261,16 @@ public class WindowRulesBoltTest {
     }
 
     private Tuple getNextTuple(int i) {
-        StreamlineEvent event = new StreamlineEventImpl(ImmutableMap.<String, Object>of("empid", i, "salary", i * 10, "deptid", i/5), "dsrcid");
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(
+                ImmutableMap.of("empid", i, "salary", i * 10, "deptid", i/5)
+        ).dataSourceId("dsrcid").build();
         return new TupleImpl(mockContext, new Values(event), 1, "inputstream");
     }
 
     private Tuple getTupleForSum(int i) {
-        StreamlineEvent event = new StreamlineEventImpl(ImmutableMap.<String, Object>of("id", 1, "intField", i, "longField", (long) i, "doubleField", (double)i), "dsrcid");
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(
+                ImmutableMap.of("id", 1, "intField", i, "longField", (long) i, "doubleField", (double)i)
+        ).dataSourceId("dsrcid").build();
         return new TupleImpl(mockContext, new Values(event), 1, "inputstream");
     }
 }

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/grouping/FieldsGroupingAsCustomGroupingTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/grouping/FieldsGroupingAsCustomGroupingTest.java
@@ -20,7 +20,7 @@ public class FieldsGroupingAsCustomGroupingTest {
         FieldsGroupingAsCustomGrouping fg = new FieldsGroupingAsCustomGrouping(Collections.singletonList("A"));
         Map<String, Object> keyValues = Collections.singletonMap("A", "PUFPaY9KxDAcGqfsorJp1R");
         fg.prepare(null, null, Arrays.asList(0, 1));
-        List<Integer> res = fg.chooseTasks(0, Collections.singletonList(new StreamlineEventImpl(keyValues, "srcID")));
+        List<Integer> res = fg.chooseTasks(0, Collections.singletonList(StreamlineEventImpl.builder().fieldsAndValues(keyValues).dataSourceId("srcID").build()));
         Assert.assertEquals(1, res.size());
         Assert.assertTrue(res.get(0) == 0 || res.get(0) == 1);
     }

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/hbase/StreamlineEventHBaseMapperTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/hbase/StreamlineEventHBaseMapperTest.java
@@ -37,13 +37,15 @@ import static com.google.common.base.Charsets.UTF_8;
 @RunWith(JMockit.class)
 public class StreamlineEventHBaseMapperTest {
 
-    private static final String ROW_KEY_FIELD = "rowKey";
     private static final String COLUMN_FAMILY= "columnFamily";
     private static final String COLUMN_FIELD= "columnField";
     private static final Map<String, Object> TEST_PARSED_MAP = new HashMap<String, Object>() {{
        put(COLUMN_FIELD, COLUMN_FIELD);
     }};
-    private static final StreamlineEvent TEST_EVENT = new StreamlineEventImpl(TEST_PARSED_MAP, "dsrcid1", ROW_KEY_FIELD);
+    private static final StreamlineEvent TEST_EVENT = StreamlineEventImpl.builder()
+            .fieldsAndValues(TEST_PARSED_MAP)
+            .dataSourceId("dsrcid1")
+            .build();
 
 
     private StreamlineEventHBaseMapper mapper = new StreamlineEventHBaseMapper(COLUMN_FAMILY);
@@ -59,7 +61,7 @@ public class StreamlineEventHBaseMapperTest {
     @Test
     public void testMapper() {
         byte[] bytes = mapper.rowKey(mockTuple);
-        Assert.assertTrue(Arrays.equals(ROW_KEY_FIELD.getBytes(UTF_8), bytes));
+        Assert.assertTrue(Arrays.equals(TEST_EVENT.getId().getBytes(UTF_8), bytes));
 
         ColumnList columns = mapper.columns(mockTuple);
         Assert.assertEquals(1, columns.getColumns().size());

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/hdfs/IdentityHdfsRecordFormatTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/hdfs/IdentityHdfsRecordFormatTest.java
@@ -32,7 +32,7 @@ import java.util.HashMap;
 @RunWith(JMockit.class)
 public class IdentityHdfsRecordFormatTest {
 
-    private static final StreamlineEvent STREAMLINEEVENT = new StreamlineEventImpl(new HashMap<>(), "id");
+    private static final StreamlineEvent STREAMLINEEVENT = StreamlineEventImpl.builder().fieldsAndValues(new HashMap<>()).build();
     private static final byte[] TEST_BYTES_RESULT = (STREAMLINEEVENT.toString() + "\n").getBytes();
 
     private IdentityHdfsRecordFormat format = new IdentityHdfsRecordFormat();

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/layout/runtime/rule/topology/RulesTestSpout.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/layout/runtime/rule/topology/RulesTestSpout.java
@@ -41,15 +41,21 @@ public class RulesTestSpout extends BaseRichSpout {
 
     private SpoutOutputCollector collector;
 
-    public static final StreamlineEventImpl STREAMLINE_EVENT_1 = new StreamlineEventImpl(new HashMap<String, Object>() {{
-        put("temperature", 101);
-        put("humidity", 51);
-    }}, "dataSrcId_1", "23");
+    public static final StreamlineEventImpl STREAMLINE_EVENT_1 = StreamlineEventImpl.builder()
+            .fieldsAndValues(new HashMap<String, Object>() {{
+                put("temperature", 101);
+                put("humidity", 51);
+            }})
+            .dataSourceId("dataSrcId_1")
+            .build();
 
-    public static final StreamlineEventImpl STREAMLINE_EVENT_2 = new StreamlineEventImpl(new HashMap<String, Object>() {{
-        put("temperature", 99);
-        put("humidity", 49);
-    }}, "dataSrcId_2", "24");
+    public static final StreamlineEventImpl STREAMLINE_EVENT_2 = StreamlineEventImpl.builder()
+            .fieldsAndValues(new HashMap<String, Object>() {{
+                put("temperature", 99);
+                put("humidity", 49);
+            }})
+            .dataSourceId("dataSrcId_2")
+            .build();
 
     private static final List<Values> LIST_VALUES = Lists.newArrayList(new Values(STREAMLINE_EVENT_1), new Values(STREAMLINE_EVENT_2));
 

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/testing/EventCorrelatingOutputCollectorTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/testing/EventCorrelatingOutputCollectorTest.java
@@ -1,0 +1,429 @@
+package com.hortonworks.streamline.streams.runtime.storm.testing;
+
+import com.google.common.collect.Lists;
+import com.hortonworks.streamline.streams.StreamlineEvent;
+import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
+import com.hortonworks.streamline.streams.common.event.correlation.EventCorrelationInjector;
+import com.hortonworks.streamline.streams.runtime.utils.StreamlineEventTestUtil;
+import mockit.Deencapsulation;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Verifications;
+import mockit.integration.junit4.JMockit;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.TupleImpl;
+import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.Utils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(JMockit.class)
+public class EventCorrelatingOutputCollectorTest {
+    private static final String TEST_COMPONENT_NAME_FOR_STORM = "1-testComponent";
+    private static final String TEST_TARGET_COMPONENT_FOR_TASK_0_FOR_STORM = "0-testTargetComponent0";
+    private static final int TASK_0 = 0;
+    private static final int TASK_1 = 1;
+    private static final int TASK_2 = 2;
+
+    @Injectable
+    private TopologyContext mockedTopologyContext;
+
+    @Injectable
+    private OutputCollector mockedOutputCollector;
+
+    private StormEventCorrelationInjector mockStormEventCorrelationInjector = new StormEventCorrelationInjector();
+
+    private EventCorrelationInjector eventCorrelationInjector = new EventCorrelationInjector();
+
+    private EventCorrelatingOutputCollector sut;
+
+    public static final StreamlineEventImpl INPUT_STREAMLINE_EVENT = StreamlineEventImpl.builder()
+            .fieldsAndValues(new HashMap<String, Object>() {{
+                put("illuminance", 70);
+                put("temp", 104);
+                put("foo", 100);
+                put("humidity", "40h");
+            }})
+            .dataSourceId("ds-" + System.currentTimeMillis())
+            .build();
+
+    public static final StreamlineEventImpl PARENT_STREAMLINE_EVENT = StreamlineEventImpl.builder()
+            .from(INPUT_STREAMLINE_EVENT)
+            .build();
+
+    @Test
+    public void emit() throws Exception {
+        setupExpectationsForTuple();
+        setupExpectationsForTopologyContextEmit();
+        setupExpectationsForEventCorrelationInjector();
+
+        sut = new EventCorrelatingOutputCollector(mockedTopologyContext, mockedOutputCollector);
+        Deencapsulation.setField(sut, "eventCorrelationInjector", mockStormEventCorrelationInjector);
+
+        StreamlineEvent parentEvent = eventCorrelationInjector.injectCorrelationInformation(
+                PARENT_STREAMLINE_EVENT, Collections.emptyList(), TEST_COMPONENT_NAME_FOR_STORM);
+        Tuple anchor = new TupleImpl(mockedTopologyContext, new Values(parentEvent), TASK_0,
+                Utils.DEFAULT_STREAM_ID);
+
+        String testStreamId = "testStreamId";
+        List<Integer> expectedTasks = Lists.newArrayList(TASK_1, TASK_2);
+        final List<Tuple> anchors = Collections.singletonList(anchor);
+        final Values tuple = new Values(INPUT_STREAMLINE_EVENT);
+
+        // String streamId, Tuple anchor, List<Object> anchor
+        new Expectations() {{
+            mockedOutputCollector.emit(testStreamId, anchor, withAny(tuple));
+            result = expectedTasks;
+        }};
+
+        List<Integer> tasks = sut.emit(testStreamId, anchor, tuple);
+        assertEquals(expectedTasks, tasks);
+
+        new Verifications() {{
+            List<Object> capturedValues;
+            mockedOutputCollector.emit(testStreamId, anchor, capturedValues = withCapture());
+            StreamlineEventTestUtil.assertEventIsProperlyCopied((StreamlineEvent) capturedValues.get(0), INPUT_STREAMLINE_EVENT);
+
+            List<Tuple> capturedParents;
+            mockStormEventCorrelationInjector.injectCorrelationInformation(tuple,
+                    capturedParents = withCapture(), TEST_COMPONENT_NAME_FOR_STORM);
+            assertEquals(1, capturedParents.size());
+            assertEquals(anchor, capturedParents.get(0));
+        }};
+
+        // String streamId, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emit(testStreamId, withAny(tuple));
+            result = expectedTasks;
+        }};
+
+        tasks = sut.emit(testStreamId, tuple);
+        assertEquals(expectedTasks, tasks);
+
+        new Verifications() {{
+            List<Object> capturedValues;
+            mockedOutputCollector.emit(testStreamId, capturedValues = withCapture());
+            StreamlineEventTestUtil.assertEventIsProperlyCopied((StreamlineEvent) capturedValues.get(0), INPUT_STREAMLINE_EVENT);
+
+            List<Tuple> capturedParents;
+            mockStormEventCorrelationInjector.injectCorrelationInformation(tuple,
+                    capturedParents = withCapture(), TEST_COMPONENT_NAME_FOR_STORM);
+            assertEquals(0, capturedParents.size());
+        }};
+
+        // Collection<Tuple> anchors, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emit(anchors, withAny(tuple));
+            result = expectedTasks;
+        }};
+
+        tasks = sut.emit(anchors, tuple);
+        assertEquals(expectedTasks, tasks);
+
+        new Verifications() {{
+            List<Object> capturedValues;
+            mockedOutputCollector.emit(anchors, capturedValues = withCapture());
+            StreamlineEventTestUtil.assertEventIsProperlyCopied((StreamlineEvent) capturedValues.get(0), INPUT_STREAMLINE_EVENT);
+
+            List<Tuple> capturedParents;
+            mockStormEventCorrelationInjector.injectCorrelationInformation(tuple,
+                    capturedParents = withCapture(), TEST_COMPONENT_NAME_FOR_STORM);
+            assertEquals(1, capturedParents.size());
+            assertEquals(anchor, capturedParents.get(0));
+        }};
+
+        // Tuple anchor, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emit(anchor, withAny(tuple));
+            result = expectedTasks;
+        }};
+
+        tasks = sut.emit(anchor, tuple);
+        assertEquals(expectedTasks, tasks);
+
+        new Verifications() {{
+            List<Object> capturedValues;
+            mockedOutputCollector.emit(anchor, capturedValues = withCapture());
+            StreamlineEventTestUtil.assertEventIsProperlyCopied((StreamlineEvent) capturedValues.get(0), INPUT_STREAMLINE_EVENT);
+
+            List<Tuple> capturedParents;
+            mockStormEventCorrelationInjector.injectCorrelationInformation(tuple,
+                    capturedParents = withCapture(), TEST_COMPONENT_NAME_FOR_STORM);
+            assertEquals(1, capturedParents.size());
+            assertEquals(anchor, capturedParents.get(0));
+        }};
+
+        // List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emit(withAny(tuple));
+            result = expectedTasks;
+        }};
+
+        tasks = sut.emit(tuple);
+        assertEquals(expectedTasks, tasks);
+
+        new Verifications() {{
+            List<Object> capturedValues;
+            mockedOutputCollector.emit(capturedValues = withCapture());
+            StreamlineEventTestUtil.assertEventIsProperlyCopied((StreamlineEvent) capturedValues.get(0), INPUT_STREAMLINE_EVENT);
+
+            List<Tuple> capturedParents;
+            mockStormEventCorrelationInjector.injectCorrelationInformation(tuple,
+                    capturedParents = withCapture(), TEST_COMPONENT_NAME_FOR_STORM);
+            assertEquals(0, capturedParents.size());
+        }};
+
+        // String streamId, Collection<Tuple> anchors, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emit(testStreamId, anchors, withAny(tuple));
+            result = expectedTasks;
+        }};
+
+        tasks = sut.emit(testStreamId, anchors, tuple);
+        assertEquals(expectedTasks, tasks);
+
+        new Verifications() {{
+            List<Object> capturedValues;
+            mockedOutputCollector.emit(testStreamId, anchors, capturedValues = withCapture());
+            StreamlineEventTestUtil.assertEventIsProperlyCopied((StreamlineEvent) capturedValues.get(0), INPUT_STREAMLINE_EVENT);
+
+            List<Tuple> capturedParents;
+            mockStormEventCorrelationInjector.injectCorrelationInformation(tuple,
+                    capturedParents = withCapture(), TEST_COMPONENT_NAME_FOR_STORM);
+            assertEquals(1, capturedParents.size());
+            assertEquals(anchor, capturedParents.get(0));
+        }};
+
+    }
+
+    @Test
+    public void emitDirect() throws Exception {
+        setupExpectationsForTuple();
+        setupExpectationsForTopologyContextEmit();
+        setupExpectationsForEventCorrelationInjector();
+
+        sut = new EventCorrelatingOutputCollector(mockedTopologyContext, mockedOutputCollector);
+        Deencapsulation.setField(sut, "eventCorrelationInjector", mockStormEventCorrelationInjector);
+
+        StreamlineEvent parentEvent = eventCorrelationInjector.injectCorrelationInformation(
+                PARENT_STREAMLINE_EVENT, Collections.emptyList(), TEST_COMPONENT_NAME_FOR_STORM);
+        Tuple anchor = new TupleImpl(mockedTopologyContext, new Values(parentEvent), TASK_0,
+                Utils.DEFAULT_STREAM_ID);
+
+        int testTaskId = TASK_1;
+        String testStreamId = "testStreamId";
+        final List<Tuple> anchors = Collections.singletonList(anchor);
+        final Values tuple = new Values(INPUT_STREAMLINE_EVENT);
+
+        // int taskId, String streamId, Tuple anchor, List<Object> anchor
+        new Expectations() {{
+            mockedOutputCollector.emitDirect(testTaskId, testStreamId, anchor, withAny(tuple));
+        }};
+
+        sut.emitDirect(testTaskId, testStreamId, anchor, tuple);
+
+        new Verifications() {{
+            List<Object> capturedValues;
+            mockedOutputCollector.emitDirect(testTaskId, testStreamId, anchor, capturedValues = withCapture());
+            StreamlineEventTestUtil.assertEventIsProperlyCopied((StreamlineEvent) capturedValues.get(0), INPUT_STREAMLINE_EVENT);
+
+            List<Tuple> capturedParents;
+            mockStormEventCorrelationInjector.injectCorrelationInformation(tuple,
+                    capturedParents = withCapture(), TEST_COMPONENT_NAME_FOR_STORM);
+            assertEquals(1, capturedParents.size());
+            assertEquals(anchor, capturedParents.get(0));
+        }};
+
+        // int taskId, String streamId, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emitDirect(testTaskId, testStreamId, withAny(tuple));
+        }};
+
+        sut.emitDirect(testTaskId, testStreamId, tuple);
+
+        new Verifications() {{
+            List<Object> capturedValues;
+            mockedOutputCollector.emitDirect(testTaskId, testStreamId, capturedValues = withCapture());
+            StreamlineEventTestUtil.assertEventIsProperlyCopied((StreamlineEvent) capturedValues.get(0), INPUT_STREAMLINE_EVENT);
+
+            List<Tuple> capturedParents;
+            mockStormEventCorrelationInjector.injectCorrelationInformation(tuple,
+                    capturedParents = withCapture(), TEST_COMPONENT_NAME_FOR_STORM);
+            assertEquals(0, capturedParents.size());
+        }};
+
+        // int taskId, Collection<Tuple> anchors, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emitDirect(testTaskId, anchors, withAny(tuple));
+        }};
+
+        sut.emitDirect(testTaskId, anchors, tuple);
+
+        new Verifications() {{
+            List<Object> capturedValues;
+            mockedOutputCollector.emitDirect(testTaskId, anchors, capturedValues = withCapture());
+            StreamlineEventTestUtil.assertEventIsProperlyCopied((StreamlineEvent) capturedValues.get(0), INPUT_STREAMLINE_EVENT);
+
+            List<Tuple> capturedParents;
+            mockStormEventCorrelationInjector.injectCorrelationInformation(tuple,
+                    capturedParents = withCapture(), TEST_COMPONENT_NAME_FOR_STORM);
+            assertEquals(1, capturedParents.size());
+            assertEquals(anchor, capturedParents.get(0));
+        }};
+
+        // int taskId, Tuple anchor, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emitDirect(testTaskId, anchor, withAny(tuple));
+        }};
+
+        sut.emitDirect(testTaskId, anchor, tuple);
+
+        new Verifications() {{
+            List<Object> capturedValues;
+            mockedOutputCollector.emitDirect(testTaskId, anchor, capturedValues = withCapture());
+            StreamlineEventTestUtil.assertEventIsProperlyCopied((StreamlineEvent) capturedValues.get(0), INPUT_STREAMLINE_EVENT);
+
+            List<Tuple> capturedParents;
+            mockStormEventCorrelationInjector.injectCorrelationInformation(tuple,
+                    capturedParents = withCapture(), TEST_COMPONENT_NAME_FOR_STORM);
+            assertEquals(1, capturedParents.size());
+            assertEquals(anchor, capturedParents.get(0));
+        }};
+
+        // int taskId, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emitDirect(testTaskId, withAny(tuple));
+        }};
+
+        sut.emitDirect(testTaskId, tuple);
+
+        new Verifications() {{
+            List<Object> capturedValues;
+            mockedOutputCollector.emitDirect(testTaskId, capturedValues = withCapture());
+            StreamlineEventTestUtil.assertEventIsProperlyCopied((StreamlineEvent) capturedValues.get(0), INPUT_STREAMLINE_EVENT);
+
+            List<Tuple> capturedParents;
+            mockStormEventCorrelationInjector.injectCorrelationInformation(tuple,
+                    capturedParents = withCapture(), TEST_COMPONENT_NAME_FOR_STORM);
+            assertEquals(0, capturedParents.size());
+        }};
+
+        // int taskId, String streamId, Collection<Tuple> anchors, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emitDirect(testTaskId, testStreamId, anchors, withAny(tuple));
+        }};
+
+        sut.emitDirect(testTaskId, testStreamId, anchors, tuple);
+
+        new Verifications() {{
+            List<Object> capturedValues;
+            mockedOutputCollector.emitDirect(testTaskId, testStreamId, anchors, capturedValues = withCapture());
+            StreamlineEventTestUtil.assertEventIsProperlyCopied((StreamlineEvent) capturedValues.get(0), INPUT_STREAMLINE_EVENT);
+
+            List<Tuple> capturedParents;
+            mockStormEventCorrelationInjector.injectCorrelationInformation(tuple,
+                    capturedParents = withCapture(), TEST_COMPONENT_NAME_FOR_STORM);
+            assertEquals(1, capturedParents.size());
+            assertEquals(anchor, capturedParents.get(0));
+        }};
+
+    }
+
+    @Test
+    public void testAck() throws Exception {
+        setupExpectationsForTuple();
+        setupExpectationsForTopologyContextNoEmit();
+        sut = new EventCorrelatingOutputCollector(mockedTopologyContext, mockedOutputCollector);
+
+        Tuple anchor = new TupleImpl(mockedTopologyContext, new Values(PARENT_STREAMLINE_EVENT), TASK_0,
+                Utils.DEFAULT_STREAM_ID);
+
+        sut.ack(anchor);
+
+        new Verifications() {{
+            mockedOutputCollector.ack(anchor); times = 1;
+        }};
+    }
+
+    @Test
+    public void testFail() throws Exception {
+        setupExpectationsForTuple();
+        setupExpectationsForTopologyContextNoEmit();
+        sut = new EventCorrelatingOutputCollector(mockedTopologyContext, mockedOutputCollector);
+
+        Tuple anchor = new TupleImpl(mockedTopologyContext, new Values(PARENT_STREAMLINE_EVENT), TASK_0,
+                Utils.DEFAULT_STREAM_ID);
+
+        sut.fail(anchor);
+
+        new Verifications() {{
+            mockedOutputCollector.fail(anchor); times = 1;
+        }};
+    }
+
+    @Test
+    public void testResetTimeout() throws Exception {
+        setupExpectationsForTuple();
+        setupExpectationsForTopologyContextNoEmit();
+        sut = new EventCorrelatingOutputCollector(mockedTopologyContext, mockedOutputCollector);
+
+        Tuple anchor = new TupleImpl(mockedTopologyContext, new Values(PARENT_STREAMLINE_EVENT), TASK_0,
+                Utils.DEFAULT_STREAM_ID);
+
+        sut.resetTimeout(anchor);
+
+        new Verifications() {{
+            mockedOutputCollector.resetTimeout(anchor); times = 1;
+        }};
+    }
+
+    @Test
+    public void testReportError() throws Exception {
+        setupExpectationsForTopologyContextNoEmit();
+        sut = new EventCorrelatingOutputCollector(mockedTopologyContext, mockedOutputCollector);
+
+        Throwable throwable = new RuntimeException("error");
+        sut.reportError(throwable);
+
+        new Verifications() {{
+            mockedOutputCollector.reportError(throwable); times = 1;
+        }};
+    }
+
+    private void setupExpectationsForTuple() {
+        new Expectations() {{
+            mockedTopologyContext.getComponentId(TASK_0);
+            result = TEST_TARGET_COMPONENT_FOR_TASK_0_FOR_STORM;
+
+            mockedTopologyContext.getComponentOutputFields(TEST_TARGET_COMPONENT_FOR_TASK_0_FOR_STORM, anyString);
+            result = new Fields(StreamlineEvent.STREAMLINE_EVENT);
+        }};
+    }
+
+    private void setupExpectationsForTopologyContextEmit() {
+        new Expectations() {{
+            mockedTopologyContext.getThisComponentId();
+            result = TEST_COMPONENT_NAME_FOR_STORM;
+        }};
+    }
+
+    private void setupExpectationsForTopologyContextNoEmit() {
+        new Expectations() {{
+        }};
+    }
+
+    private void setupExpectationsForEventCorrelationInjector() {
+        new Expectations(mockStormEventCorrelationInjector) {{
+        }};
+    }
+
+}

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/testing/EventCorrelatingSpoutOutputCollectorTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/testing/EventCorrelatingSpoutOutputCollectorTest.java
@@ -1,0 +1,295 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.streamline.streams.runtime.storm.testing;
+
+import com.google.common.collect.Lists;
+import com.hortonworks.streamline.streams.StreamlineEvent;
+import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
+import com.hortonworks.streamline.streams.runtime.utils.StreamlineEventTestUtil;
+import mockit.Deencapsulation;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Verifications;
+import mockit.integration.junit4.JMockit;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.Values;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JMockit.class)
+public class EventCorrelatingSpoutOutputCollectorTest {
+    private static final String TEST_COMPONENT_NAME_FOR_STORM = "1-testComponent";
+    private static final int TASK_1 = 1;
+    private static final int TASK_2 = 2;
+
+    @Injectable
+    private TopologyContext mockedTopologyContext;
+
+    private StormEventCorrelationInjector mockEventCorrelationInjector = new StormEventCorrelationInjector();
+
+    @Injectable
+    private SpoutOutputCollector mockedOutputCollector;
+
+    private EventCorrelatingSpoutOutputCollector sut;
+
+    public static final StreamlineEventImpl INPUT_STREAMLINE_EVENT = StreamlineEventImpl.builder()
+            .fieldsAndValues(new HashMap<String, Object>() {{
+                put("illuminance", 70);
+                put("temp", 104);
+                put("foo", 100);
+                put("humidity", "40h");
+            }})
+            .dataSourceId("ds-" + System.currentTimeMillis())
+            .build();
+
+    @Test
+    public void emit() throws Exception {
+        String testStreamId = "testStreamId";
+        final Values tuple = new Values(INPUT_STREAMLINE_EVENT);
+        String messageId = "testMessageId";
+        List<Integer> expectedTasks = Lists.newArrayList(TASK_1, TASK_2);
+
+        setupExpectationsForTopologyContextEmit();
+        setupExpectationsForEventCorrelationInjector();
+
+        sut = new EventCorrelatingSpoutOutputCollector(mockedTopologyContext, mockedOutputCollector);
+        Deencapsulation.setField(sut, "eventCorrelationInjector", mockEventCorrelationInjector);
+
+        // String streamId, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emit(testStreamId, withAny(tuple));
+            this.result = expectedTasks;
+        }};
+
+        List<Integer> tasks = sut.emit(testStreamId, tuple);
+        assertEquals(expectedTasks, tasks);
+
+        new Verifications() {{
+            List<Object> capturedValues;
+            mockedOutputCollector.emit(testStreamId, capturedValues = withCapture());
+            StreamlineEventTestUtil.assertEventIsProperlyCopied((StreamlineEvent) capturedValues.get(0), INPUT_STREAMLINE_EVENT);
+
+            List<Tuple> capturedParents;
+            mockEventCorrelationInjector.injectCorrelationInformation(tuple,
+                    capturedParents = withCapture(), TEST_COMPONENT_NAME_FOR_STORM);
+            assertEquals(0, capturedParents.size());
+        }};
+
+        // List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emit(withAny(tuple));
+            result = expectedTasks;
+        }};
+
+        tasks = sut.emit(tuple);
+        assertEquals(expectedTasks, tasks);
+
+        new Verifications() {{
+            List<Object> capturedValues;
+            mockedOutputCollector.emit(capturedValues = withCapture());
+            StreamlineEventTestUtil.assertEventIsProperlyCopied((StreamlineEvent) capturedValues.get(0), INPUT_STREAMLINE_EVENT);
+
+            List<Tuple> capturedParents;
+            mockEventCorrelationInjector.injectCorrelationInformation(tuple,
+                    capturedParents = withCapture(), TEST_COMPONENT_NAME_FOR_STORM);
+            assertEquals(0, capturedParents.size());
+        }};
+
+        // String streamId, List<Object> tuple, Object messageId
+        new Expectations() {{
+            mockedOutputCollector.emit(testStreamId, withAny(tuple), messageId);
+            result = expectedTasks;
+        }};
+
+        tasks = sut.emit(testStreamId, tuple, messageId);
+        assertEquals(expectedTasks, tasks);
+
+        new Verifications() {{
+            List<Object> capturedValues;
+            mockedOutputCollector.emit(testStreamId, capturedValues = withCapture(), messageId);
+            StreamlineEventTestUtil.assertEventIsProperlyCopied((StreamlineEvent) capturedValues.get(0), INPUT_STREAMLINE_EVENT);
+
+            List<Tuple> capturedParents;
+            mockEventCorrelationInjector.injectCorrelationInformation(tuple,
+                    capturedParents = withCapture(), TEST_COMPONENT_NAME_FOR_STORM);
+            assertEquals(0, capturedParents.size());
+        }};
+
+        // List<Object> tuple, Object messageId
+        new Expectations() {{
+            mockedOutputCollector.emit(withAny(tuple), messageId);
+            result = expectedTasks;
+        }};
+
+        tasks = sut.emit(tuple, messageId);
+        assertEquals(expectedTasks, tasks);
+
+        new Verifications() {{
+            List<Object> capturedValues;
+            mockedOutputCollector.emit(capturedValues = withCapture(), messageId);
+            StreamlineEventTestUtil.assertEventIsProperlyCopied((StreamlineEvent) capturedValues.get(0), INPUT_STREAMLINE_EVENT);
+
+            List<Tuple> capturedParents;
+            mockEventCorrelationInjector.injectCorrelationInformation(tuple,
+                    capturedParents = withCapture(), TEST_COMPONENT_NAME_FOR_STORM);
+            assertEquals(0, capturedParents.size());
+        }};
+    }
+
+    @Test
+    public void emitDirect() throws Exception {
+        setupExpectationsForTopologyContextEmit();
+        setupExpectationsForEventCorrelationInjector();
+
+        sut = new EventCorrelatingSpoutOutputCollector(mockedTopologyContext, mockedOutputCollector);
+        Deencapsulation.setField(sut, "eventCorrelationInjector", mockEventCorrelationInjector);
+
+        String testStreamId = "testStreamId";
+        final Values tuple = new Values(INPUT_STREAMLINE_EVENT);
+        String messageId = "testMessageId";
+
+        // int taskId, String streamId, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emitDirect(TASK_1, testStreamId, withAny(tuple));
+        }};
+
+        sut.emitDirect(TASK_1, testStreamId, tuple);
+
+        new Verifications() {{
+            List<Object> capturedValues;
+            mockedOutputCollector.emitDirect(TASK_1, testStreamId, capturedValues = withCapture());
+            StreamlineEventTestUtil.assertEventIsProperlyCopied((StreamlineEvent) capturedValues.get(0), INPUT_STREAMLINE_EVENT);
+
+            List<Tuple> capturedParents;
+            mockEventCorrelationInjector.injectCorrelationInformation(tuple,
+                    capturedParents = withCapture(), TEST_COMPONENT_NAME_FOR_STORM);
+            assertEquals(0, capturedParents.size());
+        }};
+
+        // int taskId, List<Object> tuple
+        new Expectations() {{
+            mockedOutputCollector.emitDirect(TASK_1, withAny(tuple));
+        }};
+
+        sut.emitDirect(TASK_1, tuple);
+
+        new Verifications() {{
+            List<Object> capturedValues;
+            mockedOutputCollector.emitDirect(TASK_1, capturedValues = withCapture());
+            StreamlineEventTestUtil.assertEventIsProperlyCopied((StreamlineEvent) capturedValues.get(0), INPUT_STREAMLINE_EVENT);
+
+            List<Tuple> capturedParents;
+            mockEventCorrelationInjector.injectCorrelationInformation(tuple,
+                    capturedParents = withCapture(), TEST_COMPONENT_NAME_FOR_STORM);
+            assertEquals(0, capturedParents.size());
+        }};
+
+        // int taskId, String streamId, List<Object> tuple, Object messageId
+        new Expectations() {{
+            mockedOutputCollector.emitDirect(TASK_1, testStreamId, withAny(tuple), messageId);
+        }};
+
+        sut.emitDirect(TASK_1, testStreamId, tuple, messageId);
+
+        new Verifications() {{
+            List<Object> capturedValues;
+            mockedOutputCollector.emitDirect(TASK_1, testStreamId, capturedValues = withCapture(), messageId);
+            StreamlineEventTestUtil.assertEventIsProperlyCopied((StreamlineEvent) capturedValues.get(0), INPUT_STREAMLINE_EVENT);
+
+            List<Tuple> capturedParents;
+            mockEventCorrelationInjector.injectCorrelationInformation(tuple,
+                    capturedParents = withCapture(), TEST_COMPONENT_NAME_FOR_STORM);
+            assertEquals(0, capturedParents.size());
+        }};
+
+        // int taskId, List<Object> tuple, Object messageId
+        new Expectations() {{
+            mockedOutputCollector.emitDirect(TASK_1, withAny(tuple), messageId);
+        }};
+
+        sut.emitDirect(TASK_1, tuple, messageId);
+
+        new Verifications() {{
+            List<Object> capturedValues;
+            mockedOutputCollector.emitDirect(TASK_1, capturedValues = withCapture(), messageId);
+            StreamlineEventTestUtil.assertEventIsProperlyCopied((StreamlineEvent) capturedValues.get(0), INPUT_STREAMLINE_EVENT);
+
+            List<Tuple> capturedParents;
+            mockEventCorrelationInjector.injectCorrelationInformation(tuple,
+                    capturedParents = withCapture(), TEST_COMPONENT_NAME_FOR_STORM);
+            assertEquals(0, capturedParents.size());
+        }};
+    }
+
+    @Test
+    public void reportError() throws Exception {
+        setupExpectationsForTopologyContextNoEmit();
+        setupExpectationsForEventCorrelationInjector();
+
+        sut = new EventCorrelatingSpoutOutputCollector(mockedTopologyContext, mockedOutputCollector);
+        Deencapsulation.setField(sut, "eventCorrelationInjector", mockEventCorrelationInjector);
+
+        Throwable throwable = new RuntimeException("error");
+        sut.reportError(throwable);
+
+        new Verifications() {{
+            mockedOutputCollector.reportError(throwable); times = 1;
+        }};
+    }
+
+    @Test
+    public void getPendingCount() throws Exception {
+        setupExpectationsForTopologyContextNoEmit();
+        setupExpectationsForEventCorrelationInjector();
+
+        sut = new EventCorrelatingSpoutOutputCollector(mockedTopologyContext, mockedOutputCollector);
+        Deencapsulation.setField(sut, "eventCorrelationInjector", mockEventCorrelationInjector);
+
+        sut.getPendingCount();
+
+        new Verifications() {{
+            mockedOutputCollector.getPendingCount(); times = 1;
+        }};
+    }
+
+    private void setupExpectationsForTopologyContextEmit() {
+        new Expectations() {{
+            mockedTopologyContext.getThisComponentId();
+            result = TEST_COMPONENT_NAME_FOR_STORM;
+        }};
+    }
+
+    private void setupExpectationsForTopologyContextNoEmit() {
+        new Expectations() {{
+        }};
+    }
+
+    private void setupExpectationsForEventCorrelationInjector() {
+        new Expectations(mockEventCorrelationInjector) {{
+        }};
+    }
+
+}

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/testing/StormEventCorrelationInjectorTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/testing/StormEventCorrelationInjectorTest.java
@@ -1,0 +1,199 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.runtime.storm.testing;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.hortonworks.streamline.streams.StreamlineEvent;
+import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
+import com.hortonworks.streamline.streams.common.event.correlation.EventCorrelationInjector;
+import com.hortonworks.streamline.streams.runtime.utils.StreamlineEventTestUtil;
+import com.hortonworks.streamline.streams.storm.common.StormTopologyUtil;
+import mockit.Expectations;
+import mockit.Injectable;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.TupleImpl;
+import org.apache.storm.tuple.Values;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+
+public class StormEventCorrelationInjectorTest {
+
+    private static final String TEST_COMPONENT_NAME = "1-testComponent";
+
+    private StormEventCorrelationInjector sut = new StormEventCorrelationInjector();
+    private EventCorrelationInjector eventCorrelationInjector = new EventCorrelationInjector();
+
+    @Injectable
+    private TopologyContext mockedTopologyContext;
+
+    public static final StreamlineEventImpl INPUT_STREAMLINE_EVENT = StreamlineEventImpl.builder()
+            .fieldsAndValues(new HashMap<String, Object>() {{
+                put("illuminance", 70);
+                put("temp", 104);
+                put("foo", 100);
+                put("humidity", "40h");
+            }})
+            .dataSourceId("ds-" + System.currentTimeMillis())
+            .header(Collections.singletonMap("A", 1))
+            .build();
+
+    @Test
+    public void tupleArgsTestNoParent() throws Exception {
+        StreamlineEvent injectedEvent = sut.injectCorrelationInformation(
+                new Values(INPUT_STREAMLINE_EVENT), Collections.emptyList(), TEST_COMPONENT_NAME);
+
+        StreamlineEventTestUtil.assertEventIsProperlyCopied(injectedEvent, INPUT_STREAMLINE_EVENT);
+
+        // added headers
+        assertEquals(Collections.emptySet(), EventCorrelationInjector.getRootIds(injectedEvent));
+        assertEquals(Collections.emptySet(), EventCorrelationInjector.getParentIds(injectedEvent));
+        assertEquals(StormTopologyUtil.extractStreamlineComponentName(TEST_COMPONENT_NAME), EventCorrelationInjector.getSourceComponentName(injectedEvent));
+    }
+
+    @Test
+    public void tupleArgsTestWithAParentWhichIsRootEvent() throws Exception {
+        StreamlineEvent parentEvent = copyEventWithNewID();
+
+        // use same component name for parent and ancestor for easy testing
+        parentEvent = eventCorrelationInjector.injectCorrelationInformation(parentEvent, Collections.emptyList(), TEST_COMPONENT_NAME);
+
+        int parentTaskId = 1;
+        String parentComponentName = "1-parentComponent";
+
+        new Expectations() {{
+            mockedTopologyContext.getComponentId(parentTaskId);
+            result = parentComponentName;
+
+            mockedTopologyContext.getComponentOutputFields(parentComponentName, INPUT_STREAMLINE_EVENT.getSourceStream());
+            result = new Fields(StreamlineEvent.STREAMLINE_EVENT);
+        }};
+
+        Tuple parentTuple = new TupleImpl(mockedTopologyContext, new Values(parentEvent), parentTaskId,
+                INPUT_STREAMLINE_EVENT.getSourceStream());
+
+        StreamlineEvent injectedEvent = sut.injectCorrelationInformation(
+                new Values(INPUT_STREAMLINE_EVENT), Collections.singletonList(parentTuple), TEST_COMPONENT_NAME);
+
+        StreamlineEventTestUtil.assertEventIsProperlyCopied(injectedEvent, INPUT_STREAMLINE_EVENT);
+
+        // added headers
+        assertEquals(Collections.singleton(parentEvent.getId()), EventCorrelationInjector.getRootIds(injectedEvent));
+        assertEquals(Collections.singleton(parentEvent.getId()), EventCorrelationInjector.getParentIds(injectedEvent));
+        assertEquals(StormTopologyUtil.extractStreamlineComponentName(TEST_COMPONENT_NAME), EventCorrelationInjector.getSourceComponentName(injectedEvent));
+    }
+
+    @Test
+    public void tupleArgsTestWithTwoParentsWhichAreRootEvents() throws Exception {
+        int parent1TaskId = 1;
+        String parent1ComponentName = "1-parentComponent";
+        int parent2TaskId = 2;
+        String parent2ComponentName = "2-parentComponent2";
+
+        new Expectations() {{
+            mockedTopologyContext.getComponentId(parent1TaskId);
+            result = parent1ComponentName;
+            mockedTopologyContext.getComponentId(parent2TaskId);
+            result = parent2ComponentName;
+
+            mockedTopologyContext.getComponentOutputFields(parent1ComponentName, INPUT_STREAMLINE_EVENT.getSourceStream());
+            result = new Fields(StreamlineEvent.STREAMLINE_EVENT);
+            mockedTopologyContext.getComponentOutputFields(parent2ComponentName, INPUT_STREAMLINE_EVENT.getSourceStream());
+            result = new Fields(StreamlineEvent.STREAMLINE_EVENT);
+        }};
+
+        StreamlineEvent parentEvent1 = copyEventWithNewID();
+
+        parentEvent1 = eventCorrelationInjector.injectCorrelationInformation(parentEvent1, Collections.emptyList(), TEST_COMPONENT_NAME);
+
+        Tuple parentTuple1 = new TupleImpl(mockedTopologyContext, new Values(parentEvent1), parent1TaskId,
+                INPUT_STREAMLINE_EVENT.getSourceStream());
+
+        StreamlineEvent parentEvent2 = copyEventWithNewID();
+        parentEvent2 = eventCorrelationInjector.injectCorrelationInformation(parentEvent2, Collections.emptyList(), TEST_COMPONENT_NAME);
+
+        Tuple parentTuple2 = new TupleImpl(mockedTopologyContext, new Values(parentEvent2), parent2TaskId,
+                INPUT_STREAMLINE_EVENT.getSourceStream());
+
+        StreamlineEvent injectedEvent = sut.injectCorrelationInformation(
+                new Values(INPUT_STREAMLINE_EVENT),
+                Lists.newArrayList(parentTuple1, parentTuple2), TEST_COMPONENT_NAME);
+
+        StreamlineEventTestUtil.assertEventIsProperlyCopied(injectedEvent, INPUT_STREAMLINE_EVENT);
+
+        // added headers
+        assertEquals(Sets.newHashSet(parentEvent1.getId(), parentEvent2.getId()), EventCorrelationInjector.getRootIds(injectedEvent));
+        assertEquals(Sets.newHashSet(parentEvent1.getId(), parentEvent2.getId()), EventCorrelationInjector.getParentIds(injectedEvent));
+        assertEquals(StormTopologyUtil.extractStreamlineComponentName(TEST_COMPONENT_NAME), EventCorrelationInjector.getSourceComponentName(injectedEvent));
+    }
+
+    @Test
+    public void tupleArgsTestWithTwoParentsWhichOneIsRootEventAndAnotherOneIsNonRootEvent() throws Exception {
+        int parent1TaskId = 1;
+        String parent1ComponentName = "1-parentComponent";
+        int parent2TaskId = 2;
+        String parent2ComponentName = "2-parentComponent2";
+
+        new Expectations() {{
+            mockedTopologyContext.getComponentId(parent1TaskId);
+            result = parent1ComponentName;
+            mockedTopologyContext.getComponentId(parent2TaskId);
+            result = parent2ComponentName;
+
+            mockedTopologyContext.getComponentOutputFields(parent1ComponentName, INPUT_STREAMLINE_EVENT.getSourceStream());
+            result = new Fields(StreamlineEvent.STREAMLINE_EVENT);
+            mockedTopologyContext.getComponentOutputFields(parent2ComponentName, INPUT_STREAMLINE_EVENT.getSourceStream());
+            result = new Fields(StreamlineEvent.STREAMLINE_EVENT);
+        }};
+
+        StreamlineEvent parentEvent1 = copyEventWithNewID();
+        parentEvent1 = eventCorrelationInjector.injectCorrelationInformation(parentEvent1, Collections.emptyList(), TEST_COMPONENT_NAME);
+
+        Tuple parentTuple1 = new TupleImpl(mockedTopologyContext, new Values(parentEvent1), parent1TaskId,
+                INPUT_STREAMLINE_EVENT.getSourceStream());
+
+        StreamlineEvent parentOfParentEvent2 = copyEventWithNewID();
+        parentOfParentEvent2 = eventCorrelationInjector.injectCorrelationInformation(parentOfParentEvent2, Collections.emptyList(), TEST_COMPONENT_NAME);
+
+        StreamlineEvent parentEvent2 = copyEventWithNewID();
+        parentEvent2 = eventCorrelationInjector.injectCorrelationInformation(parentEvent2, Collections.singletonList(parentOfParentEvent2), TEST_COMPONENT_NAME);
+
+        Tuple parentTuple2 = new TupleImpl(mockedTopologyContext, new Values(parentEvent2), parent2TaskId,
+                INPUT_STREAMLINE_EVENT.getSourceStream());
+
+        StreamlineEvent injectedEvent = sut.injectCorrelationInformation(
+                new Values(INPUT_STREAMLINE_EVENT),
+                Lists.newArrayList(parentTuple1, parentTuple2), TEST_COMPONENT_NAME);
+
+        StreamlineEventTestUtil.assertEventIsProperlyCopied(injectedEvent, INPUT_STREAMLINE_EVENT);
+
+        // added headers
+        assertEquals(Sets.newHashSet(parentEvent1.getId(), parentOfParentEvent2.getId()), EventCorrelationInjector.getRootIds(injectedEvent));
+        assertEquals(Sets.newHashSet(parentEvent1.getId(), parentEvent2.getId()), EventCorrelationInjector.getParentIds(injectedEvent));
+        assertEquals(StormTopologyUtil.extractStreamlineComponentName(TEST_COMPONENT_NAME), EventCorrelationInjector.getSourceComponentName(injectedEvent));
+    }
+
+    private StreamlineEventImpl copyEventWithNewID() {
+        return StreamlineEventImpl.builder().from(INPUT_STREAMLINE_EVENT).build();
+    }
+
+}

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/utils/StreamlineEventTestUtil.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/utils/StreamlineEventTestUtil.java
@@ -1,0 +1,29 @@
+package com.hortonworks.streamline.streams.runtime.utils;
+
+import com.hortonworks.streamline.streams.StreamlineEvent;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public final class StreamlineEventTestUtil {
+
+    public static void assertEventIsProperlyCopied(StreamlineEvent newEvent, StreamlineEvent sourceEvent) {
+        // key-value
+        assertEquals(newEvent.entrySet(), sourceEvent.entrySet());
+
+        // header
+        sourceEvent.getHeader().forEach((k, v) -> {
+            assertTrue(newEvent.getHeader().containsKey(k));
+            assertEquals(v, newEvent.getHeader().get(k));
+        });
+
+        // other fields
+        assertEquals(newEvent.getDataSourceId(), sourceEvent.getDataSourceId());
+        assertEquals(newEvent.getSourceStream(), sourceEvent.getSourceStream());
+        assertEquals(newEvent.getAuxiliaryFieldsAndValues(), sourceEvent.getAuxiliaryFieldsAndValues());
+
+        // id should be different
+        assertNotEquals(newEvent.getId(), sourceEvent.getId());
+    }
+}

--- a/streams/runners/storm/runtime/src/test/resources/normalization/bulkNormalizationScript.groovy
+++ b/streams/runners/storm/runtime/src/test/resources/normalization/bulkNormalizationScript.groovy
@@ -1,6 +1,6 @@
 Map<String, Object> result = new HashMap<>();
 binding.getVariables();
-Map<String, Object> defaultValues = ['foo': 'bar', 'new-field': 'new-value'];
+Map<String, Object> defaultValues = ['foo': 'bar', 'new-field': 'new value'];
 __outputSchema.getFields().each
         { field ->
             String key = field.getName();

--- a/streams/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/normalization/NormalizationRuntime.java
+++ b/streams/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/normalization/NormalizationRuntime.java
@@ -41,7 +41,7 @@ public abstract class NormalizationRuntime {
 
     public final StreamlineEvent execute(StreamlineEvent event) throws NormalizationException {
         Map<String, Object> result = normalize(event);
-        return new StreamlineEventImpl(result, event.getDataSourceId(), event.getId(), event.getHeader());
+        return StreamlineEventImpl.builder().from(event).fieldsAndValues(result).build();
     }
 
     protected abstract Map<String, Object> normalize(StreamlineEvent event) throws NormalizationException;

--- a/streams/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/processor/MultiLangProcessorRuntime.java
+++ b/streams/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/processor/MultiLangProcessorRuntime.java
@@ -204,8 +204,10 @@ public class MultiLangProcessorRuntime implements Serializable, ProcessorRuntime
     }
 
     private StreamlineEvent convertShellEvent(ShellMsg.ShellEvent shellEvent, StreamlineEvent inputEvent) {
-        StreamlineEventImpl streamlineEvent = new StreamlineEventImpl(shellEvent.getFieldsAndValues(), inputEvent.getDataSourceId(), inputEvent.getId(), inputEvent.getHeader());
-        return streamlineEvent;
+        return StreamlineEventImpl.builder()
+                .from(inputEvent)
+                .fieldsAndValues(shellEvent.getFieldsAndValues())
+                .build();
     }
 
     private void die(Throwable exception) {

--- a/streams/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/rule/sql/SqlScript.java
+++ b/streams/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/rule/sql/SqlScript.java
@@ -194,7 +194,6 @@ public class SqlScript extends Script<StreamlineEvent, Collection<StreamlineEven
                 }
                 if (inputEvent != null) {
                     result = builder.dataSourceId(inputEvent.getDataSourceId())
-                            .id(inputEvent.getId())
                             .header(inputEvent.getHeader())
                             .sourceStream(inputEvent.getSourceStream())
                             .build();

--- a/streams/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/splitjoin/DefaultJoiner.java
+++ b/streams/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/splitjoin/DefaultJoiner.java
@@ -44,7 +44,10 @@ public class DefaultJoiner implements Joiner {
             fieldValues.putAll(subEvent);
         }
 
-        return new StreamlineEventImpl(fieldValues, eventGroup.getDataSourceId(),
-                UUID.randomUUID().toString(), Collections.<String, Object>emptyMap(), null, auxiliaryFieldValues);
+        return StreamlineEventImpl.builder()
+                .fieldsAndValues(fieldValues)
+                .dataSourceId(eventGroup.getDataSourceId())
+                .auxiliaryFieldsAndValues(auxiliaryFieldValues)
+                .build();
     }
 }

--- a/streams/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/splitjoin/DefaultSplitter.java
+++ b/streams/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/splitjoin/DefaultSplitter.java
@@ -58,8 +58,7 @@ public class DefaultSplitter implements Splitter {
         headers.put(SplitActionRuntime.SPLIT_GROUP_ID, groupId);
         headers.put(SplitActionRuntime.SPLIT_PARTITION_ID, partNo);
         headers.put(SplitActionRuntime.SPLIT_TOTAL_PARTITIONS_ID, totalParts);
-        return new StreamlineEventImpl(event, event.getDataSourceId(),
-                UUID.randomUUID().toString(), headers, stream, event.getAuxiliaryFieldsAndValues());
+        return StreamlineEventImpl.builder().from(event).header(headers).sourceStream(stream).build();
     }
 
     /**

--- a/streams/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/splitjoin/JoinActionRuntime.java
+++ b/streams/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/splitjoin/JoinActionRuntime.java
@@ -92,7 +92,7 @@ public class JoinActionRuntime extends AbstractSplitJoinActionRuntime {
     }
 
     private StreamlineEvent getStreamlineEvent(StreamlineEvent event, String stream) {
-        return new StreamlineEventImpl(event, event.getDataSourceId(), event.getId(), event.getHeader(), stream, event.getAuxiliaryFieldsAndValues());
+        return StreamlineEventImpl.builder().from(event).sourceStream(stream).build();
     }
 
     protected EventGroup groupEvents(StreamlineEvent event) {

--- a/streams/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/transform/AddHeaderTransformRuntime.java
+++ b/streams/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/transform/AddHeaderTransformRuntime.java
@@ -46,15 +46,16 @@ public class AddHeaderTransformRuntime implements TransformRuntime {
 
     @Override
     public List<StreamlineEvent> execute(StreamlineEvent input) {
-        Map<String, Object> header = new HashMap<>();
+        Map<String, Object> header = new HashMap<>(input.getHeader());
         if(addHeaderTransform.getFixedHeader() != null) {
             header.putAll(addHeaderTransform.getFixedHeader());
         }
         header.put(HEADER_FIELD_DATASOURCE_IDS, Collections.singletonList(input.getDataSourceId()));
         header.put(HEADER_FIELD_EVENT_IDS, Collections.singletonList(input.getId()));
         header.put(HEADER_FIELD_TIMESTAMP, System.currentTimeMillis());
-        return Collections.<StreamlineEvent>singletonList(
-                new StreamlineEventImpl(input, input.getDataSourceId(), header));
+
+        return Collections.singletonList(
+                StreamlineEventImpl.builder().from(input).header(header).build());
     }
 
     @Override

--- a/streams/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/transform/EnrichmentTransformRuntime.java
+++ b/streams/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/transform/EnrichmentTransformRuntime.java
@@ -56,7 +56,7 @@ public class EnrichmentTransformRuntime implements TransformRuntime {
         Map<String, Object> enrichments = (Map<String, Object>) auxiliaryFieldsAndValues.get(EnrichmentTransform.ENRICHMENTS_FIELD_NAME);
         if (enrichments == null) {
             enrichments = new HashMap<>();
-            event.addAuxiliaryFieldAndValue(EnrichmentTransform.ENRICHMENTS_FIELD_NAME, enrichments);
+            event = event.addAuxiliaryFieldAndValue(EnrichmentTransform.ENRICHMENTS_FIELD_NAME, enrichments);
         }
 
         for (String fieldName : fieldsToBeEnriched) {

--- a/streams/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/TransformRuntimePipelineActionTest.java
+++ b/streams/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/TransformRuntimePipelineActionTest.java
@@ -50,7 +50,7 @@ public class TransformRuntimePipelineActionTest {
         defaults.put("2", "TWO");
         defaults.put("3", "THREE");
 
-        StreamlineEvent event = new StreamlineEventImpl(fieldsAndValues, "dsrcid");
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(fieldsAndValues).dataSourceId("dsrcid").build();
         MergeTransform merge = new MergeTransform(defaults);
         ProjectionTransform projection = new ProjectionTransform("test-projection", defaults.keySet());
         TransformAction transformAction = new TransformAction(ImmutableList.of(merge, projection));
@@ -77,7 +77,7 @@ public class TransformRuntimePipelineActionTest {
         defaults.put("3", "THREE");
         defaults.put("4", "${2} plus ${2}");
 
-        StreamlineEvent event = new StreamlineEventImpl(fieldsAndValues, "dsrcid");
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(fieldsAndValues).dataSourceId("dsrcid").build();
         MergeTransform merge = new MergeTransform(defaults);
         SubstituteTransform substitute = new SubstituteTransform();
         ProjectionTransform projection = new ProjectionTransform("test-projection", defaults.keySet());

--- a/streams/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/rule/sql/SqlNestedExprScriptTest.java
+++ b/streams/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/rule/sql/SqlNestedExprScriptTest.java
@@ -62,7 +62,7 @@ public class SqlNestedExprScriptTest {
 
         Map<String, Object> kv = new HashMap<>();
         kv.put("x", 100);
-        StreamlineEvent event = new StreamlineEventImpl(kv, "1");
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(kv).dataSourceId("1").build();
         Collection<StreamlineEvent> result = sqlScript.evaluate(event);
         Assert.assertTrue(result.isEmpty());
     }
@@ -83,7 +83,7 @@ public class SqlNestedExprScriptTest {
         Map<String, Object> kv = new HashMap<>();
         kv.put("x", 10);
         kv.put("y", nested);
-        StreamlineEvent event = new StreamlineEventImpl(kv, "1");
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(kv).dataSourceId("1").build();
         Collection<StreamlineEvent> result = sqlScript.evaluate(event);
         Assert.assertEquals(1, result.size());
     }
@@ -105,7 +105,7 @@ public class SqlNestedExprScriptTest {
         Map<String, Object> kv = new HashMap<>();
         kv.put("x", 10);
         kv.put("y", nestedMap);
-        StreamlineEvent event = new StreamlineEventImpl(kv, "1");
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(kv).dataSourceId("1").build();
         Collection<StreamlineEvent> result = sqlScript.evaluate(event);
         Assert.assertTrue(result.isEmpty());
     }

--- a/streams/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/script/GroovyScriptNestedExprTest.java
+++ b/streams/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/script/GroovyScriptNestedExprTest.java
@@ -46,7 +46,7 @@ public class GroovyScriptNestedExprTest {
         Map<String, Object> kv = new HashMap<>();
         kv.put("x", 2);
         kv.put("y", nested);
-        StreamlineEvent event = new StreamlineEventImpl(kv, "1");
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(kv).dataSourceId("1").build();
         Boolean result = groovyScript.evaluate(event);
         System.out.println(result);
     }
@@ -60,7 +60,7 @@ public class GroovyScriptNestedExprTest {
         Map<String, Object> kv = new HashMap<>();
         kv.put("x", 2);
         kv.put("y", nested);
-        StreamlineEvent event = new StreamlineEventImpl(kv, "1");
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(kv).dataSourceId("1").build();
         Boolean result = groovyScript.evaluate(event);
         System.out.println(result);
     }
@@ -76,7 +76,7 @@ public class GroovyScriptNestedExprTest {
         Map<String, Object> kv = new HashMap<>();
         kv.put("x", 2);
         kv.put("y", nestedMap);
-        StreamlineEvent event = new StreamlineEventImpl(kv, "1");
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(kv).dataSourceId("1").build();
         Boolean result = groovyScript.evaluate(event);
         System.out.println(result);
     }

--- a/streams/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/script/GroovyScriptTest.java
+++ b/streams/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/script/GroovyScriptTest.java
@@ -17,6 +17,7 @@
 
 package com.hortonworks.streamline.streams.runtime.script;
 
+import com.hortonworks.streamline.streams.StreamlineEvent;
 import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
 import com.hortonworks.streamline.streams.runtime.script.engine.GroovyScriptEngine;
 import org.junit.Assert;
@@ -48,7 +49,7 @@ public class GroovyScriptTest {
         fieldsAndValue.put("temperature", 20);
         fieldsAndValue.put("humidity", 10);
         try {
-            assertTrue(groovyScript.evaluate(new StreamlineEventImpl(fieldsAndValue, "1")));
+            assertTrue(groovyScript.evaluate(StreamlineEventImpl.builder().fieldsAndValues(fieldsAndValue).dataSourceId("1").build()));
         } catch (ScriptException e) {
             e.printStackTrace();
             Assert.fail("It shouldn't throw ScriptException");
@@ -57,7 +58,7 @@ public class GroovyScriptTest {
         fieldsAndValue.clear();
         fieldsAndValue.put("no_related_field", 3);
         try {
-            groovyScript.evaluate(new StreamlineEventImpl(fieldsAndValue, "1"));
+            groovyScript.evaluate(StreamlineEventImpl.builder().fieldsAndValues(fieldsAndValue).dataSourceId("1").build());
             // it means that previous bound variables are used now
             Assert.fail("It should not evaluate correctly");
         } catch (ScriptException e) {
@@ -92,7 +93,7 @@ public class GroovyScriptTest {
                         fieldsAndValue.put("a", aVal);
 
                         try {
-                            assertEquals(aVal % 2 == 0, groovyScript.evaluate(new StreamlineEventImpl(fieldsAndValue, "1")));
+                            assertEquals(aVal % 2 == 0, groovyScript.evaluate(StreamlineEventImpl.builder().fieldsAndValues(fieldsAndValue).dataSourceId("1").build()));
                         } catch (Throwable e) {
                             e.printStackTrace();
                             anyException.set(e);

--- a/streams/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/splitjoin/SplitJoinTest.java
+++ b/streams/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/splitjoin/SplitJoinTest.java
@@ -262,7 +262,11 @@ public class SplitJoinTest {
     private StreamlineEvent createRootEvent() {
         Map<String, Object> fieldValues = new HashMap<String, Object>(){{put("foo", "foo-value"); put("bar", "bar-"+System.currentTimeMillis());}};
 
-        return new StreamlineEventImpl(fieldValues, "ds-1", UUID.randomUUID().toString(), Collections.<String, Object>emptyMap(), "source-stream");
+        return StreamlineEventImpl.builder()
+                .fieldsAndValues(fieldValues)
+                .dataSourceId("ds-1")
+                .sourceStream("source-stream")
+                .build();
     }
 
     @Mocked

--- a/streams/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/transform/MergeTransformRuntimeTest.java
+++ b/streams/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/transform/MergeTransformRuntimeTest.java
@@ -43,7 +43,7 @@ public class MergeTransformRuntimeTest {
         defaults.put("2", "TWO");
         defaults.put("3", "THREE");
 
-        StreamlineEvent event = new StreamlineEventImpl(fieldsAndValues, "dsrcid");
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(fieldsAndValues).dataSourceId("dsrcid").build();
         TransformRuntime transformRuntime = new MergeTransformRuntime(new MergeTransform(defaults));
         List<StreamlineEvent> result = transformRuntime.execute(event);
         System.out.println(result);

--- a/streams/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/transform/SubstituteTransformRuntimeTest.java
+++ b/streams/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/transform/SubstituteTransformRuntimeTest.java
@@ -41,7 +41,7 @@ public class SubstituteTransformRuntimeTest {
         fieldsAndValues.put("2", "two");
         fieldsAndValues.put("3", "three");
 
-        StreamlineEvent event = new StreamlineEventImpl(fieldsAndValues, "dsrcid");
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(fieldsAndValues).dataSourceId("dsrcid").build();
         TransformRuntime transformRuntime = new SubstituteTransformRuntime();
         List<StreamlineEvent> result = transformRuntime.execute(event);
         assertEquals(1, result.size());
@@ -58,7 +58,7 @@ public class SubstituteTransformRuntimeTest {
         fieldsAndValues.put("2", "two");
         fieldsAndValues.put("3", "${1} plus ${2}");
 
-        StreamlineEvent event = new StreamlineEventImpl(fieldsAndValues, "dsrcid");
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(fieldsAndValues).dataSourceId("dsrcid").build();
         TransformRuntime transformRuntime = new SubstituteTransformRuntime();
         List<StreamlineEvent> result = transformRuntime.execute(event);
         assertEquals(1, result.size());
@@ -75,7 +75,7 @@ public class SubstituteTransformRuntimeTest {
         fieldsAndValues.put("2", "${1} plus ${1}");
         fieldsAndValues.put("3", "${1} plus two");
 
-        StreamlineEvent event = new StreamlineEventImpl(fieldsAndValues, "dsrcid");
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(fieldsAndValues).dataSourceId("dsrcid").build();
         TransformRuntime transformRuntime = new SubstituteTransformRuntime(new SubstituteTransform(Collections.singleton("3")));
         List<StreamlineEvent> result = transformRuntime.execute(event);
         assertEquals(1, result.size());
@@ -92,7 +92,7 @@ public class SubstituteTransformRuntimeTest {
         fieldsAndValues.put("2", 2);
         fieldsAndValues.put("3", "${1} plus ${2}");
 
-        StreamlineEvent event = new StreamlineEventImpl(fieldsAndValues, "dsrcid");
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(fieldsAndValues).dataSourceId("dsrcid").build();
         TransformRuntime transformRuntime = new SubstituteTransformRuntime();
         List<StreamlineEvent> result = transformRuntime.execute(event);
         assertEquals(1, result.size());
@@ -109,7 +109,7 @@ public class SubstituteTransformRuntimeTest {
         fieldsAndValues.put("2", "${1} plus ${1}");
         fieldsAndValues.put("3", "${1} plus ${2}");
 
-        StreamlineEvent event = new StreamlineEventImpl(fieldsAndValues, "dsrcid");
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(fieldsAndValues).dataSourceId("dsrcid").build();
         TransformRuntime transformRuntime = new SubstituteTransformRuntime();
         List<StreamlineEvent> result = transformRuntime.execute(event);
         assertEquals(1, result.size());
@@ -125,7 +125,7 @@ public class SubstituteTransformRuntimeTest {
         fieldsAndValues.put("1", "${2} minus one");
         fieldsAndValues.put("2", "${1} plus one");
 
-        StreamlineEvent event = new StreamlineEventImpl(fieldsAndValues, "dsrcid");
+        StreamlineEvent event = StreamlineEventImpl.builder().fieldsAndValues(fieldsAndValues).dataSourceId("dsrcid").build();
         TransformRuntime transformRuntime = new SubstituteTransformRuntime();
         List<StreamlineEvent> result = transformRuntime.execute(event);
         System.out.println(result);

--- a/streams/sdk/src/main/java/com/hortonworks/streamline/streams/StreamlineEvent.java
+++ b/streams/sdk/src/main/java/com/hortonworks/streamline/streams/StreamlineEvent.java
@@ -16,6 +16,7 @@
 package com.hortonworks.streamline.streams;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -58,7 +59,7 @@ public interface StreamlineEvent  extends Map<String,Object>, Serializable {
     /**
      * Adds given {@code field} and {@code value} to auxiliary Map.
      */
-    void addAuxiliaryFieldAndValue(String field, Object value);
+    StreamlineEvent addAuxiliaryFieldAndValue(String field, Object value);
 
     /**
      * The event header that represents some meta data about

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyTestRunResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyTestRunResource.java
@@ -26,6 +26,7 @@ import com.hortonworks.streamline.common.exception.SchemaValidationFailedExcepti
 import com.hortonworks.streamline.common.exception.service.exception.request.BadRequestException;
 import com.hortonworks.streamline.common.exception.service.exception.request.EntityNotFoundException;
 import com.hortonworks.streamline.common.util.WSUtils;
+import com.hortonworks.streamline.streams.StreamlineEvent;
 import com.hortonworks.streamline.streams.actions.topology.service.TopologyActionsService;
 import com.hortonworks.streamline.streams.catalog.Topology;
 import com.hortonworks.streamline.streams.catalog.TopologySink;
@@ -36,6 +37,10 @@ import com.hortonworks.streamline.streams.catalog.TopologyTestRunCaseSink;
 import com.hortonworks.streamline.streams.catalog.TopologyTestRunCaseSource;
 import com.hortonworks.streamline.streams.catalog.TopologyTestRunHistory;
 import com.hortonworks.streamline.streams.catalog.service.StreamCatalogService;
+import com.hortonworks.streamline.streams.common.event.EventInformation;
+import com.hortonworks.streamline.streams.common.event.EventLogFileReader;
+import com.hortonworks.streamline.streams.common.event.tree.EventInformationTreeBuilder;
+import com.hortonworks.streamline.streams.common.event.tree.EventInformationTreeNode;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.BooleanUtils;
 import org.datanucleus.util.StringUtils;
@@ -56,13 +61,14 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -70,7 +76,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static java.util.stream.Collectors.toMap;
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static javax.ws.rs.core.Response.Status.OK;
 
@@ -80,15 +86,16 @@ public class TopologyTestRunResource {
     private static final Logger LOG = LoggerFactory.getLogger(TopologyTestRunResource.class);
 
     private static final Integer DEFAULT_LIST_ENTITIES_COUNT = 5;
-    public static final Charset ENCODING_UTF_8 = Charset.forName("UTF-8");
 
     private final StreamCatalogService catalogService;
     private final TopologyActionsService actionsService;
+    private final EventLogFileReader eventLogFileReader;
     private final ObjectMapper objectMapper;
 
     public TopologyTestRunResource(StreamCatalogService catalogService, TopologyActionsService actionsService) {
         this.catalogService = catalogService;
         this.actionsService = actionsService;
+        this.eventLogFileReader = new EventLogFileReader();
         this.objectMapper = new ObjectMapper();
     }
 
@@ -227,6 +234,55 @@ public class TopologyTestRunResource {
     }
 
     @GET
+    @Path("/topologies/{topologyId}/testhistories/{historyId}/events/root")
+    public Response getRootEventsOfTestRunTopologyHistory(@Context UriInfo urlInfo,
+                                                          @PathParam("topologyId") Long topologyId,
+                                                          @PathParam("historyId") Long historyId) throws Exception {
+        File eventLogFile = getEventLogFile(topologyId, historyId);
+        Stream<EventInformation> eventsStream = eventLogFileReader.loadEventLogFileAsStream(eventLogFile);
+
+        Stream<EventInformation> rootEventsStream = eventsStream.filter(e -> e != null && e.getRootIds().isEmpty());
+        Stream<String> rootEventIdsStream = rootEventsStream.map(EventInformation::getEventId);
+
+        return WSUtils.respondEntities(rootEventIdsStream.collect(toList()), OK);
+    }
+
+    @GET
+    @Path("/topologies/{topologyId}/testhistories/{historyId}/events/tree/{rootEventId}")
+    public Response getEventTreeOfTestRunTopologyHistory(@Context UriInfo urlInfo,
+                                                          @PathParam("topologyId") Long topologyId,
+                                                          @PathParam("historyId") Long historyId,
+                                                          @PathParam("rootEventId") String rootEventId) throws Exception {
+        File eventLogFile = getEventLogFile(topologyId, historyId);
+        List<EventInformation> events = eventLogFileReader.loadEventLogFile(eventLogFile);
+
+        EventInformationTreeNode rootEventNode = new EventInformationTreeBuilder(events).constructEventTree(rootEventId);
+
+        if (rootEventNode == null) {
+            throw BadRequestException.message("Can't find provided root event " + rootEventId + " from events.");
+        }
+        return WSUtils.respondEntity(rootEventNode, OK);
+    }
+
+    @GET
+    @Path("/topologies/{topologyId}/testhistories/{historyId}/events/tree/{rootEventId}/subtree/{subRootEventId}")
+    public Response getEventSubTreeOfTestRunTopologyHistory(@Context UriInfo urlInfo,
+                                                            @PathParam("topologyId") Long topologyId,
+                                                            @PathParam("historyId") Long historyId,
+                                                            @PathParam("rootEventId") String rootEventId,
+                                                            @PathParam("subRootEventId") String subRootEventId) throws Exception {
+        File eventLogFile = getEventLogFile(topologyId, historyId);
+        List<EventInformation> events = eventLogFileReader.loadEventLogFile(eventLogFile);
+
+        EventInformationTreeNode subRootEventNode = new EventInformationTreeBuilder(events).constructEventTree(rootEventId, subRootEventId);
+
+        if (subRootEventNode == null) {
+            throw BadRequestException.message("Can't find provided root event " + rootEventId + " from events.");
+        }
+        return WSUtils.respondEntity(subRootEventNode, OK);
+    }
+
+    @GET
     @Path("/topologies/{topologyId}/testhistories/{historyId}/events")
     public Response getEventsOfTestRunTopologyHistory(@Context UriInfo urlInfo,
                                                       @PathParam("topologyId") Long topologyId,
@@ -250,31 +306,23 @@ public class TopologyTestRunResource {
                                                            @PathParam("topologyId") Long topologyId,
                                                            @PathParam("historyId") Long historyId) throws Exception {
         File eventLogFile = getEventLogFile(topologyId, historyId);
-        String content = FileUtils.readFileToString(eventLogFile, ENCODING_UTF_8);
+        String content = FileUtils.readFileToString(eventLogFile, StandardCharsets.UTF_8);
 
         InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
         String fileName = String.format("events-topology-%d-history-%d.log", topologyId, historyId);
         return Response.status(OK)
-                .entity(is)
-                .header("Content-Disposition", "attachment; filename=\"" + fileName + "\"")
-                .build();
+            .entity(is)
+            .header("Content-Disposition", "attachment; filename=\"" + fileName + "\"")
+            .build();
     }
 
     private Response getEventsOfTestRunTopologyHistory(Long topologyId, Long historyId, String componentName) throws IOException {
         File eventLogFile = getEventLogFile(topologyId, historyId);
-
-        List<String> lines = FileUtils.readLines(eventLogFile, ENCODING_UTF_8);
-        Stream<Map<String, Object>> eventsStream = lines.stream().map(line -> {
-            try {
-                return objectMapper.readValue(line, new TypeReference<Map<String, Object>>() {});
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        });
+        Stream<EventInformation> eventsStream = eventLogFileReader.loadEventLogFileAsStream(eventLogFile);
 
         if (!StringUtils.isEmpty(componentName)) {
             eventsStream = eventsStream.filter(event -> {
-                String eventComponentName = (String) event.get("componentName");
+                String eventComponentName = event.getComponentName();
                 return eventComponentName != null && eventComponentName.equals(componentName);
             });
         }
@@ -735,5 +783,6 @@ public class TopologyTestRunResource {
             return timestamp;
         }
     }
+
 
 }

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyTestRunResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyTestRunResource.java
@@ -40,6 +40,7 @@ import com.hortonworks.streamline.streams.catalog.service.StreamCatalogService;
 import com.hortonworks.streamline.streams.common.event.EventInformation;
 import com.hortonworks.streamline.streams.common.event.EventLogFileReader;
 import com.hortonworks.streamline.streams.common.event.correlation.CorrelatedEventsGrouper;
+import com.hortonworks.streamline.streams.common.event.correlation.GroupedCorrelationEvents;
 import com.hortonworks.streamline.streams.common.event.tree.EventInformationTreeBuilder;
 import com.hortonworks.streamline.streams.common.event.tree.EventInformationTreeNode;
 import org.apache.commons.io.FileUtils;
@@ -257,8 +258,8 @@ public class TopologyTestRunResource {
         File eventLogFile = getEventLogFile(topologyId, historyId);
         List<EventInformation> events = eventLogFileReader.loadEventLogFile(eventLogFile);
 
-        Map<String, List<EventInformation>> groupedEvents = new CorrelatedEventsGrouper(events).groupByComponent(rootEventId);
-        if (groupedEvents.isEmpty()) {
+        GroupedCorrelationEvents groupedEvents = new CorrelatedEventsGrouper(events).groupByComponent(rootEventId);
+        if (!groupedEvents.getAllEvents().containsKey(rootEventId)) {
             throw BadRequestException.message("Can't find provided root event " + rootEventId + " from events.");
         }
         return WSUtils.respondEntity(groupedEvents, OK);


### PR DESCRIPTION
* wrapping collector to add event correlation information before writing event & emit
  * do some hacks around TestRunWindowProcessorBolt because of Storm's behavior
    * WindowedOutputCollector in WindowedBoltExecutor automatically adds inputTuples as anchor which can't be tracked from wrapped collectors
* provide event information via:
  * constructing event tree based on events and provide full event tree or subtree
  * providing all correlated events group by component
* provide some HTTP API regarding above features
  * full event tree associated to given root event
  * sub event tree associated to given root event and start from given sub root event
  * add another HTTP API: provide all correlated events group by component
    * /api/v1/catalog/topologies/:topologyId/testhistories/:historyId/events/correlated/:rootEventId
      * (event id -> event) map for looking up all events
      * (component -> (input event ids, output event ids)) map for grouping events by component