### PR TITLE
ISSUE-1014 Dynamically changing log level at Application level

### DIFF
--- a/common/src/main/java/com/hortonworks/streamline/common/JsonClientUtil.java
+++ b/common/src/main/java/com/hortonworks/streamline/common/JsonClientUtil.java
@@ -118,4 +118,8 @@ public class JsonClientUtil {
     public static <T> T postForm(WebTarget target, MultivaluedMap<String, String> form, MediaType mediaType, Class<T> clazz) {
         return target.request(mediaType).post(Entity.form(form), clazz);
     }
+
+    public static <T> T postEntity(WebTarget target, Object entity, MediaType mediaType, Class<T> clazz) {
+        return target.request(mediaType).post(Entity.json(entity), clazz);
+    }
 }

--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/TopologyActions.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/TopologyActions.java
@@ -74,6 +74,12 @@ public interface TopologyActions {
     // return topology status
     Status status(TopologyLayout topology, String asUser) throws Exception;
 
+    // change log level of topology with duration
+    LogLevelInformation configureLogLevel(TopologyLayout topology, LogLevel targetLogLevel, int durationSecs, String asUser) throws Exception;
+
+    // get current log level of topology
+    LogLevelInformation getLogLevel(TopologyLayout topology, String asUser) throws Exception;
+
     /**
      * the Path where topology specific artifacts are kept
      */
@@ -93,5 +99,27 @@ public interface TopologyActions {
         String STATUS_UNKNOWN = "Unknown";
         String getStatus();
         Map<String, String> getExtra();
+    }
+
+    enum LogLevel {
+        TRACE, DEBUG, INFO, WARN, ERROR
+    }
+
+    class LogLevelInformation {
+        private LogLevel logLevel;
+        private long epoch;
+
+        public LogLevelInformation(LogLevel logLevel, long epoch) {
+            this.logLevel = logLevel;
+            this.epoch = epoch;
+        }
+
+        public LogLevel getLogLevel() {
+            return logLevel;
+        }
+
+        public long getEpoch() {
+            return epoch;
+        }
     }
 }

--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyActionsService.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyActionsService.java
@@ -173,6 +173,18 @@ public class TopologyActionsService implements ContainingNamespaceAwareContainer
         return topologyActions.getRuntimeTopologyId(CatalogToLayoutConverter.getTopologyLayout(topology), asUser);
     }
 
+    public TopologyActions.LogLevelInformation configureLogLevel(Topology topology, TopologyActions.LogLevel targetLogLevel, int durationSecs,
+                                  String asUser) throws Exception {
+        TopologyActions topologyActions = getTopologyActionsInstance(topology);
+        return topologyActions.configureLogLevel(CatalogToLayoutConverter.getTopologyLayout(topology), targetLogLevel,
+                durationSecs, asUser);
+    }
+
+    public TopologyActions.LogLevelInformation getLogLevel(Topology topology, String asUser) throws Exception {
+        TopologyActions topologyActions = getTopologyActionsInstance(topology);
+        return topologyActions.getLogLevel(CatalogToLayoutConverter.getTopologyLayout(topology), asUser);
+    }
+
     @Override
     public void invalidateInstance(Long namespaceId) {
         try {
@@ -342,4 +354,5 @@ public class TopologyActionsService implements ContainingNamespaceAwareContainer
     public StreamCatalogService getCatalogService() {
         return catalogService;
     }
+
 }

--- a/streams/runners/storm/common/src/main/java/com/hortonworks/streamline/streams/storm/common/logger/LogLevelLoggerRequest.java
+++ b/streams/runners/storm/common/src/main/java/com/hortonworks/streamline/streams/storm/common/logger/LogLevelLoggerRequest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.storm.common.logger;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class LogLevelLoggerRequest {
+    @JsonProperty("target_level")
+    private String targetLevel;
+
+    @JsonProperty("reset_level")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String resetLevel;
+
+    @JsonProperty("timeout")
+    private int timeout;
+
+    public LogLevelLoggerRequest(String targetLevel, int timeout) {
+        this.targetLevel = targetLevel;
+        this.timeout = timeout;
+    }
+
+    public LogLevelLoggerRequest(String targetLevel, String resetLevel, int timeout) {
+        this.targetLevel = targetLevel;
+        this.resetLevel = resetLevel;
+        this.timeout = timeout;
+    }
+
+    public String getTargetLevel() {
+        return targetLevel;
+    }
+
+    public String getResetLevel() {
+        return resetLevel;
+    }
+
+    public int getTimeout() {
+        return timeout;
+    }
+}

--- a/streams/runners/storm/common/src/main/java/com/hortonworks/streamline/streams/storm/common/logger/LogLevelLoggerResponse.java
+++ b/streams/runners/storm/common/src/main/java/com/hortonworks/streamline/streams/storm/common/logger/LogLevelLoggerResponse.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.storm.common.logger;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+public class LogLevelLoggerResponse {
+    @JsonProperty("target_level")
+    private String targetLevel;
+
+    @JsonProperty("reset_level")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String resetLevel;
+
+    @JsonProperty("timeout")
+    private Integer timeout;
+
+    @JsonProperty("timeout_epoch")
+    private Long timeoutEpoch;
+
+    public LogLevelLoggerResponse(String targetLevel, String resetLevel, Integer timeout, Long timeoutEpoch) {
+        this.targetLevel = targetLevel;
+        this.resetLevel = resetLevel;
+        this.timeout = timeout;
+        this.timeoutEpoch = timeoutEpoch;
+    }
+
+    public LogLevelLoggerResponse(String targetLevel, Integer timeout, Long timeoutEpoch) {
+        this.targetLevel = targetLevel;
+        this.timeout = timeout;
+        this.timeoutEpoch = timeoutEpoch;
+    }
+
+    public String getTargetLevel() {
+        return targetLevel;
+    }
+
+    public String getResetLevel() {
+        return resetLevel;
+    }
+
+    public Integer getTimeout() {
+        return timeout;
+    }
+
+    public Long getTimeoutEpoch() {
+        return timeoutEpoch;
+    }
+
+    public static com.hortonworks.streamline.streams.storm.common.logger.LogLevelLoggerResponse of(Map<String, Object> data) {
+        String targetLevel = (String) data.get("target_level");
+        String resetLevel = (String) data.get("reset_level");
+        Number timeout = (Number) data.get("timeout");
+        Number timeoutEpoch = (Number) data.get("timeout_epoch");
+
+        return new com.hortonworks.streamline.streams.storm.common.logger.LogLevelLoggerResponse(targetLevel, resetLevel, timeout.intValue(), timeoutEpoch.longValue());
+    }
+}

--- a/streams/runners/storm/common/src/main/java/com/hortonworks/streamline/streams/storm/common/logger/LogLevelRequest.java
+++ b/streams/runners/storm/common/src/main/java/com/hortonworks/streamline/streams/storm/common/logger/LogLevelRequest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.storm.common.logger;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LogLevelRequest {
+    private Map<String, LogLevelLoggerRequest> namedLoggerLevels;
+
+    public LogLevelRequest() {
+        this.namedLoggerLevels = new HashMap<>();
+    }
+
+    public void addLoggerRequest(String targetPackage, String targetLogLevel, String resetLogLevel, int timeoutSecs) {
+        namedLoggerLevels.put(targetPackage, new LogLevelLoggerRequest(targetLogLevel, resetLogLevel, timeoutSecs));
+    }
+
+    public void addLoggerRequest(String targetPackage, String targetLogLevel, int timeoutSecs) {
+        namedLoggerLevels.put(targetPackage, new LogLevelLoggerRequest(targetLogLevel, timeoutSecs));
+    }
+
+    public Map<String, LogLevelLoggerRequest> getNamedLoggerLevels() {
+        return namedLoggerLevels;
+    }
+}

--- a/streams/runners/storm/common/src/main/java/com/hortonworks/streamline/streams/storm/common/logger/LogLevelResponse.java
+++ b/streams/runners/storm/common/src/main/java/com/hortonworks/streamline/streams/storm/common/logger/LogLevelResponse.java
@@ -1,0 +1,29 @@
+package com.hortonworks.streamline.streams.storm.common.logger;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LogLevelResponse {
+    private Map<String, LogLevelLoggerResponse> namedLoggerLevels;
+
+    public LogLevelResponse() {
+        this.namedLoggerLevels = new HashMap<>();
+    }
+
+    public void addLoggerResponse(String targetPackage, LogLevelLoggerResponse response) {
+        namedLoggerLevels.put(targetPackage, response);
+    }
+
+    public void addLoggerResponse(String targetPackage, String targetLogLevel, String resetLogLevel,
+                                  int timeoutSecs, long timeoutEpoch) {
+        namedLoggerLevels.put(targetPackage, new LogLevelLoggerResponse(targetLogLevel, resetLogLevel, timeoutSecs, timeoutEpoch));
+    }
+
+    public void addLoggerResponse(String targetPackage, String targetLogLevel, int timeoutSecs, long timeoutEpoch) {
+        namedLoggerLevels.put(targetPackage, new LogLevelLoggerResponse(targetLogLevel, timeoutSecs, timeoutEpoch));
+    }
+
+    public Map<String, LogLevelLoggerResponse> getNamedLoggerLevels() {
+        return namedLoggerLevels;
+    }
+}


### PR DESCRIPTION
* add HTTP API endpoints to get/modify log level at Application level
  * GET /api/v1/catalog/topologies/:topologyId/logconfig
  * POST /api/v1/catalog/topologies/:topologyId/logconfig
    * Params: targetLogLevel, durationSecs

`targetLogLevel` would be one of these: TRACE, DEBUG, INFO, WARN, ERROR

We only use `ROOT` as Logger name, as we would want to change log level at application level.