### PR TITLE
ISSUE-1001 Implement backend part of Log Search feature

### DIFF
--- a/bootstrap/sql/mysql/v010__add_log_search_service_to_namespace.sql
+++ b/bootstrap/sql/mysql/v010__add_log_search_service_to_namespace.sql
@@ -1,0 +1,15 @@
+-- Copyright 2017 Hortonworks.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--    http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+ALTER TABLE `namespace` ADD logSearchService VARCHAR(255) NULL;

--- a/bootstrap/sql/oracle/v009__add_log_search_service_to_namespace.sql
+++ b/bootstrap/sql/oracle/v009__add_log_search_service_to_namespace.sql
@@ -1,0 +1,15 @@
+-- Copyright 2017 Hortonworks.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--    http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+ALTER TABLE "namespace" ADD ("logSearchService" VARCHAR(255) NULL);

--- a/bootstrap/sql/postgresql/v010__add_log_search_service_to_namespace.sql
+++ b/bootstrap/sql/postgresql/v010__add_log_search_service_to_namespace.sql
@@ -1,0 +1,15 @@
+-- Copyright 2017 Hortonworks.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--    http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+ALTER TABLE "namespace" ADD COLUMN "logSearchService" VARCHAR(255) NULL;

--- a/conf/streamline_jaas.conf
+++ b/conf/streamline_jaas.conf
@@ -29,3 +29,12 @@ RegistryClient {
   useTicketCache=false
   principal="registy_client_principal@EXAMPLE.COM";
 };
+Client {
+  com.sun.security.auth.module.Krb5LoginModule required
+  useKeyTab=true
+  keyTab="/etc/solr_client.keytab"
+  storeKey=true
+  useTicketCache=true
+  debug=true
+  principal="solr_client_principal@EXAMPLE.COM";
+};

--- a/pom.xml
+++ b/pom.xml
@@ -811,6 +811,16 @@
             </dependency>
             <dependency>
                 <groupId>com.hortonworks.streamline</groupId>
+                <artifactId>streamline-logsearch</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.hortonworks.streamline</groupId>
+                <artifactId>streamline-logsearch-storm</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.hortonworks.streamline</groupId>
                 <artifactId>streams</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/catalog/Namespace.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/catalog/Namespace.java
@@ -38,6 +38,7 @@ public class Namespace extends AbstractStorable {
   @SearchableField
   private String streamingEngine;
   private String timeSeriesDB;
+  private String logSearchService;
   @SearchableField
   private String description = "";
   private Long timestamp;
@@ -103,6 +104,17 @@ public class Namespace extends AbstractStorable {
   }
 
   /**
+   * The selected Log Search Service of the namespace
+   */
+  public String getLogSearchService() {
+    return logSearchService;
+  }
+
+  public void setLogSearchService(String logSearchService) {
+    this.logSearchService = logSearchService;
+  }
+
+  /**
    * The namespace description (optional)
    */
   public String getDescription() {
@@ -134,10 +146,11 @@ public class Namespace extends AbstractStorable {
       return false;
     if (getTimeSeriesDB() != null ? !getTimeSeriesDB().equals(namespace.getTimeSeriesDB()) : namespace.getTimeSeriesDB() != null)
       return false;
+    if (getLogSearchService() != null ? !getLogSearchService().equals(namespace.getLogSearchService()) : namespace.getLogSearchService() != null)
+      return false;
     if (getDescription() != null ? !getDescription().equals(namespace.getDescription()) : namespace.getDescription() != null)
       return false;
     return getTimestamp() != null ? getTimestamp().equals(namespace.getTimestamp()) : namespace.getTimestamp() == null;
-
   }
 
   @Override
@@ -146,6 +159,7 @@ public class Namespace extends AbstractStorable {
     result = 31 * result + (getName() != null ? getName().hashCode() : 0);
     result = 31 * result + (getStreamingEngine() != null ? getStreamingEngine().hashCode() : 0);
     result = 31 * result + (getTimeSeriesDB() != null ? getTimeSeriesDB().hashCode() : 0);
+    result = 31 * result + (getLogSearchService() != null ? getLogSearchService().hashCode() : 0);
     result = 31 * result + (getDescription() != null ? getDescription().hashCode() : 0);
     result = 31 * result + (getTimestamp() != null ? getTimestamp().hashCode() : 0);
     return result;
@@ -158,6 +172,7 @@ public class Namespace extends AbstractStorable {
             ", name='" + name + '\'' +
             ", streamingEngine='" + streamingEngine + '\'' +
             ", timeSeriesDB='" + timeSeriesDB + '\'' +
+            ", logSearchService='" + logSearchService + '\'' +
             ", description='" + description + '\'' +
             ", timestamp=" + timestamp +
             '}';

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/discovery/ambari/ComponentPropertyPattern.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/discovery/ambari/ComponentPropertyPattern.java
@@ -51,7 +51,10 @@ public enum ComponentPropertyPattern {
   KAFKA_BROKER("listeners", Pattern.compile("([a-zA-Z]+)://[a-zA-Z0-9_\\-\\\\.]*:([0-9]+)")),
 
   // AMBARI_METRICS
-  METRICS_COLLECTOR("timeline.metrics.service.webapp.address", Pattern.compile("()[a-zA-Z0-9_\\-\\\\.]*:([0-9]+)"));
+  METRICS_COLLECTOR("timeline.metrics.service.webapp.address", Pattern.compile("()[a-zA-Z0-9_\\-\\\\.]*:([0-9]+)")),
+
+  // AMBARI_INFRA
+  INFRA_SOLR("infra_solr_port");
 
   private final String connectionConfName;
   private final Pattern parsePattern;

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/discovery/ambari/ServiceConfigurations.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/discovery/ambari/ServiceConfigurations.java
@@ -34,7 +34,8 @@ public enum ServiceConfigurations {
       "hivemetastore-site", "hiveserver2-interactive-site",
       "hiveserver2-site","hive-site"),
   AMBARI_METRICS("ams-env", "ams-site"),
-  DRUID("druid-common", "druid-overlord");
+  DRUID("druid-common", "druid-overlord"),
+  AMBARI_INFRA("infra-solr-env");
 
   private final String[] confNames;
 

--- a/streams/logsearch/pom.xml
+++ b/streams/logsearch/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>streams</artifactId>
+        <groupId>com.hortonworks.streamline</groupId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>streamline-logsearch</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.hortonworks.streamline</groupId>
+            <artifactId>streamline-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.hortonworks.streamline</groupId>
+            <artifactId>streamline-cluster</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.hortonworks.streamline</groupId>
+            <artifactId>streamline-layout</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.hortonworks.streamline</groupId>
+            <artifactId>streamline-catalog</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/DefaultTopologyLogSearch.java
+++ b/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/DefaultTopologyLogSearch.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.logsearch;
+
+import com.hortonworks.streamline.common.exception.ConfigException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultTopologyLogSearch implements TopologyLogSearch {
+  @Override
+  public void init(Map<String, Object> conf) throws ConfigException {
+    // no-op
+  }
+
+  @Override
+  public LogSearchResult search(LogSearchCriteria criteria) {
+    // no-op. just returning empty result
+    return new LogSearchResult(0L, Collections.emptyList());
+  }
+}

--- a/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/LogSearchCriteria.java
+++ b/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/LogSearchCriteria.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.logsearch;
+
+import java.util.Collections;
+import java.util.List;
+
+public class LogSearchCriteria {
+    private String appId;
+    private List<String> componentNames;
+    private List<String> logLevels;
+    private String searchString;
+    private long from;
+    private long to;
+    private Integer start;
+    private Integer limit;
+
+    public String getAppId() {
+        return appId;
+    }
+
+    public List<String> getComponentNames() {
+        return componentNames;
+    }
+
+    public List<String> getLogLevels() {
+        return logLevels;
+    }
+
+    public String getSearchString() {
+        return searchString;
+    }
+
+    public long getFrom() {
+        return from;
+    }
+
+    public long getTo() {
+        return to;
+    }
+
+    public Integer getStart() {
+        return start;
+    }
+
+    public Integer getLimit() {
+        return limit;
+    }
+
+    public LogSearchCriteria(String appId, String componentName, String logLevel, String searchString,
+                             long from, long to, Integer start, Integer limit) {
+        this.appId = appId;
+        this.componentNames = Collections.singletonList(componentName);
+        this.logLevels = Collections.singletonList(logLevel);
+        this.searchString = searchString;
+        this.from = from;
+        this.to = to;
+        this.start = start;
+        this.limit = limit;
+    }
+
+    public LogSearchCriteria(String appId, List<String> componentNames, List<String> logLevels, String searchString,
+                             long from, long to, Integer start, Integer limit) {
+        this.appId = appId;
+        this.componentNames = componentNames;
+        this.logLevels = logLevels;
+        this.searchString = searchString;
+        this.from = from;
+        this.to = to;
+        this.start = start;
+        this.limit = limit;
+    }
+
+    public static class Builder {
+        private String appId;
+        private List<String> componentNames;
+        private List<String> logLevels;
+        private String searchString;
+        private long from;
+        private long to;
+        private Integer start;
+        private Integer limit;
+
+        public Builder(String appId, long from, long to) {
+            this.appId = appId;
+            this.from = from;
+            this.to = to;
+        }
+
+        public Builder setComponentNames(List<String> componentNames) {
+            this.componentNames = componentNames;
+            return this;
+        }
+
+        public Builder setLogLevels(List<String> logLevels) {
+            this.logLevels = logLevels;
+            return this;
+        }
+
+        public Builder setSearchString(String searchString) {
+            this.searchString = searchString;
+            return this;
+        }
+
+        public Builder setStart(Integer start) {
+            this.start = start;
+            return this;
+        }
+
+        public Builder setLimit(Integer limit) {
+            this.limit = limit;
+            return this;
+        }
+
+        public LogSearchCriteria build() {
+            return new LogSearchCriteria(appId, componentNames, logLevels, searchString, from, to, start, limit);
+        }
+    }
+}

--- a/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/LogSearchResult.java
+++ b/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/LogSearchResult.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.logsearch;
+
+import java.util.List;
+
+public class LogSearchResult {
+    private Long matchedDocs;
+    private List<LogDocument> documents;
+
+    public LogSearchResult(Long matchedDocs, List<LogDocument> documents) {
+        this.matchedDocs = matchedDocs;
+        this.documents = documents;
+    }
+
+    public Long getMatchedDocs() {
+        return matchedDocs;
+    }
+
+    public List<LogDocument> getDocuments() {
+        return documents;
+    }
+
+    public static class LogDocument {
+        private String appId;
+        private String componentName;
+        private String logLevel;
+        private String logMessage;
+        private String host;
+        private Integer port;
+
+        private long timestamp;
+
+        public LogDocument(String appId, String componentName, String logLevel, String logMessage,
+                           String host, Integer port, long timestamp) {
+            this.appId = appId;
+            this.componentName = componentName;
+            this.logLevel = logLevel;
+            this.logMessage = logMessage;
+            this.host = host;
+            this.port = port;
+            this.timestamp = timestamp;
+        }
+
+        public String getAppId() {
+            return appId;
+        }
+
+        public String getComponentName() {
+            return componentName;
+        }
+
+        public String getLogLevel() {
+            return logLevel;
+        }
+
+        public String getLogMessage() {
+            return logMessage;
+        }
+
+        public String getHost() {
+            return host;
+        }
+
+        public Integer getPort() {
+            return port;
+        }
+
+        public long getTimestamp() {
+            return timestamp;
+        }
+    }
+}

--- a/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/TopologyLogSearch.java
+++ b/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/TopologyLogSearch.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.logsearch;
+
+import com.hortonworks.streamline.common.exception.ConfigException;
+
+import java.util.List;
+import java.util.Map;
+
+public interface TopologyLogSearch {
+    // Any one time initialization is done here
+    void init (Map<String, Object> conf) throws ConfigException;
+
+    LogSearchResult search(LogSearchCriteria criteria);
+}

--- a/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/container/TopologyLogSearchContainer.java
+++ b/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/container/TopologyLogSearchContainer.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.logsearch.container;
+
+import com.hortonworks.streamline.common.exception.ConfigException;
+import com.hortonworks.streamline.streams.cluster.catalog.*;
+import com.hortonworks.streamline.streams.cluster.container.NamespaceAwareContainer;
+import com.hortonworks.streamline.streams.cluster.discovery.ambari.ComponentPropertyPattern;
+import com.hortonworks.streamline.streams.cluster.discovery.ambari.ServiceConfigurations;
+import com.hortonworks.streamline.streams.cluster.service.EnvironmentService;
+import com.hortonworks.streamline.streams.layout.TopologyLayoutConstants;
+import com.hortonworks.streamline.streams.logsearch.DefaultTopologyLogSearch;
+import com.hortonworks.streamline.streams.logsearch.TopologyLogSearch;
+import com.hortonworks.streamline.streams.logsearch.container.mapping.MappedTopologyLogSearchImpl;
+
+import javax.security.auth.Subject;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TopologyLogSearchContainer extends NamespaceAwareContainer<TopologyLogSearch> {
+    public static final String COMPONENT_NAME_INFRA_SOLR = ComponentPropertyPattern.INFRA_SOLR.name();
+    public static final String SERVICE_CONFIGURATION_NAME_INFRA_SOLR = ServiceConfigurations.AMBARI_INFRA.getConfNames()[0];
+    public static final String SOLR_API_URL_KEY = "solrApiUrl";
+    public static final String SECURED_CLUSTER_KEY = "secured";
+    public static final String AMBARI_INFRA_SOLR_KERBEROS_PRINCIPAL = "infra_solr_kerberos_principal";
+
+    private final Subject subject;
+
+    public TopologyLogSearchContainer(EnvironmentService environmentService, Subject subject) {
+        super(environmentService);
+        this.subject = subject;
+    }
+
+    @Override
+    protected TopologyLogSearch initializeInstance(Namespace namespace) {
+        MappedTopologyLogSearchImpl topologyLogSearchImpl;
+
+        String className;
+        Map<String, Object> confLogSearch;
+
+        String streamingEngine = namespace.getStreamingEngine();
+        String logSearchService = namespace.getLogSearchService();
+        if (logSearchService != null && !logSearchService.isEmpty()) {
+            String key = MappedTopologyLogSearchImpl.getName(streamingEngine, logSearchService);
+            try {
+                topologyLogSearchImpl = MappedTopologyLogSearchImpl.valueOf(key);
+            } catch (IllegalArgumentException e) {
+                throw new RuntimeException("Unsupported log search service: " + logSearchService, e);
+            }
+
+            confLogSearch = buildAmbariInfraLogSearchConfigMap(namespace, logSearchService, subject);
+            className = topologyLogSearchImpl.getClassName();
+        } else {
+            confLogSearch = Collections.emptyMap();
+            className = DefaultTopologyLogSearch.class.getName();
+        }
+
+        return initTopologyLogSearch(confLogSearch, className);
+    }
+
+    private TopologyLogSearch initTopologyLogSearch(Map<String, Object> conf, String className) {
+        try {
+            TopologyLogSearch topologyLogSearch = instantiate(className);
+            topologyLogSearch.init(conf);
+            return topologyLogSearch;
+        } catch (IllegalAccessException | InstantiationException | ClassNotFoundException | ConfigException e) {
+            throw new RuntimeException("Can't initialize Topology log search instance - Class Name: " + className, e);
+        }
+    }
+
+    private Map<String, Object> buildAmbariInfraLogSearchConfigMap(Namespace namespace, String logSearchServiceName,
+                                                                   Subject subject) {
+        // Assuming that a namespace has one mapping of log search service
+        Service logSearchService = getFirstOccurenceServiceForNamespace(namespace, logSearchServiceName);
+        if (logSearchService == null) {
+            throw new RuntimeException("Log search service " + logSearchServiceName + " is not associated to the namespace " +
+                    namespace.getName() + "(" + namespace.getId() + ")");
+        }
+
+        Component infraSolr = getComponent(logSearchService, COMPONENT_NAME_INFRA_SOLR)
+                .orElseThrow(() -> new RuntimeException(logSearchService + " doesn't have " + COMPONENT_NAME_INFRA_SOLR + " as component"));
+
+        Collection<ComponentProcess> solrProcesses = environmentService.listComponentProcesses(infraSolr.getId());
+        if (solrProcesses.isEmpty()) {
+            throw new RuntimeException(logSearchService + " doesn't have any process for " + COMPONENT_NAME_INFRA_SOLR + " as component");
+        }
+
+        ComponentProcess solrProcess = solrProcesses.iterator().next();
+        String solrHost = solrProcess.getHost();
+        Integer solrPort = solrProcess.getPort();
+
+        assertHostAndPort(COMPONENT_NAME_INFRA_SOLR, solrHost, solrPort);
+
+        ServiceConfiguration infraSolrConf = getServiceConfiguration(logSearchService, SERVICE_CONFIGURATION_NAME_INFRA_SOLR)
+                .orElseThrow(() -> new RuntimeException(logSearchService + "doesn't have " + SERVICE_CONFIGURATION_NAME_INFRA_SOLR + " as service configuration"));
+
+        boolean secured;
+        try {
+            secured = infraSolrConf.getConfigurationMap().containsKey(AMBARI_INFRA_SOLR_KERBEROS_PRINCIPAL);
+        } catch (IOException e) {
+            throw new RuntimeException("Fail to read service configuration " + SERVICE_CONFIGURATION_NAME_INFRA_SOLR);
+        }
+
+        Map<String, Object> confForLogSearchService = new HashMap<>();
+        confForLogSearchService.put(SOLR_API_URL_KEY, buildAmbariInfraSolrRestApiRootUrl(solrHost, solrPort));
+        confForLogSearchService.put(TopologyLayoutConstants.SUBJECT_OBJECT, subject);
+        confForLogSearchService.put(SECURED_CLUSTER_KEY, secured);
+        return confForLogSearchService;
+    }
+
+    private String buildAmbariInfraSolrRestApiRootUrl(String host, Integer port) {
+        return "http://" + host + ":" + port + "/solr";
+    }
+}

--- a/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/container/mapping/MappedTopologyLogSearchImpl.java
+++ b/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/container/mapping/MappedTopologyLogSearchImpl.java
@@ -1,0 +1,34 @@
+/**
+  * Copyright 2017 Hortonworks.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+
+  *   http://www.apache.org/licenses/LICENSE-2.0
+
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.logsearch.container.mapping;
+
+public enum MappedTopologyLogSearchImpl {
+    STORM_AMBARI_INFRA("com.hortonworks.streamline.streams.logsearch.storm.ambari.AmbariInfraWithStormLogSearch");
+
+    private final String className;
+
+    MappedTopologyLogSearchImpl(String className) {
+        this.className = className;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public static String getName(String streamingEngine, String logSearchService) {
+        return streamingEngine + "_" + logSearchService;
+    }
+}

--- a/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/topology/service/TopologyLogSearchService.java
+++ b/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/topology/service/TopologyLogSearchService.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.logsearch.topology.service;
+
+import com.hortonworks.streamline.streams.catalog.Topology;
+import com.hortonworks.streamline.streams.cluster.catalog.Namespace;
+import com.hortonworks.streamline.streams.cluster.container.ContainingNamespaceAwareContainer;
+import com.hortonworks.streamline.streams.cluster.service.EnvironmentService;
+import com.hortonworks.streamline.streams.logsearch.LogSearchCriteria;
+import com.hortonworks.streamline.streams.logsearch.LogSearchResult;
+import com.hortonworks.streamline.streams.logsearch.TopologyLogSearch;
+import com.hortonworks.streamline.streams.logsearch.container.TopologyLogSearchContainer;
+
+import javax.security.auth.Subject;
+import java.util.List;
+
+public class TopologyLogSearchService implements ContainingNamespaceAwareContainer {
+  private final EnvironmentService environmentService;
+  private final TopologyLogSearchContainer topologyLogSearchContainer;
+
+  public TopologyLogSearchService(EnvironmentService environmentService, Subject subject) {
+    this.environmentService = environmentService;
+    this.topologyLogSearchContainer = new TopologyLogSearchContainer(environmentService, subject);
+  }
+
+  public LogSearchResult search(Topology topology, LogSearchCriteria criteria) {
+    TopologyLogSearch topologyLogSearch = getTopologyLogSearchInstance(topology);
+    return topologyLogSearch.search(criteria);
+  }
+
+  @Override
+  public void invalidateInstance(Long namespaceId) {
+    try {
+      topologyLogSearchContainer.invalidateInstance(namespaceId);
+    } catch (Throwable e) {
+      // swallow
+    }
+  }
+
+  private TopologyLogSearch getTopologyLogSearchInstance(Topology topology) {
+    Namespace namespace = environmentService.getNamespace(topology.getNamespaceId());
+    if (namespace == null) {
+      throw new RuntimeException("Corresponding namespace not found: " + topology.getNamespaceId());
+    }
+
+    TopologyLogSearch topologyLogSearch = topologyLogSearchContainer.findInstance(namespace);
+    if (topologyLogSearch == null) {
+      throw new RuntimeException("Can't find Topology Log Search for such namespace " + topology.getNamespaceId());
+    }
+    return topologyLogSearch;
+  }
+}

--- a/streams/pom.xml
+++ b/streams/pom.xml
@@ -30,6 +30,7 @@
         <module>sql</module>
         <!-- test jar builders -->
         <module>test-support</module>
+        <module>logsearch</module>
     </modules>
 
 </project>

--- a/streams/runners/storm/logsearch/pom.xml
+++ b/streams/runners/storm/logsearch/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>streamline-runners-storm</artifactId>
+        <groupId>com.hortonworks.streamline</groupId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>streamline-logsearch-storm</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>com.hortonworks.streamline</groupId>
+            <artifactId>streamline-common-storm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.hortonworks.streamline</groupId>
+            <artifactId>streamline-logsearch</artifactId>
+        </dependency>
+        <!-- ambari infra -->
+        <dependency>
+            <groupId>org.apache.solr</groupId>
+            <artifactId>solr-solrj</artifactId>
+            <version>6.4.0</version>
+        </dependency>
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/streams/runners/storm/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/storm/ambari/AmbariInfraWithStormLogSearch.java
+++ b/streams/runners/storm/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/storm/ambari/AmbariInfraWithStormLogSearch.java
@@ -1,0 +1,174 @@
+package com.hortonworks.streamline.streams.logsearch.storm.ambari;
+
+import com.hortonworks.streamline.common.exception.ConfigException;
+import com.hortonworks.streamline.streams.logsearch.LogSearchCriteria;
+import com.hortonworks.streamline.streams.logsearch.LogSearchResult;
+import com.hortonworks.streamline.streams.logsearch.TopologyLogSearch;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.HttpClientUtil;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
+import org.apache.solr.client.solrj.impl.Krb5HttpClientConfigurer;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrDocumentList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Implementation of TopologyLogSearch for Ambari Infra (Solr) with Storm.
+ * <p/>
+ * This class assumes that worker logs are collected via LogFeeder with known configuration, and pushed to Ambari Infra (Solr).
+ */
+public class AmbariInfraWithStormLogSearch implements TopologyLogSearch {
+    private static final Logger LOG = LoggerFactory.getLogger(AmbariInfraWithStormLogSearch.class);
+
+    // the configuration keys
+    static final String SOLR_API_URL_KEY = "solrApiUrl";
+    static final String COLLECTION_NAME = "collection";
+    static final String SECURED_CLUSTER = "secured";
+
+    public static final String COLUMN_NAME_STREAMLINE_TOPOLOGY_ID = "sdi_streamline_topology_id";
+    public static final String COLUMN_NAME_STREAMLINE_COMPONENT_NAME = "sdi_streamline_component_name";
+    public static final String COLUMN_NAME_STORM_WORKER_PORT = "sdi_storm_worker_port";
+    public static final String COLUMN_NAME_HOST = "host";
+    public static final String COLUMN_NAME_LOG_TIME = "logtime";
+    public static final String COLUMN_NAME_LOG_LEVEL = "level";
+    public static final String COLUMN_NAME_LOG_MESSAGE = "log_message";
+
+    public static final String DEFAULT_COLLECTION_NAME = "hadoop_logs";
+    private HttpSolrClient solr;
+
+    public AmbariInfraWithStormLogSearch() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void init(Map<String, Object> conf) throws ConfigException {
+        String solrApiUrl = null;
+        String collectionName = null;
+        if (conf != null) {
+            solrApiUrl = (String) conf.get(SOLR_API_URL_KEY);
+            collectionName = (String) conf.get(COLLECTION_NAME);
+            if (collectionName == null) {
+                collectionName = DEFAULT_COLLECTION_NAME;
+            }
+        }
+
+        if (solrApiUrl == null || collectionName == null) {
+            throw new ConfigException("'solrApiUrl' must be presented in configuration.");
+        }
+
+        if ((boolean) conf.getOrDefault(SECURED_CLUSTER, false)) {
+            HttpClientUtil.addConfigurer(new Krb5HttpClientConfigurer());
+        }
+        solr = new HttpSolrClient.Builder(solrApiUrl + "/" + collectionName).build();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LogSearchResult search(LogSearchCriteria logSearchCriteria) {
+        SolrQuery query = new SolrQuery();
+
+        query.setQuery(buildColumnAndValue(COLUMN_NAME_LOG_MESSAGE, buildValue(logSearchCriteria.getSearchString())));
+        query.addFilterQuery(buildColumnAndValue(COLUMN_NAME_STREAMLINE_TOPOLOGY_ID, buildValue(logSearchCriteria.getAppId())));
+        query.addFilterQuery(buildColumnAndValue(COLUMN_NAME_LOG_TIME, buildDateRangeValue(logSearchCriteria.getFrom(), logSearchCriteria.getTo())));
+
+        List<String> componentNames = logSearchCriteria.getComponentNames();
+        if (componentNames != null && !componentNames.isEmpty()) {
+            query.addFilterQuery(buildColumnAndValue(COLUMN_NAME_STREAMLINE_COMPONENT_NAME, buildORValues(logSearchCriteria.getComponentNames())));
+        }
+
+        List<String> logLevels = logSearchCriteria.getLogLevels();
+        if (logLevels != null && !logLevels.isEmpty()) {
+            query.addFilterQuery(buildColumnAndValue(COLUMN_NAME_LOG_LEVEL, buildORValues(logSearchCriteria.getLogLevels())));
+        }
+
+        query.addSort(COLUMN_NAME_LOG_TIME, SolrQuery.ORDER.asc);
+
+        if (logSearchCriteria.getStart() != null) {
+            query.setStart(logSearchCriteria.getStart());
+        }
+        if (logSearchCriteria.getLimit() != null) {
+            query.setRows(logSearchCriteria.getLimit());
+        }
+
+        LOG.debug("Querying to Solr: query => {}", query);
+
+        long numFound;
+        List<LogSearchResult.LogDocument> results = new ArrayList<>();
+        try {
+            QueryResponse response = solr.query(query);
+
+            SolrDocumentList docList = response.getResults();
+            numFound = docList.getNumFound();
+
+            for (SolrDocument document : docList) {
+                String appId = (String) document.getFieldValue(COLUMN_NAME_STREAMLINE_TOPOLOGY_ID);
+                String componentName = (String) document.getFieldValue(COLUMN_NAME_STREAMLINE_COMPONENT_NAME);
+                String logLevel = (String) document.getFieldValue(COLUMN_NAME_LOG_LEVEL);
+                String logMessage = (String) document.getFieldValue(COLUMN_NAME_LOG_MESSAGE);
+                String host = (String) document.getFieldValue(COLUMN_NAME_HOST);
+                String port = (String) document.getFieldValue(COLUMN_NAME_STORM_WORKER_PORT);
+                Date logDate = (Date) document.getFieldValue(COLUMN_NAME_LOG_TIME);
+                long timestamp = logDate.toInstant().toEpochMilli();
+
+                LogSearchResult.LogDocument logDocument = new LogSearchResult.LogDocument(appId, componentName,
+                        logLevel, logMessage, host, port != null ? Integer.parseInt(port) : null, timestamp);
+                results.add(logDocument);
+            }
+
+        } catch (SolrServerException | IOException e) {
+            // TODO: any fine-grained control needed?
+            throw new RuntimeException(e);
+        }
+
+        return new LogSearchResult(numFound, results);
+    }
+
+    private String buildColumnAndValue(String column, String value) {
+        return column + ":" + value;
+    }
+
+    private String buildORValues(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            throw new IllegalArgumentException("Values should not be null or empty.");
+        }
+
+        if (values.size() > 1) {
+            return "(" + String.join(" OR ", values) + ")";
+        } else {
+            // values.size() == 1
+            return values.get(0);
+        }
+    }
+
+    private String buildValue(String value) {
+        if (value == null || value.isEmpty()) {
+            return "*";
+        }
+
+        return value;
+    }
+
+    private String buildDateRangeValue(long from, long to) {
+        String value = "[%s TO %s]";
+
+        Instant fromInstant = Instant.ofEpochMilli(from);
+        Instant toInstant = Instant.ofEpochMilli(to);
+
+        return String.format(value, fromInstant.toString(), toInstant.toString());
+    }
+
+}

--- a/streams/runners/storm/logsearch/src/test/java/com/hortonworks/streamline/streams/logsearch/storm/ambari/AmbariInfraWithStormLogSearchTest.java
+++ b/streams/runners/storm/logsearch/src/test/java/com/hortonworks/streamline/streams/logsearch/storm/ambari/AmbariInfraWithStormLogSearchTest.java
@@ -1,0 +1,272 @@
+package com.hortonworks.streamline.streams.logsearch.storm.ambari;
+
+import com.github.tomakehurst.wiremock.http.QueryParameter;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.matching.ValuePattern;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import com.google.common.collect.Lists;
+import com.hortonworks.streamline.streams.logsearch.LogSearchCriteria;
+import com.hortonworks.streamline.streams.logsearch.LogSearchResult;
+import mockit.Deencapsulation;
+import org.apache.commons.io.IOUtils;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
+import org.apache.solr.client.solrj.impl.XMLResponseParser;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.hortonworks.streamline.streams.logsearch.storm.ambari.AmbariInfraWithStormLogSearch.COLUMN_NAME_LOG_LEVEL;
+import static com.hortonworks.streamline.streams.logsearch.storm.ambari.AmbariInfraWithStormLogSearch.COLUMN_NAME_LOG_MESSAGE;
+import static com.hortonworks.streamline.streams.logsearch.storm.ambari.AmbariInfraWithStormLogSearch.COLUMN_NAME_LOG_TIME;
+import static com.hortonworks.streamline.streams.logsearch.storm.ambari.AmbariInfraWithStormLogSearch.COLUMN_NAME_STREAMLINE_COMPONENT_NAME;
+import static com.hortonworks.streamline.streams.logsearch.storm.ambari.AmbariInfraWithStormLogSearch.COLUMN_NAME_STREAMLINE_TOPOLOGY_ID;
+import static org.junit.Assert.*;
+
+public class AmbariInfraWithStormLogSearchTest {
+    private final String TEST_SOLR_API_PATH = "/solr";
+    private final String TEST_COLLECTION_NAME = "test_collection";
+    private final String STUB_REQUEST_API_PATH = TEST_SOLR_API_PATH + "/" + TEST_COLLECTION_NAME + "/select";
+
+    private AmbariInfraWithStormLogSearch logSearch;
+    private String buildTestSolrApiUrl;
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(18886);
+
+    public static final String TEST_APP_ID = "1";
+    public static final long TEST_FROM = System.currentTimeMillis() - (1000 * 60 * 30);
+    public static final long TEST_TO = System.currentTimeMillis();
+
+    @Before
+    public void setUp() throws Exception {
+        logSearch = new AmbariInfraWithStormLogSearch();
+
+        Map<String, Object> conf = new HashMap<>();
+        buildTestSolrApiUrl = "http://localhost:18886" + TEST_SOLR_API_PATH;
+        conf.put(AmbariInfraWithStormLogSearch.SOLR_API_URL_KEY, buildTestSolrApiUrl);
+        conf.put(AmbariInfraWithStormLogSearch.COLLECTION_NAME, TEST_COLLECTION_NAME);
+
+        logSearch.init(conf);
+
+        // we are doing some hack to change parser, since default wt (javabin) would be faster
+        // but not good to construct custom result by ourselves
+        HttpSolrClient solrClient = Deencapsulation.getField(logSearch, "solr");
+        solrClient.setParser(new XMLResponseParser());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+    }
+
+    @Test
+    public void testSearchWithMinimumParameters() throws Exception {
+        stubSolrUrl();
+
+        LogSearchCriteria logSearchCriteria = new LogSearchCriteria.Builder(TEST_APP_ID, TEST_FROM, TEST_TO).build();
+        LogSearchResult result = logSearch.search(logSearchCriteria);
+        verifyResults(result);
+
+        // please note that space should be escaped to '+' since Wiremock doesn't handle it when matching...
+        String dateRangeValue = "%s:[%s+TO+%s]";
+
+        Instant fromInstant = Instant.ofEpochMilli(TEST_FROM);
+        Instant toInstant = Instant.ofEpochMilli(TEST_TO);
+
+        dateRangeValue = String.format(dateRangeValue, COLUMN_NAME_LOG_TIME, fromInstant.toString(), toInstant.toString());
+
+        List<LoggedRequest> requests = wireMockRule.findAll(getRequestedFor(urlPathEqualTo(STUB_REQUEST_API_PATH)));
+        assertEquals(1, requests.size());
+
+        LoggedRequest request = requests.get(0);
+
+        QueryParameter qParam = request.queryParameter("q");
+        assertTrue(qParam.containsValue(COLUMN_NAME_LOG_MESSAGE + ":*"));
+
+        QueryParameter fqParam = request.queryParameter("fq");
+        assertTrue(fqParam.containsValue(COLUMN_NAME_STREAMLINE_TOPOLOGY_ID + ":" + TEST_APP_ID));
+        assertTrue(fqParam.containsValue(dateRangeValue));
+        assertFalse(fqParam.hasValueMatching(ValuePattern.containing(COLUMN_NAME_LOG_LEVEL)));
+        assertFalse(fqParam.hasValueMatching(ValuePattern.containing(COLUMN_NAME_STREAMLINE_COMPONENT_NAME)));
+
+        QueryParameter sortParam = request.queryParameter("sort");
+        assertTrue(sortParam.containsValue(COLUMN_NAME_LOG_TIME + "+asc"));
+    }
+
+    @Test
+    public void testSearchWithFullParameters() throws Exception {
+        stubSolrUrl();
+
+        int testStart = 100;
+        int testLimit = 2000;
+        List<String> testLogLevels = Lists.newArrayList("INFO", "DEBUG");
+        String testSearchString = "helloworld";
+        List<String> testComponentNames = Lists.newArrayList("testComponent", "testComponent2");
+
+        LogSearchCriteria logSearchCriteria = new LogSearchCriteria.Builder(TEST_APP_ID, TEST_FROM, TEST_TO)
+            .setLogLevels(testLogLevels)
+            .setSearchString(testSearchString)
+            .setComponentNames(testComponentNames)
+            .setStart(testStart)
+            .setLimit(testLimit)
+            .build();
+
+        LogSearchResult result = logSearch.search(logSearchCriteria);
+
+        // note that the result doesn't change given that we just provide same result from file
+        verifyResults(result);
+
+        // please note that space should be escaped to '+' since Wiremock doesn't handle it when matching...
+        String dateRangeValue = "%s:[%s+TO+%s]";
+
+        Instant fromInstant = Instant.ofEpochMilli(TEST_FROM);
+        Instant toInstant = Instant.ofEpochMilli(TEST_TO);
+
+        dateRangeValue = String.format(dateRangeValue, COLUMN_NAME_LOG_TIME, fromInstant.toString(), toInstant.toString());
+
+        String expectedComponentNames = "(" + String.join("+OR+", testComponentNames) + ")";
+        String expectedLogLevels = "(" + String.join("+OR+", testLogLevels) + ")";
+
+        List<LoggedRequest> requests = wireMockRule.findAll(getRequestedFor(urlPathEqualTo(STUB_REQUEST_API_PATH)));
+        assertEquals(1, requests.size());
+
+        LoggedRequest request = requests.get(0);
+
+        QueryParameter qParam = request.queryParameter("q");
+        assertTrue(qParam.containsValue(COLUMN_NAME_LOG_MESSAGE + ":" + testSearchString));
+
+        QueryParameter fqParam = request.queryParameter("fq");
+        assertTrue(fqParam.containsValue(COLUMN_NAME_STREAMLINE_TOPOLOGY_ID + ":" + TEST_APP_ID));
+        assertTrue(fqParam.containsValue(COLUMN_NAME_STREAMLINE_COMPONENT_NAME + ":" + expectedComponentNames));
+        assertTrue(fqParam.containsValue(COLUMN_NAME_LOG_LEVEL + ":" + expectedLogLevels));
+        assertTrue(fqParam.containsValue(dateRangeValue));
+
+        QueryParameter sortParam = request.queryParameter("sort");
+        assertTrue(sortParam.containsValue(COLUMN_NAME_LOG_TIME + "+asc"));
+
+        QueryParameter startParam = request.queryParameter("start");
+        assertTrue(startParam.containsValue(String.valueOf(testStart)));
+
+        QueryParameter rowsParam = request.queryParameter("rows");
+        assertTrue(rowsParam.containsValue(String.valueOf(testLimit)));
+    }
+
+    @Test
+    public void testSearchWithSingleComponentNameAndLogLevelParameters() throws Exception {
+        stubSolrUrl();
+
+        int testStart = 100;
+        int testLimit = 2000;
+        List<String> testLogLevels = Collections.singletonList("INFO");
+        String testSearchString = "helloworld";
+        List<String> testComponentNames = Collections.singletonList("testComponent");
+
+        LogSearchCriteria logSearchCriteria = new LogSearchCriteria.Builder(TEST_APP_ID, TEST_FROM, TEST_TO)
+            .setLogLevels(testLogLevels)
+            .setSearchString(testSearchString)
+            .setComponentNames(testComponentNames)
+            .setStart(testStart)
+            .setLimit(testLimit)
+            .build();
+
+        LogSearchResult result = logSearch.search(logSearchCriteria);
+
+        // note that the result doesn't change given that we just provide same result from file
+        verifyResults(result);
+
+        // others are covered from testSearchWithFullParameters()
+
+        List<LoggedRequest> requests = wireMockRule.findAll(getRequestedFor(urlPathEqualTo(STUB_REQUEST_API_PATH)));
+        assertEquals(1, requests.size());
+
+        LoggedRequest request = requests.get(0);
+
+        QueryParameter fqParam = request.queryParameter("fq");
+        assertTrue(fqParam.containsValue(COLUMN_NAME_STREAMLINE_COMPONENT_NAME + ":" + testComponentNames.get(0)));
+        assertTrue(fqParam.containsValue(COLUMN_NAME_LOG_LEVEL + ":" + testLogLevels.get(0)));
+    }
+
+    private void verifyResults(LogSearchResult results) {
+        assertEquals(Long.valueOf(1434L), results.getMatchedDocs());
+
+        // 5 static rows are presented in pre-stored result for making just test simpler...
+        // please refer 'ambari-infra-log-search-output.xml'
+        List<LogSearchResult.LogDocument> documents = results.getDocuments();
+        assertEquals(5, documents.size());
+
+        LogSearchResult.LogDocument document = documents.get(0);
+        assertEquals("1", document.getAppId());
+        assertEquals("SOURCE", document.getComponentName());
+        assertEquals("DEBUG", document.getLogLevel());
+        assertEquals("host1", document.getHost());
+        assertEquals(Integer.valueOf(6700), document.getPort());
+        assertTrue(document.getLogMessage().startsWith("Polled [0] records from Kafka."));
+        assertEquals(Instant.parse("2017-11-24T07:48:58.347Z"), Instant.ofEpochMilli(document.getTimestamp()));
+
+        document = documents.get(1);
+        assertEquals("1", document.getAppId());
+        assertEquals("SOURCE", document.getComponentName());
+        assertEquals("DEBUG", document.getLogLevel());
+        assertEquals("host1", document.getHost());
+        assertEquals(Integer.valueOf(6700), document.getPort());
+        assertTrue(document.getLogMessage().startsWith("Topic partitions with entries"));
+        assertEquals(Instant.parse("2017-11-24T07:48:58.348Z"), Instant.ofEpochMilli(document.getTimestamp()));
+
+        document = documents.get(2);
+        assertEquals("1", document.getAppId());
+        assertEquals("SOURCE", document.getComponentName());
+        assertEquals("DEBUG", document.getLogLevel());
+        assertEquals("host1", document.getHost());
+        assertEquals(Integer.valueOf(6700), document.getPort());
+        assertTrue(document.getLogMessage().startsWith("Polled [0] records from Kafka."));
+        assertEquals(Instant.parse("2017-11-24T07:48:58.549Z"), Instant.ofEpochMilli(document.getTimestamp()));
+
+        document = documents.get(3);
+        assertEquals("1", document.getAppId());
+        assertEquals("SOURCE", document.getComponentName());
+        assertEquals("DEBUG", document.getLogLevel());
+        assertEquals("host1", document.getHost());
+        assertEquals(Integer.valueOf(6700), document.getPort());
+        assertTrue(document.getLogMessage().startsWith("Topic partitions with entries"));
+        assertEquals(Instant.parse("2017-11-24T07:48:58.55Z"), Instant.ofEpochMilli(document.getTimestamp()));
+
+        document = documents.get(4);
+        assertEquals("1", document.getAppId());
+        assertEquals("SOURCE", document.getComponentName());
+        assertEquals("INFO", document.getLogLevel());
+        assertEquals("host1", document.getHost());
+        assertEquals(Integer.valueOf(6700), document.getPort());
+        assertTrue(document.getLogMessage().startsWith("Trying to load entry for cache"));
+        assertEquals(Instant.parse("2017-11-24T15:43:37.902Z"), Instant.ofEpochMilli(document.getTimestamp()));
+
+    }
+
+    private void stubSolrUrl() throws IOException {
+        try (InputStream is = getClass().getResourceAsStream("/ambari-infra-log-search-output.xml")) {
+            String body = IOUtils.toString(is, Charset.forName("UTF-8"));
+
+            wireMockRule.stubFor(get(urlPathEqualTo(STUB_REQUEST_API_PATH))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/xml; charset=UTF-8")
+                            .withHeader("Transfer-Encoding", "chunked")
+                            .withBody(body)));
+        }
+    }
+
+}

--- a/streams/runners/storm/logsearch/src/test/resources/ambari-infra-log-search-output.xml
+++ b/streams/runners/storm/logsearch/src/test/resources/ambari-infra-log-search-output.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+
+    <lst name="responseHeader">
+        <int name="status">0</int>
+        <int name="QTime">9</int>
+        <lst name="params">
+            <str name="q">*:*</str>
+            <str name="indent">on</str>
+            <arr name="fq">
+                <str>type:storm_worker</str>
+                <str>sdi_streamline_topology_id:1</str>
+            </arr>
+            <str name="sort">logtime desc</str>
+            <str name="rows">5</str>
+            <str name="wt">xml</str>
+            <str name="_">1511508905220</str>
+        </lst>
+    </lst>
+    <result name="response" numFound="1434" start="0">
+        <doc>
+            <str name="cluster">cl1</str>
+            <str name="sdi_storm_worker_port">6700</str>
+            <str name="level">DEBUG</str>
+            <long name="event_count">1</long>
+            <str name="ip">8.8.8.8</str>
+            <str name="sdi_storm_topology_id">streamline-1-SimpleTopology-2-1511506224</str>
+            <str name="type">storm_worker</str>
+            <str name="sdi_streamline_component_name">SOURCE</str>
+            <long name="seq_num">8139</long>
+            <str name="path">/var/log/storm/workers-artifacts/streamline-1-SimpleTopology-2-1511506224/6700/worker.log</str>
+            <str name="sdi_streamline_topology_id">1</str>
+            <str name="thread_name">Thread-8-1-SOURCE-executor[1 1]</str>
+            <str name="host">host1</str>
+            <str name="log_message">Polled [0] records from Kafka. [0] uncommitted offsets across all topic partitions</str>
+            <str name="logger_name">o.a.s.k.s.KafkaSpout</str>
+            <str name="sdi_streamline_topology_name">SimpleTopology</str>
+            <str name="id">6ccf2d8b-a054-4101-a9fc-eaf849f8641d</str>
+            <str name="message_md5">-781060069358189183</str>
+            <date name="logtime">2017-11-24T07:48:58.347Z</date>
+            <str name="event_md5">15115097383476641010307367239884</str>
+            <int name="logfile_line_number">5867</int>
+            <str name="_ttl_">+7DAYS</str>
+            <date name="_expire_at_">2017-12-01T07:48:58.751Z</date>
+            <long name="_version_">1584932835825811465</long></doc>
+        <doc>
+            <str name="cluster">cl1</str>
+            <str name="sdi_storm_worker_port">6700</str>
+            <str name="level">DEBUG</str>
+            <long name="event_count">1</long>
+            <str name="ip">8.8.8.8</str>
+            <str name="sdi_storm_topology_id">streamline-1-SimpleTopology-2-1511506224</str>
+            <str name="type">storm_worker</str>
+            <str name="sdi_streamline_component_name">SOURCE</str>
+            <long name="seq_num">8140</long>
+            <str name="path">/var/log/storm/workers-artifacts/streamline-1-SimpleTopology-2-1511506224/6700/worker.log</str>
+            <str name="sdi_streamline_topology_id">1</str>
+            <str name="thread_name">Thread-8-1-SOURCE-executor[1 1]</str>
+            <str name="host">host1</str>
+            <str name="log_message">Topic partitions with entries ready to be retried [{}]</str>
+            <str name="logger_name">o.a.s.k.s.KafkaSpoutRetryExponentialBackoff</str>
+            <str name="sdi_streamline_topology_name">SimpleTopology</str>
+            <str name="id">5057fbe4-e672-45bf-bae0-38199983a1af</str>
+            <str name="message_md5">-5370743142998518809</str>
+            <date name="logtime">2017-11-24T07:48:58.348Z</date>
+            <str name="event_md5">1511509738348-627861834468380206</str>
+            <int name="logfile_line_number">5868</int>
+            <str name="_ttl_">+7DAYS</str>
+            <date name="_expire_at_">2017-12-01T07:48:58.751Z</date>
+            <long name="_version_">1584932835825811466</long></doc>
+
+        <doc>
+            <str name="cluster">cl1</str>
+            <str name="sdi_storm_worker_port">6700</str>
+            <str name="level">DEBUG</str>
+            <long name="event_count">1</long>
+            <str name="ip">8.8.8.8</str>
+            <str name="sdi_storm_topology_id">streamline-1-SimpleTopology-2-1511506224</str>
+            <str name="type">storm_worker</str>
+            <str name="sdi_streamline_component_name">SOURCE</str>
+            <long name="seq_num">8141</long>
+            <str name="path">/var/log/storm/workers-artifacts/streamline-1-SimpleTopology-2-1511506224/6700/worker.log</str>
+            <str name="sdi_streamline_topology_id">1</str>
+            <str name="thread_name">Thread-8-1-SOURCE-executor[1 1]</str>
+            <str name="host">host1</str>
+            <str name="log_message">Polled [0] records from Kafka. [0] uncommitted offsets across all topic partitions</str>
+            <str name="logger_name">o.a.s.k.s.KafkaSpout</str>
+            <str name="sdi_streamline_topology_name">SimpleTopology</str>
+            <str name="id">836c723e-90e9-4824-95c5-b99b3967ea26</str>
+            <str name="message_md5">-781060069358189183</str>
+            <date name="logtime">2017-11-24T07:48:58.549Z</date>
+            <str name="event_md5">1511509738549-8043280530774360873</str>
+            <int name="logfile_line_number">5869</int>
+            <str name="_ttl_">+7DAYS</str>
+            <date name="_expire_at_">2017-12-01T07:48:58.751Z</date>
+            <long name="_version_">1584932835825811467</long></doc>
+        <doc>
+            <str name="cluster">cl1</str>
+            <str name="sdi_storm_worker_port">6700</str>
+            <str name="level">DEBUG</str>
+            <long name="event_count">1</long>
+            <str name="ip">8.8.8.8</str>
+            <str name="sdi_storm_topology_id">streamline-1-SimpleTopology-2-1511506224</str>
+            <str name="type">storm_worker</str>
+            <str name="sdi_streamline_component_name">SOURCE</str>
+            <long name="seq_num">8142</long>
+            <str name="path">/var/log/storm/workers-artifacts/streamline-1-SimpleTopology-2-1511506224/6700/worker.log</str>
+            <str name="sdi_streamline_topology_id">1</str>
+            <str name="thread_name">Thread-8-1-SOURCE-executor[1 1]</str>
+            <str name="host">host1</str>
+            <str name="log_message">Topic partitions with entries ready to be retried [{}]</str>
+            <str name="logger_name">o.a.s.k.s.KafkaSpoutRetryExponentialBackoff</str>
+            <str name="sdi_streamline_topology_name">SimpleTopology</str>
+            <str name="id">8a5836db-2397-4f4f-b6c2-55d61e191881</str>
+            <str name="message_md5">-5370743142998518809</str>
+            <date name="logtime">2017-11-24T07:48:58.55Z</date>
+            <str name="event_md5">1511509738550-8541202563198249423</str>
+            <int name="logfile_line_number">5870</int>
+            <str name="_ttl_">+7DAYS</str>
+            <date name="_expire_at_">2017-12-01T07:48:58.751Z</date>
+            <long name="_version_">1584932835826860032</long></doc>
+        <doc>
+            <str name="cluster">cl1</str>
+            <str name="sdi_storm_worker_port">6700</str>
+            <str name="level">INFO</str>
+            <long name="event_count">1</long>
+            <str name="ip">8.8.8.8</str>
+            <str name="sdi_storm_topology_id">streamline-1-SimpleTopology-2-1511506224</str>
+            <str name="type">storm_worker</str>
+            <str name="sdi_streamline_component_name">SOURCE</str>
+            <long name="seq_num">162</long>
+            <str name="path">/var/log/storm/workers-artifacts/streamline-1-SimpleTopology-2-1511506224/6700/worker.log</str>
+            <str name="sdi_streamline_topology_id">1</str>
+            <str name="thread_name">Thread-8-1-SOURCE-executor[1 1]</str>
+            <str name="host">host1</str>
+            <str name="log_message">Trying to load entry for cache with key [Key{schemaVersionKey=null, schemaIdVersion=SchemaIdVersion{schemaMetadataId=2, version=1, schemaVersionId=null}}] from target service</str>
+            <str name="logger_name">c.h.r.s.SchemaVersionInfoCache</str>
+            <str name="sdi_streamline_topology_name">SimpleTopology</str>
+            <str name="id">f7284874-717b-4251-b750-271cf33627ad</str>
+            <str name="message_md5">3777527502925731377</str>
+            <date name="logtime">2017-11-24T15:43:37.902Z</date>
+            <str name="event_md5">1511538217902-4326451453828180819</str>
+            <int name="logfile_line_number">325</int>
+            <str name="_ttl_">+7DAYS</str>
+            <date name="_expire_at_">2017-12-01T07:25:22.939Z</date>
+            <long name="_version_">1584931351287562242</long></doc>
+    </result>
+</response>

--- a/streams/runners/storm/pom.xml
+++ b/streams/runners/storm/pom.xml
@@ -17,6 +17,7 @@
         <module>metrics</module>
         <module>common</module>
         <module>actions</module>
+        <module>logsearch</module>
     </modules>
 
 

--- a/streams/service/pom.xml
+++ b/streams/service/pom.xml
@@ -42,6 +42,10 @@
         </dependency>
         <dependency>
             <groupId>com.hortonworks.streamline</groupId>
+            <artifactId>streamline-logsearch-storm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.hortonworks.streamline</groupId>
             <artifactId>streamline-notification</artifactId>
         </dependency>
         <dependency>
@@ -79,6 +83,10 @@
             <version>${project.parent.version}</version>
             <type>jar</type>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.hortonworks.streamline</groupId>
+            <artifactId>streamline-logsearch</artifactId>
         </dependency>
     </dependencies>
 

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/StreamsModule.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/StreamsModule.java
@@ -38,6 +38,7 @@ import com.hortonworks.streamline.streams.cluster.resource.ServiceBundleResource
 import com.hortonworks.streamline.streams.cluster.resource.ServiceCatalogResource;
 import com.hortonworks.streamline.streams.cluster.resource.ServiceConfigurationCatalogResource;
 import com.hortonworks.streamline.streams.cluster.service.EnvironmentService;
+import com.hortonworks.streamline.streams.logsearch.topology.service.TopologyLogSearchService;
 import com.hortonworks.streamline.streams.metrics.topology.service.TopologyMetricsService;
 import com.hortonworks.streamline.streams.notification.service.NotificationServiceImpl;
 import com.hortonworks.streamline.streams.security.StreamlineAuthorizer;
@@ -84,9 +85,11 @@ public class StreamsModule implements ModuleRegistration, StorageManagerAware, T
         final TopologyActionsService topologyActionsService = new TopologyActionsService(streamcatalogService,
                 environmentService, fileStorage, modelRegistryClient, config, subject, transactionManager);
         final TopologyMetricsService topologyMetricsService = new TopologyMetricsService(environmentService, subject);
+        final TopologyLogSearchService topologyLogSearchService = new TopologyLogSearchService(environmentService, subject);
 
         environmentService.addNamespaceAwareContainer(topologyActionsService);
         environmentService.addNamespaceAwareContainer(topologyMetricsService);
+        environmentService.addNamespaceAwareContainer(topologyLogSearchService);
 
         // authorizer
         final StreamlineAuthorizer authorizer = (StreamlineAuthorizer) config.get(Constants.CONFIG_AUTHORIZER);
@@ -101,7 +104,7 @@ public class StreamsModule implements ModuleRegistration, StorageManagerAware, T
         result.addAll(getClusterRelatedResources(authorizer, environmentService));
         result.add(new FileCatalogResource(authorizer, catalogService));
         result.addAll(getTopologyRelatedResources(authorizer, streamcatalogService, environmentService, topologyActionsService,
-                topologyMetricsService, securityCatalogService, subject));
+                topologyMetricsService, topologyLogSearchService, securityCatalogService, subject));
         result.add(new UDFCatalogResource(authorizer, streamcatalogService, fileStorage));
         result.addAll(getNotificationsRelatedResources(authorizer, streamcatalogService));
         result.add(new SchemaResource(createSchemaRegistryClient()));
@@ -129,10 +132,11 @@ public class StreamsModule implements ModuleRegistration, StorageManagerAware, T
                                                      EnvironmentService environmentService,
                                                      TopologyActionsService actionsService,
                                                      TopologyMetricsService metricsService,
+                                                     TopologyLogSearchService logSearchService,
                                                      SecurityCatalogService securityCatalogService,
                                                      Subject subject) {
         return Arrays.asList(
-                new TopologyCatalogResource(authorizer, streamcatalogService, actionsService),
+                new TopologyCatalogResource(authorizer, streamcatalogService, actionsService, logSearchService),
                 new TopologyActionResource(authorizer, streamcatalogService, actionsService),
                 new TopologyDashboardResource(authorizer, streamcatalogService, environmentService, actionsService,
                         metricsService, transactionManager),

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyCatalogResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyCatalogResource.java
@@ -29,6 +29,8 @@ import com.hortonworks.streamline.streams.catalog.TopologyVersion;
 import com.hortonworks.streamline.streams.catalog.service.StreamCatalogService;
 import com.hortonworks.streamline.streams.catalog.topology.TopologyData;
 import com.hortonworks.streamline.streams.exception.TopologyNotAliveException;
+import com.hortonworks.streamline.streams.logsearch.LogSearchCriteria;
+import com.hortonworks.streamline.streams.logsearch.topology.service.TopologyLogSearchService;
 import com.hortonworks.streamline.streams.security.Permission;
 import com.hortonworks.streamline.streams.security.Roles;
 import com.hortonworks.streamline.streams.security.SecurityUtil;
@@ -59,6 +61,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Optional;
 
 import static com.hortonworks.streamline.streams.catalog.Topology.NAMESPACE;
@@ -79,12 +82,14 @@ public class TopologyCatalogResource {
     private final StreamlineAuthorizer authorizer;
     private final StreamCatalogService catalogService;
     private final TopologyActionsService actionsService;
+    private final TopologyLogSearchService logSearchService;
 
     public TopologyCatalogResource(StreamlineAuthorizer authorizer, StreamCatalogService catalogService,
-                                   TopologyActionsService actionsService) {
+                                   TopologyActionsService actionsService, TopologyLogSearchService logSearchService) {
         this.authorizer = authorizer;
         this.catalogService = catalogService;
         this.actionsService = actionsService;
+        this.logSearchService = logSearchService;
     }
 
     @GET
@@ -465,5 +470,37 @@ public class TopologyCatalogResource {
         throw EntityNotFoundException.byId(topologyId.toString());
     }
 
+    @GET
+    @Path("/topologies/{topologyId}/logs")
+    @Timed
+    public Response searchTopologyLogs(@PathParam("topologyId") Long topologyId,
+        @QueryParam("componentName") List<String> componentNames,
+        @QueryParam("logLevel") List<String> logLevels,
+        @QueryParam("searchString") String searchString,
+        @QueryParam("from") Long from,
+        @QueryParam("to") Long to,
+        @QueryParam("start") Integer start,
+        @QueryParam("limit") Integer limit,
+        @Context SecurityContext securityContext) {
+
+        SecurityUtil.checkRoleOrPermissions(authorizer, securityContext, Roles.ROLE_TOPOLOGY_USER,
+            NAMESPACE, topologyId, READ);
+        Topology topology = catalogService.getTopology(topologyId);
+        if (topology != null) {
+            if (from == null) {
+                throw BadRequestException.missingParameter("from");
+            }
+            if (to == null) {
+                throw BadRequestException.missingParameter("to");
+            }
+
+            LogSearchCriteria criteria = new LogSearchCriteria(String.valueOf(topologyId),
+                componentNames, logLevels, searchString, from, to, start, limit);
+
+            return WSUtils.respondEntity(logSearchService.search(topology, criteria), OK);
+        }
+
+        throw EntityNotFoundException.byId(topologyId.toString());
+    }
 }
 


### PR DESCRIPTION
* add AMBARI_INFRA to Ambari services so that it can be imported automatically
* setup interface and container for managing implementations for the TopologyLogSearch interface
* crafted Ambari Infra & Storm pair implementation of TopologyLogSearch
  * new module 'streamline-logsearch-storm' added
* expose LogSearch feature to HTTP API


* [x] Made the API working with secured cluster
* [x] discuss and expose more fields in result

This closes #1001.