### PR TITLE
ISSUE-1065 Fix the bug in Join processor with processing time

### DIFF
--- a/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/rule/expression/Window.java
+++ b/streams/layout/src/main/java/com/hortonworks/streamline/streams/layout/component/rule/expression/Window.java
@@ -165,8 +165,9 @@ public class Window implements Serializable {
     }
 
     public void setTsFields(List<String> tsFields) {
-        Objects.requireNonNull(tsFields, "null tsFields");
-        this.tsFields = new ArrayList<>(tsFields);
+        if (tsFields != null) {
+            this.tsFields = new ArrayList<>(tsFields);
+        }
     }
 
     public int getLagMs() {


### PR DESCRIPTION
* even it disallows setting tsFields to be null, JSON deserialization tries to set it as null
  * if join processor uses processing time, tsFields are put to null from UI

Closes #1065 

Please refer #1065 for detail.