### PR TITLE
ISSUE-968 Join processor output when both streams have same field

### DIFF
--- a/webservice/src/main/resources/app/scripts/components/SelectInputComponent.jsx
+++ b/webservice/src/main/resources/app/scripts/components/SelectInputComponent.jsx
@@ -1,0 +1,146 @@
+/**
+  * Copyright 2017 Hortonworks.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *   http://www.apache.org/licenses/LICENSE-2.0
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+**/
+
+import React, {Component} from 'react';
+import _  from 'lodash';
+import {OverlayTrigger, Popover} from 'react-bootstrap';
+import Utils from '../utils/Utils';
+
+export default class SelectInputComponent extends Component{
+  constructor(props) {
+    super(props);
+    this.filterNode = [];
+    this.state = {
+      aliasValue : props.node.alias
+    };
+  }
+
+  componentDidMount(){
+    this.highlightNode();
+  }
+
+  componentDidUpdate(){
+    this.highlightNode();
+    this.valueCheck();
+  }
+
+  valueCheck = () => {
+    const {node} = this.props;
+    if(this.state.aliasValue === ''){
+      this.setInputBoxColor(node);
+    } else {
+      this.validate(node,this.state.aliasValue);
+    }
+  }
+
+  validate = (node,val) => {
+    if(!Utils.noSpecialCharString(val)){
+      this.setInputBoxColor(node);
+    }
+  }
+
+  highlightNode = () => {
+    const {outputKeysObjArr,node,legends} = this.props;
+    this.filterNode = _.filter(outputKeysObjArr, (o) =>  o.alias === node.alias);
+    if(this.filterNode.length > 1){
+      _.map(this.filterNode,(n) => {
+        const pEl = this.getParentElement(n);
+        let color = "#676767";
+        if(n.alias === node.alias){
+          color = "#fd5454";
+        }
+        if(pEl !== null && pEl !== undefined){
+          const gParent = this.getGrandParentElement(pEl);
+          gParent.style['background-color'] =  color;
+        }
+      });
+    } else {
+      const single =  this.filterNode[0];
+      const parent =  this.getParentElement(single);
+      const gParent = this.getGrandParentElement(parent);
+      gParent.style['background-color'] =  "#676767";
+    }
+  }
+
+  getParentElement = (n) => {
+    return  this.refs['pEl_'+n.keyPath+'_'+n.name];
+  }
+
+  getGrandParentElement = (parent) => {
+    return parent.parentNode.parentNode;
+  }
+
+  InputChange = (node,event) => {
+    const val = event.target.value;
+    if(val === '' || !Utils.noSpecialCharString(val)){
+      this.setInputBoxColor(node);
+    }
+    this.setState({aliasValue : val.trim()}, () => {
+      if(Utils.noSpecialCharString(this.state.aliasValue)){
+        this.props.renderValueInputChange(node,val.trim());
+      }
+    });
+  }
+
+  setInputBoxColor = (node) => {
+    const parent = this.getParentElement(node);
+    const gParent = this.getGrandParentElement(parent);
+    gParent.style.backgroundColor =  "#fd5454";
+  }
+
+  findLegends = (node) => {
+    const {legends} = this.props;
+    return _.findIndex(legends, (legend) => {
+      let stream='';
+      if(node.keyPath.search('.') !== -1){
+        stream = node.keyPath.split('.')[0];
+      } else{
+        stream = node.keyPath;
+      }
+      return legend === stream;
+    });
+  }
+
+  render(){
+    const {aliasValue} = this.state;
+    const {node,outputKeysObjArr} = this.props;
+    const styleObj = {
+      color : 'black',
+      border : '1px solid #b4bbc5',
+      borderRadius : '4px',
+      padding : '2px',
+      marginLeft : '3px'
+    };
+    const showWarning = _.filter(outputKeysObjArr, (o) =>  o.alias === node.alias);
+    let legendIndex = '';
+    let index = this.findLegends(node);
+    if(index !== -1){
+      legendIndex = ++index;
+    }
+    return(
+      <span ref={'pEl_'+node.keyPath+'_'+node.name}>
+        <strong style={{marginRight : '10px'}}>{legendIndex }</strong>
+        {node.name}
+        <span> as <input style={styleObj} ref={node.keyPath+'_'+node.name} type="text" value={aliasValue} onChange={this.InputChange.bind(this,node)}/></span>
+        {
+          showWarning.length > 1
+          ? <OverlayTrigger trigger={['hover']} placement="right" overlay={<Popover id="popover-trigger-hover">resolve the duplicate alias & special character are allow _ and - </Popover>}>
+              <span style={{marginLeft : '5px'}}><i className="fa fa-exclamation-triangle"></i></span>
+            </OverlayTrigger>
+          : null
+        }
+      </span>
+    );
+  }
+}

--- a/webservice/src/main/resources/app/scripts/components/StreamSidebar.jsx
+++ b/webservice/src/main/resources/app/scripts/components/StreamSidebar.jsx
@@ -50,6 +50,10 @@ export default class StreamSidebar extends Component {
         level: level,
         keyPath : field.keyPath
       };
+      if(field.alias !== undefined){
+        obj.alias = field.alias;
+      }
+
 
       if (field.type === 'NESTED' && field.fields) {
         this.fieldsArr.push(obj);
@@ -96,8 +100,8 @@ export default class StreamSidebar extends Component {
                 <li key={i} style={styleObj}>
                   {
                     streamKind === "output"
-                    ? <span title={field.keyPath}>{field.name}</span>
-                    : field.name
+                    ? <span title={field.keyPath}>{field.alias !== undefined ? field.alias : field.name}</span>
+                    : field.alias !== undefined ? field.alias : field.name
                   }
                   {!field.optional && field.type !== "NESTED"
                     ? <span className="text-danger">*</span>

--- a/webservice/src/main/resources/app/scripts/components/TimeStamp.jsx
+++ b/webservice/src/main/resources/app/scripts/components/TimeStamp.jsx
@@ -1,0 +1,112 @@
+/**
+  * Copyright 2017 Hortonworks.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *   http://www.apache.org/licenses/LICENSE-2.0
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+**/
+
+import React, {Component} from 'react';
+import {DropdownButton, MenuItem} from 'react-bootstrap';
+
+export default class TimeStamp extends Component{
+  constructor(props){
+    super(props);
+  }
+  onRadioChanged = (e) => {
+    let {value = []} = this.props;
+    const newValue = e.target.value;
+    if(value === null || value === undefined){
+      value = [newValue];
+    }else{
+      const v = value.find((v) => {
+        return v.indexOf(newValue.split(':')[0]+':') == 0;
+      });
+      const index = value.indexOf(v);
+      if(index >= 0){
+        value[index] = newValue;
+      }else{
+        value.push(newValue);
+      }
+    }
+    this.props.onChange(value);
+  }
+  getOptionComp(opt, i){
+    let {value} = this.props;
+    if(value == null || value == undefined){
+      value = [];
+    }
+    const comps = [];
+    const name = opt.streamId;
+    const level = 1;
+    const createComp = (opt, level) => {
+      if(opt.fields){
+        const style = {
+          paddingLeft: (10 * level) + "px"
+        };
+        comps.push(<div style={style} key={opt.uniqueID}>
+          <strong>
+            {opt.streamId || opt.name}
+          </strong>
+        </div>);
+        opt.fields.forEach((childOpt) => {
+          createComp(childOpt, level+1);
+        });
+      }else{
+        const style = {
+          paddingLeft: (10 * level) + "px"
+        };
+        comps.push(<div style={style} key={opt.uniqueID}>
+          <label>
+            <input name={name} type="radio" value={opt.uniqueID} checked={value.indexOf(opt.uniqueID) >= 0}/>
+            {opt.name}
+          </label>
+        </div>);
+      }
+    };
+    createComp(opt, level);
+    return comps;
+  }
+  getSelectedValueComp(){
+    let {value} = this.props;
+    let comps;
+    if(value === null || value === undefined){
+      comps = <span className="tsField-placeholder">Select...</span>;
+    }else{
+      comps = value.map((v,i)=>{
+        var val = v.split(':')[1].split('.');
+        return <span className="timestamp-val" key={val[val.length-1]+'_'+i}>{val[val.length-1]}</span>;
+      });
+    }
+    return comps;
+  }
+  render(){
+    const {options = []} = this.props;
+    return(
+      <div className="timestamp-container">
+        <DropdownButton
+          title={
+            <div className="timeStamp-value">{this.getSelectedValueComp()}</div>
+          }
+          id="tsFieldDropdown"
+        >
+          <div style={{padding: options.length ? '5px' : '0 5px'}} className="tsField-dropdown" onChange={this.onRadioChanged}>
+          {
+            options.length
+            ? options.map((op, i) => {
+              return this.getOptionComp(op, i);
+            })
+            : <span style={{color : '#b3b3b3'}}>No Records</span>
+          }
+          </div>
+        </DropdownButton>
+      </div>
+    );
+  }
+}

--- a/webservice/src/main/resources/app/scripts/utils/ProcessorUtils.js
+++ b/webservice/src/main/resources/app/scripts/utils/ProcessorUtils.js
@@ -29,7 +29,7 @@ import moment from 'moment';
   else
   it will return only tempFieldsArr = nested fields
 */
-const getSchemaFields = function(fields, level, initialFetch, keyPath = []) {
+const getSchemaFields = function(fields, level, initialFetch, keyPath = [], disabled = true) {
   let fieldTempArr = [] , tempFieldsArr = [];
   const getSchemaNestedFields = (fields, level, keyPath) => {
     fields.map((field) => {
@@ -42,7 +42,9 @@ const getSchemaFields = function(fields, level, initialFetch, keyPath = []) {
       };
 
       if (field.type === 'NESTED') {
-        obj.disabled = true;
+        if(level == 0 || disabled){
+          obj.disabled = true;
+        }
         let _keypath = keyPath.slice();
         _keypath.push(field.name);
         // level === 1 ? obj.keyPath = _keypath[0] : '';
@@ -346,20 +348,20 @@ const createOutputFieldsObjArr=  function(outputFieldsArr,outputFieldsList){
   selectAllOutputFields accept the array of outputFieldsList
   and return array of unique fields
 */
-const selectAllOutputFields = function(tempFields,sinkForm){
+const selectAllOutputFields = function(tempFields,string){
   let tempAllFields = [];
   _.map(tempFields, (field, i ) => {
     if(field.type !== 'NESTED'){
       let data = null;
-      !!sinkForm
-        ?  data = _.findIndex(tempAllFields, (temp) => {return temp.value === field.value;})
+      string === 'joinForm'
+        ? data = -1
         : data = _.findIndex(tempAllFields, (temp) => {return temp.name === field.name;});
       if(data === -1){
         tempAllFields = _.concat(tempAllFields ,field);
       }
     }
   });
-  if(!!sinkForm){
+  if(string === 'sinkForm'){
     tempAllFields = tempAllFields.map((field)=>{return field.value;});
   }
   return tempAllFields;
@@ -389,22 +391,22 @@ const splitNestedKey = function(key) {
 
   return streamObjArr {name : "UI", type : "String", optional : false}
 */
-const generateOutputStreamsArr = function(fieldList,_level){
-  const generateOutputStreams = function(fields,level){
+const generateOutputStreamsArr = function(fieldList,_level,alias){
+  const generateOutputStreams = function(fields,level,alias){
     return fields.map((field) => {
       let obj = {
-        name: field.name,
+        name: !!alias ? field.alias : field.name ,
         type: field.type ,
         optional : false
       };
 
       if (field.type === 'NESTED' && field.fields) {
-        obj.fields = generateOutputStreams(field.fields, level + 1);
+        obj.fields = generateOutputStreams(field.fields, level + 1,alias);
       }
       return obj;
     });
   };
-  return generateOutputStreams(fieldList,_level);
+  return generateOutputStreams(fieldList,_level,alias);
 };
 
 const getNestedKeyFromGroup = function(str){
@@ -443,26 +445,28 @@ export class Streams {
     const streams = this.cloneStreams(this.streams);
     this.setParent(streams);
 
+    const remove = (stream, arr) => {
+      const i = arr.indexOf(stream);
+      arr.splice(i,1);
+      return true;
+    };
+
     const filter = (stream, arr) => {
       if(stream.fields && stream.fields.length){
-        /*stream.fields.forEach((s) => {
-          filter(s, stream.fields);
-        });*/
         for(let i = 0; i< stream.fields.length;){
           const removed = filter(stream.fields[i], stream.fields);
           if(!removed){
             i++;
           }
         }
+        if(!stream.fields.length){
+          return remove(stream, arr);
+        }
       } else if(stream.type != type) {
-        const i = arr.indexOf(stream);
-        arr.splice(i,1);
-        return true;
+        return remove(stream, arr);
       }
     };
-    /*streams.forEach((s) => {
-      filter(s, streams);
-    });*/
+
     for(let i = 0; i< streams.length;){
       const removed = filter(streams[i], streams);
       if(removed !== true){
@@ -508,6 +512,51 @@ export class Streams {
   }
 }
 
+const removeChildren = function (arr){ //Remove children from top level if parent is selected
+  for(let i = 0; i < arr.length;){
+    let removed = false;
+    const field = arr[i];
+    const hasParent = arr.find((f) => {
+      return (f.keyPath+'.'+f.name) == field.keyPath;
+    });
+    if(hasParent){
+      arr.splice(i,1);
+      removed = true;
+    }
+    if(!removed){
+      i++;
+    }
+  }
+};
+
+const addChildren = function(arr, outputFieldsList){ //Add children of selected parent
+  for(let i = 0; i < arr.length;i++){
+    const field = arr[i];
+    if(field.type == 'NESTED'){
+      const subFields = field.fields = [];
+      outputFieldsList.forEach((ofld) => {
+        if(ofld.keyPath == (field.keyPath+'.'+field.name)){
+          subFields.push(ofld);
+        }
+      });
+      addChildren(subFields,outputFieldsList);
+    }
+  }
+};
+
+const filterOptions = function(selected, outputFieldsList){ //Filter out children from select options if parent is selected
+  const options = [];
+  outputFieldsList.forEach((f) => {
+    const isParentSelected = selected.find((sf) => {
+      return (sf.keyPath+'.'+sf.name) == f.keyPath;
+    });
+    if(!isParentSelected){
+      options.push(f);
+    }
+  });
+  return options;
+};
+
 export default {
   getSchemaFields,
   createSelectedKeysHierarchy,
@@ -522,5 +571,8 @@ export default {
   selectAllOutputFields,
   splitNestedKey,
   generateOutputStreamsArr,
-  getNestedKeyFromGroup
+  getNestedKeyFromGroup,
+  removeChildren,
+  addChildren,
+  filterOptions
 };

--- a/webservice/src/main/resources/app/scripts/utils/Utils.js
+++ b/webservice/src/main/resources/app/scripts/utils/Utils.js
@@ -685,7 +685,7 @@ const noSpecialCharString = function(string){
   if(string === ''){
     return;
   }
-  return /^[a-zA-Z0-9/_//-]+$/.test(string);
+  return /^[a-zA-Z0-9_-]+$/.test(string);
 };
 
 export default {

--- a/webservice/src/main/resources/app/styles/css/style.css
+++ b/webservice/src/main/resources/app/styles/css/style.css
@@ -402,6 +402,44 @@ label {
   padding-top: 5px !important;
 }
 
+#tsFieldDropdown{
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 2px 10px;
+  line-height: 28px;
+}
+
+.timestamp-container .dropdown.btn-group, #tsFieldDropdown{
+  width:100%;
+  display: table;
+  white-space: normal;
+  min-height: 35px;
+}
+.timestamp-container .caret,.timestamp-container .timeStamp-value{
+  display: table-cell;
+}
+.timestamp-container .caret{
+  position: absolute;
+  top: 15px;
+  right: 5px;
+}
+
+.tsField-placeholder{
+  line-height: 30px;
+  color: #aaa;
+}
+
+.timestamp-val{
+  background: #676767;
+  color: white;
+  padding: 0px 7px;
+  border-radius: 2px;
+  font-size: 12px;
+  display: inline-block;
+  float: left;
+  margin: 1px 3px;
+}
+
 .sink-modal-form {
   margin-left: 200px;
   /*margin-right: 10px;*/
@@ -3836,4 +3874,13 @@ ul.custom-pagination li:last-child{
 ul.custom-pagination li.active{
   color: #fff;
   background-color: #808080;
+}
+.timestamp-container > .dropdown > ul {
+  width: 100%;
+  max-height: 300px;
+  overflow: auto;
+}
+.tsField-dropdown input{
+  margin: -2px 4px 0 0;
+  vertical-align: middle;
 }


### PR DESCRIPTION
Join processor support for multiple streams with same fields name by using a unique alias.
the screenshot below:

![joinscreenshot](https://user-images.githubusercontent.com/6010694/32105010-8a431c32-bb44-11e7-8da7-ebe034bbb834.png)

Stream legends are used to denote which field belong to which stream.
We can have in the way it’s shown in the screenshot or add an icon beside the “Output Fields*” label where a user can hover and check.
I am preferring the former approach so the user doesn’t have to hover over the icon every now and then to verify as it will always be available on the screen.

Open for a suggestion from others.

@shahsank3t  @arunmahadevan  @roshannaik please review and comment.
Thanks in advanced