### PR TITLE
ISSUE-1003 - Support for event-time windows in Join processor

### DIFF
--- a/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/rule/expression/Window.java
+++ b/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/rule/expression/Window.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Arrays;
 
 /**
  * Captures the windowing parameters. Internally this implies the rule has to be evaluated as an
@@ -108,7 +109,9 @@ public class Window implements Serializable {
     private WindowParam windowLength;
     private WindowParam slidingInterval;
     private String tsField;
+    private String[] tsFields;
     private int lagMs;
+    private String lateStream;
 
     // for jackson
     private Window() {
@@ -124,7 +127,9 @@ public class Window implements Serializable {
         this.windowLength = other.getWindowLength();
         this.slidingInterval = other.getSlidingInterval();
         this.tsField = other.getTsField();
+        this.tsFields = other.tsFields;
         this.lagMs = other.getLagMs();
+        this.lateStream = other.lateStream;
     }
 
     public WindowParam getWindowLength() {
@@ -151,12 +156,28 @@ public class Window implements Serializable {
         this.tsField = tsField;
     }
 
+    public String[] getTsFields() {
+        return tsFields.clone();
+    }
+
+    public void setTsFields(String[] tsFields) {
+        this.tsFields = tsFields.clone();
+    }
+
     public int getLagMs() {
         return lagMs;
     }
 
     public void setLagMs(int lagMs) {
         this.lagMs = lagMs;
+    }
+
+    public void setLateStream(String stream) {
+        lateStream = stream;
+    }
+
+    public String getLateStream() {
+        return lateStream;
     }
 
     @Override
@@ -190,7 +211,9 @@ public class Window implements Serializable {
                 "windowLength=" + windowLength +
                 ", slidingInterval=" + slidingInterval +
                 ", tsField='" + tsField + '\'' +
+                ", tsFields='[" + Arrays.toString(tsFields) + "\']" +
                 ", lagMs=" + lagMs +
+                ", lateStream=" + lateStream +
                 '}';
     }
 }

--- a/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/JoinBoltFluxComponent.java
+++ b/streams/runners/storm/layout/src/main/java/com/hortonworks/streamline/streams/layout/storm/JoinBoltFluxComponent.java
@@ -21,20 +21,14 @@ package com.hortonworks.streamline.streams.layout.storm;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import com.hortonworks.streamline.streams.layout.component.rule.expression.Window;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 
-/* ---- Sample Json of whats expected from UI  ---
+/* ---- Json samples of whats expected from UI  ---
+
+          Ex.1 ---- for counted windows  ---
 {
 "from" : {"stream": "s1", "key": "k1"},
 "joins" :
@@ -43,8 +37,44 @@ import java.util.Map;
     {"type" : "left",  "stream": "s3", "key":"k3", "with": "s1"},
     {"type" : "inner", "stream": "s4", "key":"k4", "with": "s2"}
   ],
-  "outputKeys" : [ "k1", "stream1:k2 as key2" ],
-  "window" : {"windowLength" : {"class":".Window$Count", "count":100}, "slidingInterval":{"class":".Window$Count", "count":100}, "tsField":null, "lagMs":0},
+  "outputKeys" : [ "k1", "stream1:k2 as k2" ],
+  "window" : {"windowLength" : {"class":".Window$Count", "count":100}, "slidingInterval":{"class":".Window$Count", "count":100} },
+  "outputStream" : "joinedStream1"
+}
+
+
+         Ex.2 ---- for event time driven windows  ---
+
+{
+"from" : {"stream": "s1", "key": "k1"},
+"joins" :
+  [
+    {"type" : "left",  "stream": "s2", "key":"k2", "with": "s1"},
+    {"type" : "left",  "stream": "s3", "key":"k3", "with": "s1"},
+  ],
+  "outputKeys" : [ "k1", "stream1:k2.inner as k2_inner" ],
+  "window" : {"windowLength" : {"class":".Window$Duration", "durationMs":1000},
+              "slidingInterval":{"class":".Window$Duration", "durationMs":1000},
+              "tsFields": ["s1:tsField1" , "s2:tsField2", "s3:field3.innerTsField"],  # enables event time windowing
+              "lagMs": 10,
+              "lateStream": "optionalLateStream"},
+  "outputStream" : "joinedStream1"
+}
+
+
+         Ex.3 ---- for processing time driven windows  ---
+
+{
+"from" : {"stream": "s1", "key": "k1"},
+"joins" :
+  [
+    {"type" : "left",  "stream": "s2", "key":"k2", "with": "s1"},
+    {"type" : "left",  "stream": "s3", "key":"k3", "with": "s1"},
+  ],
+  "outputKeys" : [ "k1", "stream1:k2.inner as k2_inner" ],
+  "window" : {"windowLength" : {"class":".Window$Duration", "durationMs":1000},
+              "slidingInterval":{"class":".Window$Duration", "durationMs":1000},
+              },
   "outputStream" : "joinedStream1"
 }
  */

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/StreamlineWindowedBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/StreamlineWindowedBolt.java
@@ -16,9 +16,10 @@
 package com.hortonworks.streamline.streams.runtime.storm.bolt;
 
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.storm.topology.base.BaseWindowedBolt;
 import com.hortonworks.streamline.streams.layout.component.rule.expression.Window;
+import com.hortonworks.streamline.streams.runtime.storm.bolt.query.SLMultistreamTimestampExtractor;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/SLMultistreamTimestampExtractor.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/SLMultistreamTimestampExtractor.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.hortonworks.streamline.streams.runtime.storm.bolt.query;
+
+import com.hortonworks.streamline.streams.runtime.storm.bolt.query.RealtimeJoinBolt.StreamKind;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.windowing.TimestampExtractor;
+
+import java.util.HashMap;
+
+
+public class SLMultistreamTimestampExtractor implements TimestampExtractor {
+    HashMap<String,FieldSelector> tsFields = new HashMap<>(); // stream name -> field selector
+
+    /** Field selectors should be qualified with stream name and can refer to nested fields. Aliases if any will be ignored.
+     *     Ex: "stream1:tsField"  or  "stream1:outerField.TsField"
+     *  'streamline-event.' prefix will be added to the events automatically
+     */
+    public SLMultistreamTimestampExtractor(String... fieldSelectors) {
+        for (int i = 0; i < fieldSelectors.length; i++) {
+            String fieldSel = WindowedQueryBolt.convertToStreamLineKeys(fieldSelectors[i]); // Strip any alias & prefix field with 'streamline-event.'
+            FieldSelector fs = new FieldSelector(fieldSel, StreamKind.STREAM);
+            if ( tsFields.containsKey(fs.streamName) ) {
+                throw new IllegalArgumentException("Only one timestamp field allowed per stream");
+            }
+            tsFields.put(fs.streamName, fs);
+        }
+    }
+
+    @Override
+    public long extractTimestamp(Tuple tuple) {
+        FieldSelector tsFieldSel = tsFields.get( tuple.getSourceStreamId() );
+        if (tsFieldSel == null) {
+            throw new IllegalArgumentException("Unrecognized source stream in Event: '" + tuple.getSourceStreamId() + "'");
+        }
+        Object tsField = tsFieldSel.findField(tuple);
+        if (tsField == null) {
+            throw new IllegalArgumentException("Timestamp field not found in event : '" + tsFieldSel.outputName + "'");
+        }
+        return Long.parseLong(tsField.toString());
+    }
+
+}


### PR DESCRIPTION
@shahsank3t can you test UI changes using this PR ?

- Sample windowConfig  json, passed by UI to backend for EvenTime :

```json
"window" : {"windowLength" : {"class":".Window$Duration", "durationMs":1000},
            "slidingInterval" : {"class":".Window$Duration", "durationMs":1000},
            "tsFields": ["s1:tsField1" , "s2:tsField2", "s3:field3.innerTsField"], //new
            "lagMs": 10,
            "lateStream": "optionalLateStream"  //new
 }
```
- Note: Need to ensure there is one timestamp field per input stream when using event time joins
