### PR TITLE
ISSUE-1078 Inject event correlation information for processor runtime bolts

### DIFF
--- a/streams/common/src/main/java/com/hortonworks/streamline/streams/common/event/correlation/EventCorrelationInjector.java
+++ b/streams/common/src/main/java/com/hortonworks/streamline/streams/common/event/correlation/EventCorrelationInjector.java
@@ -15,6 +15,8 @@
  **/
 package com.hortonworks.streamline.streams.common.event.correlation;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import com.hortonworks.streamline.streams.StreamlineEvent;
 import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
 import org.apache.commons.lang.StringUtils;
@@ -30,6 +32,8 @@ public class EventCorrelationInjector {
     public static final String HEADER_KEY_ROOT_IDS = "rootIds";
     public static final String HEADER_KEY_PARENT_IDS = "parentIds";
     public static final String HEADER_KEY_SOURCE_COMPONENT_NAME = "sourceComponentName";
+    public static final Set<String> EVENT_CORRELATION_HEADER_KEYS =
+            ImmutableSet.of(HEADER_KEY_ROOT_IDS, HEADER_KEY_PARENT_IDS, HEADER_KEY_SOURCE_COMPONENT_NAME);
 
     public StreamlineEvent injectCorrelationInformation(StreamlineEvent event,
                                                         List<StreamlineEvent> parentEvents) {
@@ -105,5 +109,9 @@ public class EventCorrelationInjector {
             throw new IllegalArgumentException("Source component name is not in header.");
         }
         return (String) event.getHeader().get(HEADER_KEY_SOURCE_COMPONENT_NAME);
+    }
+
+    public static Set<String> getHeaderKeys() {
+        return EVENT_CORRELATION_HEADER_KEYS;
     }
 }

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/AbstractProcessorBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/AbstractProcessorBolt.java
@@ -17,6 +17,7 @@
 package com.hortonworks.streamline.streams.runtime.storm.bolt;
 
 import com.hortonworks.streamline.streams.StreamlineEvent;
+import com.hortonworks.streamline.streams.runtime.storm.event.correlation.EventCorrelatingOutputCollector;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.base.BaseRichBolt;
@@ -41,7 +42,7 @@ public abstract class AbstractProcessorBolt extends BaseTickTupleAwareRichBolt {
     public void prepare(Map stormConf, TopologyContext context, OutputCollector collector) {
         this.stormConf = stormConf;
         this.context = context;
-        this.collector = collector;
+        this.collector = new EventCorrelatingOutputCollector(context, collector);
     }
 
     @Override

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/AbstractWindowedProcessorBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/AbstractWindowedProcessorBolt.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.runtime.storm.bolt;
+
+import com.hortonworks.streamline.streams.runtime.storm.event.correlation.EventCorrelatingWindowedOutputCollector;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
+
+import java.util.Map;
+
+public abstract class AbstractWindowedProcessorBolt extends StreamlineWindowedBolt {
+    protected Map stormConf;
+    protected TopologyContext context;
+    protected OutputCollector collector;
+
+    @Override
+    public void prepare(Map stormConf, TopologyContext context, OutputCollector collector) {
+        this.stormConf = stormConf;
+        this.context = context;
+        this.collector = new EventCorrelatingWindowedOutputCollector(context, collector);
+    }
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/model/StreamlinePMMLPredictorBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/model/StreamlinePMMLPredictorBolt.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.hortonworks.streamline.streams.runtime.storm.bolt.model;
+
+import com.hortonworks.streamline.streams.runtime.storm.event.correlation.EventCorrelatingOutputCollector;
+import org.apache.storm.pmml.PMMLPredictorBolt;
+import org.apache.storm.pmml.model.ModelOutputs;
+import org.apache.storm.pmml.runner.ModelRunnerFactory;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
+
+import java.util.Map;
+
+/**
+ * All processors need to extend either AbstractProcessorBolt or AbstractWindowedProcessorBolt to support
+ * event correlation, but the class already extends Storm's PMMLPredictorBolt, hence we can't extend the class.
+ * Instead, we override prepare() method and wrap collector directly.
+ */
+public class StreamlinePMMLPredictorBolt extends PMMLPredictorBolt {
+    /**
+     * Creates an instance of {@link PMMLPredictorBolt} that executes, for every tuple, the runner constructed with
+     * the {@link ModelRunnerFactory} specified in the parameter
+     * The {@link PMMLPredictorBolt} instantiated with this constructor declares the output fields as specified
+     * by the {@link ModelOutputs} parameter
+     *
+     * @param modelRunnerFactory
+     * @param modelOutputs
+     */
+    public StreamlinePMMLPredictorBolt(ModelRunnerFactory modelRunnerFactory, ModelOutputs modelOutputs) {
+        super(modelRunnerFactory, modelOutputs);
+    }
+
+    @Override
+    public void prepare(Map stormConf, TopologyContext context, OutputCollector collector) {
+        super.prepare(stormConf, context, new EventCorrelatingOutputCollector(context, collector));
+    }
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/SLRealtimeJoinBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/SLRealtimeJoinBolt.java
@@ -20,6 +20,9 @@ package com.hortonworks.streamline.streams.runtime.storm.bolt.query;
 
 import com.hortonworks.streamline.streams.StreamlineEvent;
 import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
+import com.hortonworks.streamline.streams.runtime.storm.event.correlation.EventCorrelatingOutputCollector;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.topology.base.BaseWindowedBolt;
 import org.apache.storm.tuple.Fields;
@@ -28,6 +31,7 @@ import org.apache.storm.tuple.Tuple;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This class derives from RealtimeBolt to customize the handling of 'streamline-event' prefix
@@ -63,6 +67,11 @@ public class SLRealtimeJoinBolt extends RealtimeJoinBolt {
      */
     public SLRealtimeJoinBolt() {
         super(StreamKind.STREAM);
+    }
+
+    @Override
+    public void prepare(Map stormConf, TopologyContext context, OutputCollector collector) {
+        super.prepare(stormConf, context, new EventCorrelatingOutputCollector(context, collector));
     }
 
     @Override

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/event/correlation/EventCorrelatingOutputCollector.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/event/correlation/EventCorrelatingOutputCollector.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package com.hortonworks.streamline.streams.runtime.storm.testing;
+package com.hortonworks.streamline.streams.runtime.storm.event.correlation;
 
 import com.hortonworks.streamline.streams.StreamlineEvent;
 import org.apache.storm.task.OutputCollector;

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/event/correlation/EventCorrelatingSpoutOutputCollector.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/event/correlation/EventCorrelatingSpoutOutputCollector.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package com.hortonworks.streamline.streams.runtime.storm.testing;
+package com.hortonworks.streamline.streams.runtime.storm.event.correlation;
 
 import com.hortonworks.streamline.streams.StreamlineEvent;
 import org.apache.storm.spout.SpoutOutputCollector;

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/event/correlation/EventCorrelatingWindowedOutputCollector.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/event/correlation/EventCorrelatingWindowedOutputCollector.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.streamline.streams.runtime.storm.event.correlation;
+
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
+
+import java.util.List;
+
+/**
+ * This class restricts emitting with not anchoring parent tuples,
+ * which makes chaining output collectors with windowed bolt work.
+ */
+public class EventCorrelatingWindowedOutputCollector extends EventCorrelatingOutputCollector {
+
+    public EventCorrelatingWindowedOutputCollector(TopologyContext topologyContext, OutputCollector delegate) {
+        // we simply ignore the _delegate in OutputCollector and override all of the methods
+        // this will work with subclass of OutputCollector since we only expose methods what we know about
+        super(topologyContext, delegate);
+    }
+
+    @Override
+    public List<Integer> emit(String streamId, List<Object> tuple) {
+        throw new UnsupportedOperationException("Emitting with implicit anchoring is not support.");
+    }
+
+    @Override
+    public List<Integer> emit(List<Object> tuple) {
+        throw new UnsupportedOperationException("Emitting with implicit anchoring is not support.");
+    }
+
+    @Override
+    public void emitDirect(int taskId, String streamId, List<Object> tuple) {
+        throw new UnsupportedOperationException("Emitting with implicit anchoring is not support.");
+    }
+
+    @Override
+    public void emitDirect(int taskId, List<Object> tuple) {
+        throw new UnsupportedOperationException("Emitting with implicit anchoring is not support.");
+    }
+}

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/event/correlation/StormEventCorrelationInjector.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/event/correlation/StormEventCorrelationInjector.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-package com.hortonworks.streamline.streams.runtime.storm.testing;
+package com.hortonworks.streamline.streams.runtime.storm.event.correlation;
 
 import com.hortonworks.streamline.streams.StreamlineEvent;
 import com.hortonworks.streamline.streams.common.event.correlation.EventCorrelationInjector;

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunProcessorBolt.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunProcessorBolt.java
@@ -35,10 +35,8 @@ public class TestRunProcessorBolt extends BaseRichBolt {
 
     @Override
     public void prepare(Map map, TopologyContext topologyContext, OutputCollector outputCollector) {
-        EventCorrelatingOutputCollector collector = new EventCorrelatingOutputCollector(topologyContext,
-                new EventLoggingOutputCollector(topologyContext, outputCollector,
-                        TestRunEventLogger.getEventLogger(eventLogFilePath))
-        );
+        EventLoggingOutputCollector collector = new EventLoggingOutputCollector(topologyContext, outputCollector,
+                TestRunEventLogger.getEventLogger(eventLogFilePath));
         processorBolt.prepare(map, topologyContext, collector);
     }
 

--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunSourceSpout.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/testing/TestRunSourceSpout.java
@@ -23,6 +23,7 @@ import com.hortonworks.streamline.streams.StreamlineEvent;
 import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
 import com.hortonworks.streamline.streams.layout.component.Stream;
 import com.hortonworks.streamline.streams.layout.component.impl.testing.TestRunSource;
+import com.hortonworks.streamline.streams.runtime.storm.event.correlation.EventCorrelatingSpoutOutputCollector;
 import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
@@ -78,6 +79,7 @@ public class TestRunSourceSpout extends BaseRichSpout {
             throw new RuntimeException("testRunSource cannot be null");
         }
 
+        // it should build the chain of output collector because we are not manipulating chaining of output collector for spouts
         this.collector = new EventCorrelatingSpoutOutputCollector(context,
                 new EventLoggingSpoutOutputCollector(context, collector,
                         TestRunEventLogger.getEventLogger(testRunSource.getEventLogFilePath()))

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/StreamsShellBoltTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/StreamsShellBoltTest.java
@@ -105,13 +105,13 @@ public class StreamsShellBoltTest {
             mockContext.getComponentOutputFields(anyString, anyString);
             result = new Fields(StreamlineEvent.STREAMLINE_EVENT);
             mockContext.getComponentId(anyInt);
-            result = "componentid";
+            result = "1-componentid";
             mockContext.getPIDDir();
             result = "/tmp";
             mockContext.getCodeDir();
             result = "/tmp";
             mockContext.getThisComponentId();
-            result = "dsrid"; minTimes = 0;
+            result = "1-componentid"; minTimes = 0;
         }};
     }
 

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/normalization/NormalizationBoltTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/normalization/NormalizationBoltTest.java
@@ -139,6 +139,9 @@ public class NormalizationBoltTest {
 
             tuple.getSourceStreamId();
             returns(INPUT_STREAM_ID);
+
+            topologyContext.getThisComponentId();
+            result = "1-componentid"; minTimes = 0;
         }};
 
         normalizationBolt.execute(tuple);

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/TestRealtimeJoinBolt.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/TestRealtimeJoinBolt.java
@@ -18,14 +18,10 @@
 
 package com.hortonworks.streamline.streams.runtime.storm.bolt.query;
 
-import clojure.lang.Atom;
 import com.hortonworks.streamline.streams.StreamlineEvent;
 import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
 import com.hortonworks.streamline.streams.runtime.storm.bolt.query.RealtimeJoinBolt.StreamKind;
 import org.apache.storm.Constants;
-import org.apache.storm.generated.StormTopology;
-import org.apache.storm.metric.api.IMetric;
-import org.apache.storm.task.GeneralTopologyContext;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.base.BaseWindowedBolt;
@@ -441,13 +437,13 @@ public class TestRealtimeJoinBolt {
         @Override
         public List<Integer> emit(Collection<Tuple> anchors, List<Object> tuple) {
             actualResults.add(tuple);
-            return null;
+            return Collections.singletonList(1);
         }
 
         @Override
         public List<Integer> emit(Tuple anchor, List<Object> tuple) {
             actualResults.add(tuple);
-            return null;
+            return Collections.singletonList(1);
         }
 
         @Override
@@ -459,7 +455,7 @@ public class TestRealtimeJoinBolt {
     static class MockTopologyContext extends TopologyContext {
 
         private final Fields fields;
-        private String srcComponentId = "component";
+        private String srcComponentId = "1-component";
 
         public MockTopologyContext(String[] fieldNames) {
             super(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/TestWindowedQueryBolt.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/query/TestWindowedQueryBolt.java
@@ -237,7 +237,7 @@ public class TestWindowedQueryBolt {
     static class MockTopologyContext extends TopologyContext {
 
         private final Fields fields;
-        private String srcComponentId = "component";
+        private String srcComponentId = "1-component";
 
         public MockTopologyContext(String[] fieldNames) {
             super(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/FunctionsTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/FunctionsTest.java
@@ -44,9 +44,9 @@ public class FunctionsTest {
             mockContext.getComponentOutputFields(anyString, anyString);
             result = new Fields(StreamlineEvent.STREAMLINE_EVENT);
             mockContext.getComponentId(anyInt);
-            result = "componentid";
+            result = "1-componentid";
             mockContext.getThisComponentId();
-            result = "componentid"; minTimes = 0;
+            result = "1-componentid"; minTimes = 0;
         }};
     }
 

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/RulesBoltConditionTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/RulesBoltConditionTest.java
@@ -57,9 +57,9 @@ public class RulesBoltConditionTest {
             mockContext.getComponentOutputFields(anyString, anyString);
             result = new Fields(StreamlineEvent.STREAMLINE_EVENT);
             mockContext.getComponentId(anyInt);
-            result = "componentid";
+            result = "1-componentid";
             mockContext.getThisComponentId();
-            result = "componentid"; minTimes = 0;
+            result = "1-componentid"; minTimes = 0;
         }};
     }
 

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/RulesBoltSqlTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/RulesBoltSqlTest.java
@@ -69,7 +69,7 @@ public class RulesBoltSqlTest extends RulesBoltTest {
             mockTuple.getSourceStreamId();
             result = "default";
             mockContext.getThisComponentId();
-            result = "componentid"; minTimes = 0;
+            result = "1-componentid"; minTimes = 0;
         }};
 
         rulesBolt.execute(mockTuple);

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/RulesBoltTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/RulesBoltTest.java
@@ -105,7 +105,7 @@ public abstract class RulesBoltTest extends RulesTopologyTest {
 
     private void createAndPrepareRulesBolt(RulesProcessor rulesProcessor, RuleProcessorRuntime.ScriptType scriptType) {
         rulesBolt = (RulesBolt)createRulesBolt(rulesProcessor, scriptType);
-        rulesBolt.prepare(null, null, mockOutputCollector);
+        rulesBolt.prepare(null, mockContext, mockOutputCollector);
     }
 
     //@Test

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/WindowRulesBoltTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/bolt/rules/WindowRulesBoltTest.java
@@ -67,9 +67,9 @@ public class WindowRulesBoltTest {
             mockContext.getComponentOutputFields(anyString, anyString);
             result = new Fields(StreamlineEvent.STREAMLINE_EVENT);
             mockContext.getComponentId(anyInt);
-            result = "componentid";
+            result = "1-componentid";
             mockContext.getThisComponentId();
-            result = "componentid"; minTimes = 0;
+            result = "1-componentid"; minTimes = 0;
         }};
     }
 

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/event/correlation/EventCorrelatingSpoutOutputCollectorTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/event/correlation/EventCorrelatingSpoutOutputCollectorTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package com.hortonworks.streamline.streams.runtime.storm.testing;
+package com.hortonworks.streamline.streams.runtime.storm.event.correlation;
 
 import com.google.common.collect.Lists;
 import com.hortonworks.streamline.streams.StreamlineEvent;

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/event/correlation/EventCorrelatingWindowedOutputCollectorTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/event/correlation/EventCorrelatingWindowedOutputCollectorTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.streamline.streams.runtime.storm.event.correlation;
+
+import mockit.Deencapsulation;
+import mockit.integration.junit4.JMockit;
+import org.apache.storm.tuple.Values;
+import org.junit.Assert;
+import org.junit.runner.RunWith;
+
+@RunWith(JMockit.class)
+public class EventCorrelatingWindowedOutputCollectorTest extends EventCorrelatingOutputCollectorTest {
+
+    @Override
+    protected EventCorrelatingOutputCollector getSystemUnderTest() {
+        EventCorrelatingWindowedOutputCollector sut = new EventCorrelatingWindowedOutputCollector(mockedTopologyContext, mockedOutputCollector);
+        Deencapsulation.setField(sut, "eventCorrelationInjector", mockStormEventCorrelationInjector);
+        return sut;
+    }
+
+    @Override
+    public void emitWithoutAnchor() throws Exception {
+        setupExpectationsForEventCorrelationInjector();
+
+        EventCorrelatingOutputCollector sut = getSystemUnderTest();
+
+        String testStreamId = "testStreamId";
+        final Values tuple = new Values(INPUT_STREAMLINE_EVENT);
+
+        // String streamId, List<Object> tuple
+        try {
+            sut.emit(testStreamId, tuple);
+            Assert.fail("Should throw UnsupportedOperationException.");
+        } catch (UnsupportedOperationException e) {
+            // expected
+        }
+
+        // List<Object> tuple
+        try {
+            sut.emit(tuple);
+            Assert.fail("Should throw UnsupportedOperationException.");
+        } catch (UnsupportedOperationException e) {
+            // expected
+        }
+    }
+
+    @Override
+    public void emitDirectWithoutAnchor() throws Exception {
+        setupExpectationsForEventCorrelationInjector();
+
+        EventCorrelatingOutputCollector sut = getSystemUnderTest();
+
+        int testTaskId = TASK_1;
+        String testStreamId = "testStreamId";
+        final Values tuple = new Values(INPUT_STREAMLINE_EVENT);
+
+        // int taskId, String streamId, List<Object> tuple
+        try {
+            sut.emitDirect(testTaskId, testStreamId, tuple);
+            Assert.fail("Should throw UnsupportedOperationException.");
+        } catch (UnsupportedOperationException e) {
+            // expected
+        }
+
+        // int taskId, List<Object> tuple
+        try {
+            sut.emitDirect(testTaskId, tuple);
+            Assert.fail("Should throw UnsupportedOperationException.");
+        } catch (UnsupportedOperationException e) {
+            // expected
+        }
+
+    }
+}

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/event/correlation/StormEventCorrelationInjectorTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/event/correlation/StormEventCorrelationInjectorTest.java
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-package com.hortonworks.streamline.streams.runtime.storm.testing;
+package com.hortonworks.streamline.streams.runtime.storm.event.correlation;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.hortonworks.streamline.streams.StreamlineEvent;
 import com.hortonworks.streamline.streams.common.StreamlineEventImpl;
 import com.hortonworks.streamline.streams.common.event.correlation.EventCorrelationInjector;
+import com.hortonworks.streamline.streams.runtime.storm.event.correlation.StormEventCorrelationInjector;
 import com.hortonworks.streamline.streams.runtime.utils.StreamlineEventTestUtil;
 import com.hortonworks.streamline.streams.storm.common.StormTopologyUtil;
 import mockit.Expectations;

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/utils/StreamlineEventTestUtil.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/utils/StreamlineEventTestUtil.java
@@ -1,6 +1,7 @@
 package com.hortonworks.streamline.streams.runtime.utils;
 
 import com.hortonworks.streamline.streams.StreamlineEvent;
+import com.hortonworks.streamline.streams.common.event.correlation.EventCorrelationInjector;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -14,8 +15,12 @@ public final class StreamlineEventTestUtil {
 
         // header
         sourceEvent.getHeader().forEach((k, v) -> {
-            assertTrue(newEvent.getHeader().containsKey(k));
-            assertEquals(v, newEvent.getHeader().get(k));
+            // if the key is related to event correlation, skip checking.
+            // information for event correlation may be different based on the context
+            if (!EventCorrelationInjector.getHeaderKeys().contains(k)) {
+                assertTrue(newEvent.getHeader().containsKey(k));
+                assertEquals(v, newEvent.getHeader().get(k));
+            }
         });
 
         // other fields


### PR DESCRIPTION
* change processor bolts to wrap output collector with event correlation aware output collector
* reduce chain of collector from TestRun(Window)ProcessorBolt since one of them is put to underlying bolt
* introduce EventCorrelatingWindowedOutputCollector to restrict emitting without anchor instead of hacking around
* fix broken tests due to the change

No UI change is necessary.

This closes #1078 