### PR TITLE
ISSUE-1081: Fix the validation errors when reading from kafka message values when length is more than offset.

### DIFF
--- a/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/spout/AvroKafkaSpoutTranslator.java
+++ b/streams/runners/storm/runtime/src/main/java/com/hortonworks/streamline/streams/runtime/storm/spout/AvroKafkaSpoutTranslator.java
@@ -105,7 +105,7 @@ public class AvroKafkaSpoutTranslator implements RecordTranslator<Object, ByteBu
 
         public int read (byte[] bytes, int off, int len) throws IOException {
             Preconditions.checkNotNull(bytes, "Given byte array can not be null");
-            Preconditions.checkPositionIndexes(off, len, bytes.length);
+            Preconditions.checkPositionIndexes(off, off + len, bytes.length);
 
             if (!buf.hasRemaining()) {
                 return -1;

--- a/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/spout/AvroKafkaSpoutTranslatorTest.java
+++ b/streams/runners/storm/runtime/src/test/java/com/hortonworks/streamline/streams/runtime/storm/spout/AvroKafkaSpoutTranslatorTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.runtime.storm.spout;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+
+public class AvroKafkaSpoutTranslatorTest {
+
+    @Test
+    public void testByteBufferInputStream() throws Exception {
+        int res = read(1000, 1000, 0, 1000);
+        assertEquals(1000, res);
+    }
+
+    @Test
+    public void testByteBufferInputStreamNonZeroOffset1() throws Exception {
+        int res = read(1000, 1000, 100, 900);
+        assertEquals(900, res);
+    }
+
+    @Test
+    public void testByteBufferInputStreamNonZeroOffset2() throws Exception {
+        int res = read(1000, 1000, 600, 400);
+        assertEquals(400, res);
+    }
+
+    @Test
+    public void testByteBufferInputStreamSmallBuffer() throws Exception {
+        int res = read(100, 1000, 600, 400);
+        assertEquals(100, res);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testByteBufferInputStreamSmallDest() throws Exception {
+        int res = read(1000, 100, 600, 400);
+        assertEquals(100, res);
+    }
+
+    private int read(int bufSize, int destSize, int offset, int length) throws IOException {
+        ByteBuffer byteBuffer = ByteBuffer.allocate(bufSize);
+        AvroKafkaSpoutTranslator.ByteBufferInputStream is = new AvroKafkaSpoutTranslator.ByteBufferInputStream(byteBuffer);
+        byte[] dest = new byte[destSize];
+        return is.read(dest, offset, length);
+    }
+}


### PR DESCRIPTION
Fix the wrong index validations and added tests.

Fixes #1081 