### PR TITLE
ISSUE-1076 Change default log level in log search to INFO,WARN,ERROR

### DIFF
--- a/streams/runners/storm/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/storm/ambari/AmbariInfraWithStormLogSearch.java
+++ b/streams/runners/storm/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/storm/ambari/AmbariInfraWithStormLogSearch.java
@@ -1,5 +1,6 @@
 package com.hortonworks.streamline.streams.logsearch.storm.ambari;
 
+import com.google.common.collect.Lists;
 import com.hortonworks.streamline.common.exception.ConfigException;
 import com.hortonworks.streamline.streams.logsearch.LogSearchCriteria;
 import com.hortonworks.streamline.streams.logsearch.LogSearchResult;
@@ -44,6 +45,9 @@ public class AmbariInfraWithStormLogSearch implements TopologyLogSearch {
     public static final String COLUMN_NAME_LOG_MESSAGE = "log_message";
 
     public static final String DEFAULT_COLLECTION_NAME = "hadoop_logs";
+
+    static final List<String> DEFAULT_LOG_LEVELS = Lists.newArrayList("INFO", "WARN", "ERROR");
+
     private HttpSolrClient solr;
 
     public AmbariInfraWithStormLogSearch() {
@@ -91,9 +95,10 @@ public class AmbariInfraWithStormLogSearch implements TopologyLogSearch {
         }
 
         List<String> logLevels = logSearchCriteria.getLogLevels();
-        if (logLevels != null && !logLevels.isEmpty()) {
-            query.addFilterQuery(buildColumnAndValue(COLUMN_NAME_LOG_LEVEL, buildORValues(logSearchCriteria.getLogLevels())));
+        if (logLevels == null || logLevels.isEmpty()) {
+            logLevels = DEFAULT_LOG_LEVELS;
         }
+        query.addFilterQuery(buildColumnAndValue(COLUMN_NAME_LOG_LEVEL, buildORValues(logLevels)));
 
         query.addSort(COLUMN_NAME_LOG_TIME, SolrQuery.ORDER.asc);
 

--- a/streams/runners/storm/logsearch/src/test/java/com/hortonworks/streamline/streams/logsearch/storm/ambari/AmbariInfraWithStormLogSearchTest.java
+++ b/streams/runners/storm/logsearch/src/test/java/com/hortonworks/streamline/streams/logsearch/storm/ambari/AmbariInfraWithStormLogSearchTest.java
@@ -90,6 +90,8 @@ public class AmbariInfraWithStormLogSearchTest {
 
         dateRangeValue = String.format(dateRangeValue, COLUMN_NAME_LOG_TIME, fromInstant.toString(), toInstant.toString());
 
+        String expectedLogLevels = "(" + String.join("+OR+", AmbariInfraWithStormLogSearch.DEFAULT_LOG_LEVELS) + ")";
+
         List<LoggedRequest> requests = wireMockRule.findAll(getRequestedFor(urlPathEqualTo(STUB_REQUEST_API_PATH)));
         assertEquals(1, requests.size());
 
@@ -101,7 +103,7 @@ public class AmbariInfraWithStormLogSearchTest {
         QueryParameter fqParam = request.queryParameter("fq");
         assertTrue(fqParam.containsValue(COLUMN_NAME_STREAMLINE_TOPOLOGY_ID + ":" + TEST_APP_ID));
         assertTrue(fqParam.containsValue(dateRangeValue));
-        assertFalse(fqParam.hasValueMatching(ValuePattern.containing(COLUMN_NAME_LOG_LEVEL)));
+        assertTrue(fqParam.containsValue(COLUMN_NAME_LOG_LEVEL + ":" + expectedLogLevels));
         assertFalse(fqParam.hasValueMatching(ValuePattern.containing(COLUMN_NAME_STREAMLINE_COMPONENT_NAME)));
 
         QueryParameter sortParam = request.queryParameter("sort");


### PR DESCRIPTION
* given that we don't want to deal with flooding DEBUG messages unless users select it

This closes #1076