### PR TITLE
ISSUE-985 Each RulesProcessor should be matched to a Storm Bolt, not …

### DIFF
--- a/streams/runners/storm/common/src/main/java/com/hortonworks/streamline/streams/storm/common/StormTopologyUtil.java
+++ b/streams/runners/storm/common/src/main/java/com/hortonworks/streamline/streams/storm/common/StormTopologyUtil.java
@@ -21,10 +21,6 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 public class StormTopologyUtil {
-    public static final String COMPONENT_NAME_STORM_AUXILIARY_PART_DELIMITER = "$$";
-    public static final String REGEX_COMPONENT_NAME_STORM_AUXILIARY_PART_DELIMITER = "\\$\\$";
-    public static final String REGEX_COMPONENT_ID_STORM_AUXILIARY_PART_DELIMITER = "\\.";
-
     private StormTopologyUtil() {
     }
 
@@ -76,10 +72,6 @@ public class StormTopologyUtil {
         return actualTopologyName;
     }
     
-    public static String createComponentNameWithAuxPart(String streamlineComponentName, String auxiliaryPart) {
-        return streamlineComponentName + COMPONENT_NAME_STORM_AUXILIARY_PART_DELIMITER + auxiliaryPart;
-    }
-
     public static String extractStreamlineComponentName(String stormComponentId) {
         String[] splitted = stormComponentId.split("-");
         if (splitted.length <= 1) {
@@ -87,13 +79,11 @@ public class StormTopologyUtil {
         }
 
         List<String> splittedList = Arrays.asList(splitted);
-        String componentName = String.join("-", splittedList.subList(1, splittedList.size()));
-        return componentName.split(REGEX_COMPONENT_NAME_STORM_AUXILIARY_PART_DELIMITER)[0];
+        return String.join("-", splittedList.subList(1, splittedList.size()));
     }
 
     public static String extractStreamlineComponentId(String stormComponentId) {
         // removes all starting from first '-'
-        String componentId = stormComponentId.substring(0, stormComponentId.indexOf('-'));
-        return componentId.split(REGEX_COMPONENT_ID_STORM_AUXILIARY_PART_DELIMITER)[0];
+        return stormComponentId.substring(0, stormComponentId.indexOf('-'));
     }
 }


### PR DESCRIPTION
…multiple

* add some assertions on checking RulesProcessor needs multiple Storm Bolts
  * if then throws IllegalStateException to prevent Storm topology being generated

This implements decision on #985 and closes #985. 