### PR TITLE
ISSUE-972 SAM test mode doesn't adjust topology message timeout with windowed rule

### DIFF
--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/TopologyActions.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/TopologyActions.java
@@ -18,6 +18,7 @@ package com.hortonworks.streamline.streams.actions;
 import com.hortonworks.streamline.streams.catalog.TopologyTestRunHistory;
 import com.hortonworks.streamline.streams.layout.component.TopologyLayout;
 import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunProcessor;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunRulesProcessor;
 import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSink;
 import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSource;
 
@@ -43,6 +44,7 @@ public interface TopologyActions {
     void runTest(TopologyLayout topology, TopologyTestRunHistory testRunHistory, String mavenArtifacts,
                  Map<String, TestRunSource> testRunSourcesForEachSource,
                  Map<String, TestRunProcessor> testRunProcessorsForEachProcessor,
+                 Map<String, TestRunRulesProcessor> testRunRulesProcessorsForEachProcessor,
                  Map<String, TestRunSink> testRunSinksForEachSink, Optional<Long> durationSecs) throws Exception;
 
     // Kill topology running as test mode if exists.

--- a/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/RulesProcessor.java
+++ b/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/RulesProcessor.java
@@ -34,6 +34,7 @@ import java.util.Set;
 
 /**
  * Represents a design time rules processor.
+ * Note that derived classes should implement its copy constructor.
  */
 public class RulesProcessor extends StreamlineProcessor {     //TODO: Rename to RuleProcessor
     private static final Logger log = LoggerFactory.getLogger(RulesProcessor.class);

--- a/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/testing/TestRunRulesProcessor.java
+++ b/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/impl/testing/TestRunRulesProcessor.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.layout.component.impl.testing;
+
+import com.hortonworks.streamline.streams.layout.component.StreamlineProcessor;
+import com.hortonworks.streamline.streams.layout.component.impl.RulesProcessor;
+
+/**
+ * Rules Processor for topology test run.
+ */
+public class TestRunRulesProcessor extends RulesProcessor {
+    private final RulesProcessor underlyingProcessor;
+    private final String eventLogFilePath;
+
+    public TestRunRulesProcessor(RulesProcessor underlyingProcessor, String eventLogFilePath) {
+        super(underlyingProcessor);
+        this.underlyingProcessor = underlyingProcessor;
+        this.eventLogFilePath = eventLogFilePath;
+    }
+
+    public TestRunRulesProcessor(TestRunRulesProcessor other) {
+        super(other);
+        this.underlyingProcessor = other.underlyingProcessor;
+        this.eventLogFilePath = other.eventLogFilePath;
+    }
+
+    public boolean isWindowed() {
+        return getRules().stream().anyMatch(r -> r.getWindow() != null);
+    }
+
+    public StreamlineProcessor getUnderlyingProcessor() {
+        return underlyingProcessor;
+    }
+
+    public String getEventLogFilePath() {
+        return eventLogFilePath;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TestRunRulesProcessor)) return false;
+        if (!super.equals(o)) return false;
+
+        TestRunRulesProcessor that = (TestRunRulesProcessor) o;
+
+        if (getUnderlyingProcessor() != null ? !getUnderlyingProcessor().equals(that.getUnderlyingProcessor()) : that.getUnderlyingProcessor() != null)
+            return false;
+        return getEventLogFilePath() != null ? getEventLogFilePath().equals(that.getEventLogFilePath()) : that.getEventLogFilePath() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (getUnderlyingProcessor() != null ? getUnderlyingProcessor().hashCode() : 0);
+        result = 31 * result + (getEventLogFilePath() != null ? getEventLogFilePath().hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "TestRunRulesProcessor{" +
+                "underlyingProcessor=" + underlyingProcessor +
+                ", eventLogFilePath='" + eventLogFilePath + '\'' +
+                '}';
+    }
+}

--- a/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/StormTopologyActionsImpl.java
+++ b/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/StormTopologyActionsImpl.java
@@ -36,6 +36,7 @@ import com.hortonworks.streamline.streams.layout.component.impl.HdfsSink;
 import com.hortonworks.streamline.streams.layout.component.impl.HdfsSource;
 import com.hortonworks.streamline.streams.layout.component.impl.HiveSink;
 import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunProcessor;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunRulesProcessor;
 import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSink;
 import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSource;
 import com.hortonworks.streamline.streams.layout.storm.StormTopologyFluxGenerator;
@@ -269,11 +270,13 @@ public class StormTopologyActionsImpl implements TopologyActions {
     public void runTest(TopologyLayout topology, TopologyTestRunHistory testRunHistory, String mavenArtifacts,
                         Map<String, TestRunSource> testRunSourcesForEachSource,
                         Map<String, TestRunProcessor> testRunProcessorsForEachProcessor,
+                        Map<String, TestRunRulesProcessor> testRunRulesProcessorsForEachProcessor,
                         Map<String, TestRunSink> testRunSinksForEachSink, Optional<Long> durationSecs) throws Exception {
         TopologyDag originalTopologyDag = topology.getTopologyDag();
 
         TestTopologyDagCreatingVisitor visitor = new TestTopologyDagCreatingVisitor(originalTopologyDag,
-                testRunSourcesForEachSource, testRunProcessorsForEachProcessor, testRunSinksForEachSink);
+                testRunSourcesForEachSource, testRunProcessorsForEachProcessor, testRunRulesProcessorsForEachProcessor,
+                testRunSinksForEachSink);
         originalTopologyDag.traverse(visitor);
         TopologyDag testTopologyDag = visitor.getTestTopologyDag();
 

--- a/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunnerTest.java
+++ b/streams/runners/storm/actions/src/test/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyTestRunnerTest.java
@@ -34,6 +34,7 @@ import com.hortonworks.streamline.streams.layout.component.StreamlineSource;
 import com.hortonworks.streamline.streams.layout.component.TopologyDag;
 import com.hortonworks.streamline.streams.layout.component.TopologyLayout;
 import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunProcessor;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunRulesProcessor;
 import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSink;
 import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSource;
 import mockit.Delegate;
@@ -336,12 +337,13 @@ public class TopologyTestRunnerTest {
     private void setSucceedTopologyActionsExpectations() throws Exception {
         new Expectations() {{
             topologyActions.runTest(withInstanceOf(TopologyLayout.class), withInstanceOf(TopologyTestRunHistory.class),
-                    anyString, withInstanceOf(Map.class),
+                    anyString, withInstanceOf(Map.class), withInstanceOf(Map.class),
                     withInstanceOf(Map.class), withInstanceOf(Map.class), withInstanceOf(Optional.class));
             result = new Delegate<Object>() {
                 Object delegate(TopologyLayout topology, TopologyTestRunHistory testRunHistory, String mavenArtifacts,
                                 Map<String, TestRunSource> testRunSourcesForEachSource,
                                 Map<String, TestRunProcessor> testRunProcessorsForEachProcessor,
+                                Map<String, TestRunRulesProcessor> testRunRulesProcessorsForEachProcessor,
                                 Map<String, TestRunSink> testRunSinksForEachSink,
                                 Optional<Long> durationSecs) throws Exception {
                     Map<String, List<Map<String, Object>>> testOutputRecords =
@@ -370,7 +372,7 @@ public class TopologyTestRunnerTest {
     private void setTopologyActionsThrowingExceptionExpectations() throws Exception {
         new Expectations() {{
             topologyActions.runTest(withInstanceOf(TopologyLayout.class), withInstanceOf(TopologyTestRunHistory.class),
-                    anyString, withInstanceOf(Map.class),
+                    anyString, withInstanceOf(Map.class), withInstanceOf(Map.class),
                     withInstanceOf(Map.class), withInstanceOf(Map.class), withInstanceOf(Optional.class));
             result = new RuntimeException("Topology test run failed!");
         }};

--- a/streams/runners/storm/common/src/main/java/com/hortonworks/streamline/streams/storm/common/StormTopologyUtil.java
+++ b/streams/runners/storm/common/src/main/java/com/hortonworks/streamline/streams/storm/common/StormTopologyUtil.java
@@ -18,8 +18,13 @@ package com.hortonworks.streamline.streams.storm.common;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 public class StormTopologyUtil {
+    public static final String COMPONENT_NAME_STORM_AUXILIARY_PART_DELIMITER = "$$";
+    public static final String REGEX_COMPONENT_NAME_STORM_AUXILIARY_PART_DELIMITER = "\\$\\$";
+    public static final String REGEX_COMPONENT_ID_STORM_AUXILIARY_PART_DELIMITER = "\\.";
+
     private StormTopologyUtil() {
     }
 
@@ -70,6 +75,10 @@ public class StormTopologyUtil {
         }
         return actualTopologyName;
     }
+    
+    public static String createComponentNameWithAuxPart(String streamlineComponentName, String auxiliaryPart) {
+        return streamlineComponentName + COMPONENT_NAME_STORM_AUXILIARY_PART_DELIMITER + auxiliaryPart;
+    }
 
     public static String extractStreamlineComponentName(String stormComponentId) {
         String[] splitted = stormComponentId.split("-");
@@ -78,6 +87,13 @@ public class StormTopologyUtil {
         }
 
         List<String> splittedList = Arrays.asList(splitted);
-        return String.join("-", splittedList.subList(1, splittedList.size()));
+        String componentName = String.join("-", splittedList.subList(1, splittedList.size()));
+        return componentName.split(REGEX_COMPONENT_NAME_STORM_AUXILIARY_PART_DELIMITER)[0];
+    }
+
+    public static String extractStreamlineComponentId(String stormComponentId) {
+        // removes all starting from first '-'
+        String componentId = stormComponentId.substring(0, stormComponentId.indexOf('-'));
+        return componentId.split(REGEX_COMPONENT_ID_STORM_AUXILIARY_PART_DELIMITER)[0];
     }
 }

--- a/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/StormTopologyFluxGenerator.java
+++ b/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/StormTopologyFluxGenerator.java
@@ -35,6 +35,7 @@ import com.hortonworks.streamline.streams.layout.component.TopologyLayout;
 import com.hortonworks.streamline.streams.layout.component.impl.RulesProcessor;
 import com.hortonworks.streamline.streams.layout.component.rule.Rule;
 import com.hortonworks.streamline.streams.layout.component.rule.expression.Window;
+import com.hortonworks.streamline.streams.storm.common.StormTopologyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -132,7 +133,9 @@ public class StormTopologyFluxGenerator extends TopologyDagVisitor {
                 windowedRulesProcessorId++;
                 windowedRulesProcessor.setRules(new ArrayList<>(entry.getValue()));
                 windowedRulesProcessor.setId(rulesProcessor.getId() + "." + windowedRulesProcessorId);
-                windowedRulesProcessor.setName(rulesProcessor.getName() + "$$windowed-" + windowedRulesProcessorId);
+                String newComponentName = StormTopologyUtil.createComponentNameWithAuxPart(rulesProcessor.getName(),
+                        "windowed-" + windowedRulesProcessorId);
+                windowedRulesProcessor.setName(newComponentName);
                 windowedRulesProcessor.getConfig().setAny(RulesProcessor.CONFIG_KEY_RULES, Collections2.transform(entry.getValue(), new Function<Rule, Long>() {
                     @Override
                     public Long apply(Rule input) {

--- a/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/TestRunRulesProcessorBoltFluxComponent.java
+++ b/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/TestRunRulesProcessorBoltFluxComponent.java
@@ -1,0 +1,83 @@
+/**
+  * Copyright 2017 Hortonworks.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+
+  *   http://www.apache.org/licenses/LICENSE-2.0
+
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.layout.storm;
+
+import com.hortonworks.streamline.common.util.ReflectionHelper;
+import com.hortonworks.streamline.streams.layout.component.StreamlineProcessor;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunProcessor;
+import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunRulesProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TestRunRulesProcessorBoltFluxComponent extends AbstractFluxComponent {
+    private final Logger log = LoggerFactory.getLogger(TestRunRulesProcessorBoltFluxComponent.class);
+
+    protected TestRunRulesProcessor testRunRulesProcessor;
+
+    @Override
+    protected void generateComponent() {
+        testRunRulesProcessor = (TestRunRulesProcessor) conf.get(StormTopologyLayoutConstants.STREAMLINE_COMPONENT_CONF_KEY);
+        String boltId = "testRunRulesProcessorBolt" + UUID_FOR_COMPONENTS;
+
+        String boltClassName;
+        if (testRunRulesProcessor.isWindowed()) {
+            boltClassName = "com.hortonworks.streamline.streams.runtime.storm.testing.TestRunWindowProcessorBolt";
+        } else {
+            boltClassName = "com.hortonworks.streamline.streams.runtime.storm.testing.TestRunProcessorBolt";
+        }
+
+        String underlyingBoltComponentId = addUnderlyingBoltComponent();
+
+        List<Object> constructorArgs = new ArrayList<>();
+        constructorArgs.add(getRefYaml(underlyingBoltComponentId));
+        constructorArgs.add(testRunRulesProcessor.getEventLogFilePath());
+        component = createComponent(boltId, boltClassName, null, constructorArgs, null);
+        addParallelismToComponent();
+    }
+
+    private String addUnderlyingBoltComponent() {
+        StreamlineProcessor underlyingProcessor = testRunRulesProcessor.getUnderlyingProcessor();
+        String transformationClass = underlyingProcessor.getTransformationClass();
+        Map<String, Object> underlyingComponent;
+        try {
+            AbstractFluxComponent transformation = ReflectionHelper.newInstance(transformationClass);
+
+            Map<String, Object> props = new LinkedHashMap<>();
+            props.putAll(underlyingProcessor.getConfig().getProperties());
+            props.put(StormTopologyLayoutConstants.STREAMLINE_COMPONENT_CONF_KEY, testRunRulesProcessor.getUnderlyingProcessor());
+            // should get rid of below things which is only supported to spout and bolt in flux
+            props.remove("parallelism");
+            transformation.withConfig(props);
+            underlyingComponent = transformation.getComponent();
+
+            for (Map<String, Object> dependentComponents : transformation.getReferencedComponents()) {
+                addToComponents(dependentComponents);
+            }
+
+            addToComponents(underlyingComponent);
+
+            return (String) underlyingComponent.get(StormTopologyLayoutConstants.YAML_KEY_ID);
+        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+            log.error("Error creating underlying transformation instance", e);
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
* create TestRunRulesProcessor which extends RulesProcessor
  * it enables StormTopologyFluxGenerator to handle it as RulesProcessor
* modify handling windowed rules to call copy constructor of its own class, not always RulesProcessor
  * fail back to call copy constructor of RulesProcessor if the class doesn't have copy constructor