### PR TITLE
ISSUE-1090 Provide backend API endpoint for fetching events indexed in Log Search service

### DIFF
--- a/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/DefaultTopologyLogSearch.java
+++ b/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/DefaultTopologyLogSearch.java
@@ -32,4 +32,10 @@ public class DefaultTopologyLogSearch implements TopologyLogSearch {
     // no-op. just returning empty result
     return new LogSearchResult(0L, Collections.emptyList());
   }
+
+  @Override
+  public EventSearchResult searchEvent(EventSearchCriteria criteria) {
+    // no-op. just returning empty result
+    return new EventSearchResult(0L, Collections.emptyList());
+  }
 }

--- a/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/EventSearchCriteria.java
+++ b/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/EventSearchCriteria.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.logsearch;
+
+import java.util.List;
+
+public class EventSearchCriteria {
+    private String appId;
+    private List<String> componentNames;
+    private String searchString;
+    private String searchEventId;
+    private long from;
+    private long to;
+    private Integer start;
+    private Integer limit;
+    private Boolean ascending;
+
+    public String getAppId() {
+        return appId;
+    }
+
+    public List<String> getComponentNames() {
+        return componentNames;
+    }
+
+    public String getSearchString() {
+        return searchString;
+    }
+
+    public String getSearchEventId() {
+        return searchEventId;
+    }
+
+    public long getFrom() {
+        return from;
+    }
+
+    public long getTo() {
+        return to;
+    }
+
+    public Integer getStart() {
+        return start;
+    }
+
+    public Integer getLimit() {
+        return limit;
+    }
+
+    public Boolean getAscending() {
+        return ascending;
+    }
+
+    public EventSearchCriteria(String appId, List<String> componentNames, String searchString,
+                               String searchEventId, long from, long to, Integer start, Integer limit,
+                               Boolean ascending) {
+        this.appId = appId;
+        this.componentNames = componentNames;
+        this.searchString = searchString;
+        this.searchEventId = searchEventId;
+        this.from = from;
+        this.to = to;
+        this.start = start;
+        this.limit = limit;
+        this.ascending = ascending;
+    }
+
+    public static class Builder {
+        private String appId;
+        private List<String> componentNames;
+        private String searchString;
+        private String searchEventId;
+        private long from;
+        private long to;
+        private Integer start;
+        private Integer limit;
+        private Boolean ascending;
+
+        public Builder(String appId, long from, long to) {
+            this.appId = appId;
+            this.from = from;
+            this.to = to;
+        }
+
+        public Builder setComponentNames(List<String> componentNames) {
+            this.componentNames = componentNames;
+            return this;
+        }
+
+        public Builder setSearchString(String searchString) {
+            this.searchString = searchString;
+            return this;
+        }
+
+        public Builder setSearchEventId(String searchEventId) {
+            this.searchEventId = searchEventId;
+            return this;
+        }
+
+        public Builder setStart(Integer start) {
+            this.start = start;
+            return this;
+        }
+
+        public Builder setLimit(Integer limit) {
+            this.limit = limit;
+            return this;
+        }
+
+        public Builder setAscending(Boolean ascending) {
+            this.ascending = ascending;
+            return this;
+        }
+
+        public EventSearchCriteria build() {
+            return new EventSearchCriteria(appId, componentNames, searchString, searchEventId,
+                    from, to, start, limit, ascending);
+        }
+    }
+}

--- a/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/EventSearchResult.java
+++ b/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/EventSearchResult.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.logsearch;
+
+import java.util.List;
+
+public class EventSearchResult {
+    private Long matchedEvents;
+    private List<Event> events;
+
+    public EventSearchResult(Long matchedEvents, List<Event> events) {
+        this.matchedEvents = matchedEvents;
+        this.events = events;
+    }
+
+    public Long getMatchedEvents() {
+        return matchedEvents;
+    }
+
+    public List<Event> getEvents() {
+        return events;
+    }
+
+    public static class Event {
+        private String appId;
+        private String componentName;
+        private String eventId;
+        private String rootIds;
+        private String parentIds;
+        private String keyValues;
+        private String headers;
+        private String auxKeyValues;
+
+        private long timestamp;
+
+        public Event(String appId, String componentName, String eventId, String rootIds, String parentIds,
+                     String keyValues, String headers, String auxKeyValues, long timestamp) {
+            this.appId = appId;
+            this.componentName = componentName;
+            this.eventId = eventId;
+            this.rootIds = rootIds;
+            this.parentIds = parentIds;
+            this.keyValues = keyValues;
+            this.headers = headers;
+            this.auxKeyValues = auxKeyValues;
+            this.timestamp = timestamp;
+        }
+
+        public String getAppId() {
+            return appId;
+        }
+
+        public String getComponentName() {
+            return componentName;
+        }
+
+        public String getEventId() {
+            return eventId;
+        }
+
+        public String getRootIds() {
+            return rootIds;
+        }
+
+        public String getParentIds() {
+            return parentIds;
+        }
+
+        public String getKeyValues() {
+            return keyValues;
+        }
+
+        public String getHeaders() {
+            return headers;
+        }
+
+        public String getAuxKeyValues() {
+            return auxKeyValues;
+        }
+
+        public long getTimestamp() {
+            return timestamp;
+        }
+    }
+}

--- a/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/TopologyLogSearch.java
+++ b/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/TopologyLogSearch.java
@@ -17,7 +17,6 @@ package com.hortonworks.streamline.streams.logsearch;
 
 import com.hortonworks.streamline.common.exception.ConfigException;
 
-import java.util.List;
 import java.util.Map;
 
 public interface TopologyLogSearch {
@@ -25,4 +24,6 @@ public interface TopologyLogSearch {
     void init (Map<String, Object> conf) throws ConfigException;
 
     LogSearchResult search(LogSearchCriteria criteria);
+
+    EventSearchResult searchEvent(EventSearchCriteria criteria);
 }

--- a/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/topology/service/TopologyLogSearchService.java
+++ b/streams/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/topology/service/TopologyLogSearchService.java
@@ -19,6 +19,8 @@ import com.hortonworks.streamline.streams.catalog.Topology;
 import com.hortonworks.streamline.streams.cluster.catalog.Namespace;
 import com.hortonworks.streamline.streams.cluster.container.ContainingNamespaceAwareContainer;
 import com.hortonworks.streamline.streams.cluster.service.EnvironmentService;
+import com.hortonworks.streamline.streams.logsearch.EventSearchCriteria;
+import com.hortonworks.streamline.streams.logsearch.EventSearchResult;
 import com.hortonworks.streamline.streams.logsearch.LogSearchCriteria;
 import com.hortonworks.streamline.streams.logsearch.LogSearchResult;
 import com.hortonworks.streamline.streams.logsearch.TopologyLogSearch;
@@ -39,6 +41,11 @@ public class TopologyLogSearchService implements ContainingNamespaceAwareContain
   public LogSearchResult search(Topology topology, LogSearchCriteria criteria) {
     TopologyLogSearch topologyLogSearch = getTopologyLogSearchInstance(topology);
     return topologyLogSearch.search(criteria);
+  }
+
+  public EventSearchResult searchEvent(Topology topology, EventSearchCriteria criteria) {
+    TopologyLogSearch topologyLogSearch = getTopologyLogSearchInstance(topology);
+    return topologyLogSearch.searchEvent(criteria);
   }
 
   @Override

--- a/streams/runners/storm/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/storm/ambari/AmbariInfraWithStormLogSearch.java
+++ b/streams/runners/storm/logsearch/src/main/java/com/hortonworks/streamline/streams/logsearch/storm/ambari/AmbariInfraWithStormLogSearch.java
@@ -1,7 +1,11 @@
 package com.hortonworks.streamline.streams.logsearch.storm.ambari;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.hortonworks.streamline.common.exception.ConfigException;
+import com.hortonworks.streamline.streams.logsearch.EventSearchCriteria;
+import com.hortonworks.streamline.streams.logsearch.EventSearchResult;
 import com.hortonworks.streamline.streams.logsearch.LogSearchCriteria;
 import com.hortonworks.streamline.streams.logsearch.LogSearchResult;
 import com.hortonworks.streamline.streams.logsearch.TopologyLogSearch;
@@ -19,9 +23,11 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Implementation of TopologyLogSearch for Ambari Infra (Solr) with Storm.
@@ -36,6 +42,10 @@ public class AmbariInfraWithStormLogSearch implements TopologyLogSearch {
     static final String COLLECTION_NAME = "collection";
     static final String SECURED_CLUSTER = "secured";
 
+    public static final String COLUMN_NAME_TYPE = "type";
+    public static final String COLUMN_VALUE_TYPE_WORKER_LOG = "storm_worker";
+    public static final String COLUMN_VALUE_TYPE_EVENT = "storm_worker_event";
+
     public static final String COLUMN_NAME_STREAMLINE_TOPOLOGY_ID = "sdi_streamline_topology_id";
     public static final String COLUMN_NAME_STREAMLINE_COMPONENT_NAME = "sdi_streamline_component_name";
     public static final String COLUMN_NAME_STORM_WORKER_PORT = "sdi_storm_worker_port";
@@ -43,6 +53,13 @@ public class AmbariInfraWithStormLogSearch implements TopologyLogSearch {
     public static final String COLUMN_NAME_LOG_TIME = "logtime";
     public static final String COLUMN_NAME_LOG_LEVEL = "level";
     public static final String COLUMN_NAME_LOG_MESSAGE = "log_message";
+
+    public static final String COLUMN_NAME_STREAMLINE_EVENT_ID = "sdi_streamline_event_id";
+    public static final String COLUMN_NAME_STREAMLINE_EVENT_ROOT_ID_SET = "sdi_streamline_root_ids";
+    public static final String COLUMN_NAME_STREAMLINE_EVENT_PARENT_ID_SET = "sdi_streamline_parent_ids";
+    public static final String COLUMN_NAME_STREAMLINE_EVENT_KEYVALUES = "sdi_streamline_event_fields_and_values";
+    public static final String COLUMN_NAME_STREAMLINE_EVENT_HEADERS = "sdi_streamline_event_headers";
+    public static final String COLUMN_NAME_STREAMLINE_EVENT_AUX_KEYVALUES = "sdi_streamline_event_aux_fields_and_values";
 
     public static final String DEFAULT_COLLECTION_NAME = "hadoop_logs";
 
@@ -86,12 +103,13 @@ public class AmbariInfraWithStormLogSearch implements TopologyLogSearch {
         SolrQuery query = new SolrQuery();
 
         query.setQuery(buildColumnAndValue(COLUMN_NAME_LOG_MESSAGE, buildValue(logSearchCriteria.getSearchString())));
+        query.addFilterQuery(buildColumnAndValue(COLUMN_NAME_TYPE, COLUMN_VALUE_TYPE_WORKER_LOG));
         query.addFilterQuery(buildColumnAndValue(COLUMN_NAME_STREAMLINE_TOPOLOGY_ID, buildValue(logSearchCriteria.getAppId())));
         query.addFilterQuery(buildColumnAndValue(COLUMN_NAME_LOG_TIME, buildDateRangeValue(logSearchCriteria.getFrom(), logSearchCriteria.getTo())));
 
         List<String> componentNames = logSearchCriteria.getComponentNames();
         if (componentNames != null && !componentNames.isEmpty()) {
-            query.addFilterQuery(buildColumnAndValue(COLUMN_NAME_STREAMLINE_COMPONENT_NAME, buildORValues(logSearchCriteria.getComponentNames())));
+            query.addFilterQuery(buildColumnAndValue(COLUMN_NAME_STREAMLINE_COMPONENT_NAME, buildORValues(componentNames)));
         }
 
         List<String> logLevels = logSearchCriteria.getLogLevels();
@@ -140,6 +158,99 @@ public class AmbariInfraWithStormLogSearch implements TopologyLogSearch {
         }
 
         return new LogSearchResult(numFound, results);
+    }
+
+    @Override
+    public EventSearchResult searchEvent(EventSearchCriteria criteria) {
+        SolrQuery query = new SolrQuery();
+
+        String searchString = criteria.getSearchString();
+
+        List<String> queryStrings = new ArrayList<>();
+        addQueryStringToListOnlyIfAvailable(queryStrings, searchString, COLUMN_NAME_STREAMLINE_EVENT_KEYVALUES);
+        addQueryStringToListOnlyIfAvailable(queryStrings, searchString, COLUMN_NAME_STREAMLINE_EVENT_HEADERS);
+        addQueryStringToListOnlyIfAvailable(queryStrings, searchString, COLUMN_NAME_STREAMLINE_EVENT_AUX_KEYVALUES);
+
+        // this is to get rid of non-streamline events
+        String queryString = buildColumnAndValue(COLUMN_NAME_STREAMLINE_EVENT_ID, buildValue(null));
+
+        if (!queryStrings.isEmpty()) {
+            queryString += " AND (" + String.join(" OR ", queryStrings) + ")";
+        }
+
+        query.setQuery(queryString);
+
+        query.addFilterQuery(buildColumnAndValue(COLUMN_NAME_TYPE, COLUMN_VALUE_TYPE_EVENT));
+        query.addFilterQuery(buildColumnAndValue(COLUMN_NAME_STREAMLINE_TOPOLOGY_ID, buildValue(criteria.getAppId())));
+        query.addFilterQuery(buildColumnAndValue(COLUMN_NAME_LOG_TIME, buildDateRangeValue(criteria.getFrom(), criteria.getTo())));
+
+        List<String> componentNames = criteria.getComponentNames();
+        if (componentNames != null && !componentNames.isEmpty()) {
+            query.addFilterQuery(buildColumnAndValue(COLUMN_NAME_STREAMLINE_COMPONENT_NAME, buildORValues(componentNames)));
+        }
+
+        String searchEventId = criteria.getSearchEventId();
+        if (searchEventId != null) {
+            // eventId OR rootId OR parentId
+            String queryToEventId = buildColumnAndValue(COLUMN_NAME_STREAMLINE_EVENT_ID, buildValue(searchEventId));
+            String queryToRootIds = buildColumnAndValue(COLUMN_NAME_STREAMLINE_EVENT_ROOT_ID_SET, buildValue("*" + searchEventId + "*"));
+            String queryToParentIds = buildColumnAndValue(COLUMN_NAME_STREAMLINE_EVENT_PARENT_ID_SET, buildValue("*" + searchEventId + "*"));
+            query.addFilterQuery(queryToEventId + " OR " + queryToRootIds + " OR " + queryToParentIds);
+        }
+
+        if (criteria.getAscending() == null || criteria.getAscending()) {
+            query.addSort(COLUMN_NAME_LOG_TIME, SolrQuery.ORDER.asc);
+        } else {
+            query.addSort(COLUMN_NAME_LOG_TIME, SolrQuery.ORDER.desc);
+        }
+
+        if (criteria.getStart() != null) {
+            query.setStart(criteria.getStart());
+        }
+        if (criteria.getLimit() != null) {
+            query.setRows(criteria.getLimit());
+        }
+
+        LOG.debug("Querying to Solr: query => {}", query);
+
+        long numFound;
+        List<EventSearchResult.Event> results = new ArrayList<>();
+        try {
+            QueryResponse response = solr.query(query);
+
+            SolrDocumentList docList = response.getResults();
+            numFound = docList.getNumFound();
+
+            for (SolrDocument document : docList) {
+                String appId = (String) document.getFieldValue(COLUMN_NAME_STREAMLINE_TOPOLOGY_ID);
+                String componentName = (String) document.getFieldValue(COLUMN_NAME_STREAMLINE_COMPONENT_NAME);
+                String eventId = (String) document.getFieldValue(COLUMN_NAME_STREAMLINE_EVENT_ID);
+                String rootIds = (String) document.getFieldValue(COLUMN_NAME_STREAMLINE_EVENT_ROOT_ID_SET);
+                String parentIds = (String) document.getFieldValue(COLUMN_NAME_STREAMLINE_EVENT_PARENT_ID_SET);
+                String keyValues = (String) document.getFieldValue(COLUMN_NAME_STREAMLINE_EVENT_KEYVALUES);
+                String headers = (String) document.getFieldValue(COLUMN_NAME_STREAMLINE_EVENT_HEADERS);
+                String auxKeyValues = (String) document.getFieldValue(COLUMN_NAME_STREAMLINE_EVENT_AUX_KEYVALUES);
+
+                Date logDate = (Date) document.getFieldValue(COLUMN_NAME_LOG_TIME);
+                long timestamp = logDate.toInstant().toEpochMilli();
+
+                EventSearchResult.Event event = new EventSearchResult.Event(appId, componentName,
+                        eventId, rootIds, parentIds, keyValues, headers, auxKeyValues, timestamp);
+                results.add(event);
+            }
+
+        } catch (SolrServerException | IOException e) {
+            // TODO: any fine-grained control needed?
+            throw new RuntimeException(e);
+        }
+
+        return new EventSearchResult(numFound, results);
+    }
+
+    private void addQueryStringToListOnlyIfAvailable(List<String> queryStrings, String searchString, String columnName) {
+        if (searchString != null && !searchString.isEmpty()) {
+            queryStrings.add(buildColumnAndValue(columnName, searchString));
+        }
     }
 
     private String buildColumnAndValue(String column, String value) {

--- a/streams/runners/storm/logsearch/src/test/java/com/hortonworks/streamline/streams/logsearch/storm/ambari/AmbariInfraWithStormLogSearchTest.java
+++ b/streams/runners/storm/logsearch/src/test/java/com/hortonworks/streamline/streams/logsearch/storm/ambari/AmbariInfraWithStormLogSearchTest.java
@@ -1,10 +1,13 @@
 package com.hortonworks.streamline.streams.logsearch.storm.ambari;
 
+import com.github.tomakehurst.wiremock.client.UrlMatchingStrategy;
 import com.github.tomakehurst.wiremock.http.QueryParameter;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.matching.ValuePattern;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.google.common.collect.Lists;
+import com.hortonworks.streamline.streams.logsearch.EventSearchCriteria;
+import com.hortonworks.streamline.streams.logsearch.EventSearchResult;
 import com.hortonworks.streamline.streams.logsearch.LogSearchCriteria;
 import com.hortonworks.streamline.streams.logsearch.LogSearchResult;
 import mockit.Deencapsulation;
@@ -20,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -29,12 +33,22 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.hortonworks.streamline.streams.logsearch.storm.ambari.AmbariInfraWithStormLogSearch.COLUMN_NAME_LOG_LEVEL;
 import static com.hortonworks.streamline.streams.logsearch.storm.ambari.AmbariInfraWithStormLogSearch.COLUMN_NAME_LOG_MESSAGE;
 import static com.hortonworks.streamline.streams.logsearch.storm.ambari.AmbariInfraWithStormLogSearch.COLUMN_NAME_LOG_TIME;
 import static com.hortonworks.streamline.streams.logsearch.storm.ambari.AmbariInfraWithStormLogSearch.COLUMN_NAME_STREAMLINE_COMPONENT_NAME;
+import static com.hortonworks.streamline.streams.logsearch.storm.ambari.AmbariInfraWithStormLogSearch.COLUMN_NAME_STREAMLINE_EVENT_AUX_KEYVALUES;
+import static com.hortonworks.streamline.streams.logsearch.storm.ambari.AmbariInfraWithStormLogSearch.COLUMN_NAME_STREAMLINE_EVENT_HEADERS;
+import static com.hortonworks.streamline.streams.logsearch.storm.ambari.AmbariInfraWithStormLogSearch.COLUMN_NAME_STREAMLINE_EVENT_ID;
+import static com.hortonworks.streamline.streams.logsearch.storm.ambari.AmbariInfraWithStormLogSearch.COLUMN_NAME_STREAMLINE_EVENT_KEYVALUES;
+import static com.hortonworks.streamline.streams.logsearch.storm.ambari.AmbariInfraWithStormLogSearch.COLUMN_NAME_STREAMLINE_EVENT_PARENT_ID_SET;
+import static com.hortonworks.streamline.streams.logsearch.storm.ambari.AmbariInfraWithStormLogSearch.COLUMN_NAME_STREAMLINE_EVENT_ROOT_ID_SET;
 import static com.hortonworks.streamline.streams.logsearch.storm.ambari.AmbariInfraWithStormLogSearch.COLUMN_NAME_STREAMLINE_TOPOLOGY_ID;
+import static com.hortonworks.streamline.streams.logsearch.storm.ambari.AmbariInfraWithStormLogSearch.COLUMN_NAME_TYPE;
+import static com.hortonworks.streamline.streams.logsearch.storm.ambari.AmbariInfraWithStormLogSearch.COLUMN_VALUE_TYPE_EVENT;
+import static com.hortonworks.streamline.streams.logsearch.storm.ambari.AmbariInfraWithStormLogSearch.COLUMN_VALUE_TYPE_WORKER_LOG;
 import static org.junit.Assert.*;
 
 public class AmbariInfraWithStormLogSearchTest {
@@ -75,12 +89,12 @@ public class AmbariInfraWithStormLogSearchTest {
     }
 
     @Test
-    public void testSearchWithMinimumParameters() throws Exception {
+    public void testLogSearchWithMinimumParameters() throws Exception {
         stubSolrUrl();
 
         LogSearchCriteria logSearchCriteria = new LogSearchCriteria.Builder(TEST_APP_ID, TEST_FROM, TEST_TO).build();
         LogSearchResult result = logSearch.search(logSearchCriteria);
-        verifyResults(result);
+        verifyLogSearchResults(result);
 
         // please note that space should be escaped to '+' since Wiremock doesn't handle it when matching...
         String dateRangeValue = "%s:[%s+TO+%s]";
@@ -102,6 +116,7 @@ public class AmbariInfraWithStormLogSearchTest {
 
         QueryParameter fqParam = request.queryParameter("fq");
         assertTrue(fqParam.containsValue(COLUMN_NAME_STREAMLINE_TOPOLOGY_ID + ":" + TEST_APP_ID));
+        assertTrue(fqParam.containsValue(COLUMN_NAME_TYPE + ":" + COLUMN_VALUE_TYPE_WORKER_LOG));
         assertTrue(fqParam.containsValue(dateRangeValue));
         assertTrue(fqParam.containsValue(COLUMN_NAME_LOG_LEVEL + ":" + expectedLogLevels));
         assertFalse(fqParam.hasValueMatching(ValuePattern.containing(COLUMN_NAME_STREAMLINE_COMPONENT_NAME)));
@@ -111,7 +126,7 @@ public class AmbariInfraWithStormLogSearchTest {
     }
 
     @Test
-    public void testSearchWithFullParameters() throws Exception {
+    public void testLogSearchWithFullParameters() throws Exception {
         stubSolrUrl();
 
         int testStart = 100;
@@ -131,7 +146,7 @@ public class AmbariInfraWithStormLogSearchTest {
         LogSearchResult result = logSearch.search(logSearchCriteria);
 
         // note that the result doesn't change given that we just provide same result from file
-        verifyResults(result);
+        verifyLogSearchResults(result);
 
         // please note that space should be escaped to '+' since Wiremock doesn't handle it when matching...
         String dateRangeValue = "%s:[%s+TO+%s]";
@@ -154,6 +169,7 @@ public class AmbariInfraWithStormLogSearchTest {
 
         QueryParameter fqParam = request.queryParameter("fq");
         assertTrue(fqParam.containsValue(COLUMN_NAME_STREAMLINE_TOPOLOGY_ID + ":" + TEST_APP_ID));
+        assertTrue(fqParam.containsValue(COLUMN_NAME_TYPE + ":" + COLUMN_VALUE_TYPE_WORKER_LOG));
         assertTrue(fqParam.containsValue(COLUMN_NAME_STREAMLINE_COMPONENT_NAME + ":" + expectedComponentNames));
         assertTrue(fqParam.containsValue(COLUMN_NAME_LOG_LEVEL + ":" + expectedLogLevels));
         assertTrue(fqParam.containsValue(dateRangeValue));
@@ -169,7 +185,7 @@ public class AmbariInfraWithStormLogSearchTest {
     }
 
     @Test
-    public void testSearchWithSingleComponentNameAndLogLevelParameters() throws Exception {
+    public void testLogSearchWithSingleComponentNameAndLogLevelParameters() throws Exception {
         stubSolrUrl();
 
         int testStart = 100;
@@ -189,9 +205,9 @@ public class AmbariInfraWithStormLogSearchTest {
         LogSearchResult result = logSearch.search(logSearchCriteria);
 
         // note that the result doesn't change given that we just provide same result from file
-        verifyResults(result);
+        verifyLogSearchResults(result);
 
-        // others are covered from testSearchWithFullParameters()
+        // others are covered from testLogSearchWithFullParameters()
 
         List<LoggedRequest> requests = wireMockRule.findAll(getRequestedFor(urlPathEqualTo(STUB_REQUEST_API_PATH)));
         assertEquals(1, requests.size());
@@ -200,10 +216,182 @@ public class AmbariInfraWithStormLogSearchTest {
 
         QueryParameter fqParam = request.queryParameter("fq");
         assertTrue(fqParam.containsValue(COLUMN_NAME_STREAMLINE_COMPONENT_NAME + ":" + testComponentNames.get(0)));
+        assertTrue(fqParam.containsValue(COLUMN_NAME_TYPE + ":" + COLUMN_VALUE_TYPE_WORKER_LOG));
         assertTrue(fqParam.containsValue(COLUMN_NAME_LOG_LEVEL + ":" + testLogLevels.get(0)));
     }
 
-    private void verifyResults(LogSearchResult results) {
+    @Test
+    public void testEventSearchWithMinimumParameters() throws Exception {
+        stubSolrUrl();
+
+        EventSearchCriteria eventSearchCriteria = new EventSearchCriteria.Builder(TEST_APP_ID, TEST_FROM, TEST_TO).build();
+        EventSearchResult result = logSearch.searchEvent(eventSearchCriteria);
+        verifyEventSearchResults(result);
+
+        // please note that space should be escaped to '+' since Wiremock doesn't handle it when matching...
+        String dateRangeValue = "%s:[%s+TO+%s]";
+
+        Instant fromInstant = Instant.ofEpochMilli(TEST_FROM);
+        Instant toInstant = Instant.ofEpochMilli(TEST_TO);
+
+        dateRangeValue = String.format(dateRangeValue, COLUMN_NAME_LOG_TIME, fromInstant.toString(), toInstant.toString());
+
+        List<LoggedRequest> requests = wireMockRule.findAll(getRequestedFor(urlPathEqualTo(STUB_REQUEST_API_PATH)));
+        assertEquals(1, requests.size());
+
+        LoggedRequest request = requests.get(0);
+
+        QueryParameter qParam = request.queryParameter("q");
+        assertTrue(qParam.containsValue(COLUMN_NAME_STREAMLINE_EVENT_ID + ":*"));
+
+        QueryParameter fqParam = request.queryParameter("fq");
+        assertTrue(fqParam.containsValue(COLUMN_NAME_TYPE + ":" + COLUMN_VALUE_TYPE_EVENT));
+        assertTrue(fqParam.containsValue(COLUMN_NAME_STREAMLINE_TOPOLOGY_ID + ":" + TEST_APP_ID));
+        assertTrue(fqParam.containsValue(dateRangeValue));
+        assertFalse(fqParam.hasValueMatching(ValuePattern.containing(COLUMN_NAME_STREAMLINE_COMPONENT_NAME)));
+        assertFalse(fqParam.hasValueMatching(ValuePattern.containing(COLUMN_NAME_STREAMLINE_EVENT_ID)));
+        assertFalse(fqParam.hasValueMatching(ValuePattern.containing(COLUMN_NAME_STREAMLINE_EVENT_ROOT_ID_SET)));
+        assertFalse(fqParam.hasValueMatching(ValuePattern.containing(COLUMN_NAME_STREAMLINE_EVENT_PARENT_ID_SET)));
+
+        QueryParameter sortParam = request.queryParameter("sort");
+        assertTrue(sortParam.containsValue(COLUMN_NAME_LOG_TIME + "+asc"));
+    }
+
+    @Test
+    public void testEventSearchWithComponentNamesAndStartAndLimitAndDescendingParameters() throws Exception {
+        stubSolrUrl();
+
+        int testStart = 100;
+        int testLimit = 2000;
+        List<String> testComponentNames = Collections.singletonList("SOURCE");
+
+        EventSearchCriteria eventSearchCriteria = new EventSearchCriteria.Builder(TEST_APP_ID, TEST_FROM, TEST_TO)
+                .setComponentNames(testComponentNames).setAscending(false).setStart(testStart).setLimit(testLimit).build();
+        EventSearchResult result = logSearch.searchEvent(eventSearchCriteria);
+        verifyEventSearchResults(result);
+
+        // please note that space should be escaped to '+' since Wiremock doesn't handle it when matching...
+        String dateRangeValue = "%s:[%s+TO+%s]";
+
+        Instant fromInstant = Instant.ofEpochMilli(TEST_FROM);
+        Instant toInstant = Instant.ofEpochMilli(TEST_TO);
+
+        dateRangeValue = String.format(dateRangeValue, COLUMN_NAME_LOG_TIME, fromInstant.toString(), toInstant.toString());
+
+        List<LoggedRequest> requests = wireMockRule.findAll(getRequestedFor(urlPathEqualTo(STUB_REQUEST_API_PATH)));
+        assertEquals(1, requests.size());
+
+        LoggedRequest request = requests.get(0);
+
+        QueryParameter qParam = request.queryParameter("q");
+        assertTrue(qParam.containsValue(COLUMN_NAME_STREAMLINE_EVENT_ID + ":*"));
+
+        QueryParameter fqParam = request.queryParameter("fq");
+        assertTrue(fqParam.containsValue(COLUMN_NAME_TYPE + ":" + COLUMN_VALUE_TYPE_EVENT));
+        assertTrue(fqParam.containsValue(COLUMN_NAME_STREAMLINE_TOPOLOGY_ID + ":" + TEST_APP_ID));
+        assertTrue(fqParam.containsValue(dateRangeValue));
+        assertTrue(fqParam.containsValue(COLUMN_NAME_STREAMLINE_COMPONENT_NAME + ":" + testComponentNames.get(0)));
+        assertFalse(fqParam.hasValueMatching(ValuePattern.containing(COLUMN_NAME_STREAMLINE_EVENT_ID)));
+        assertFalse(fqParam.hasValueMatching(ValuePattern.containing(COLUMN_NAME_STREAMLINE_EVENT_ROOT_ID_SET)));
+        assertFalse(fqParam.hasValueMatching(ValuePattern.containing(COLUMN_NAME_STREAMLINE_EVENT_PARENT_ID_SET)));
+
+        QueryParameter sortParam = request.queryParameter("sort");
+        assertTrue(sortParam.containsValue(COLUMN_NAME_LOG_TIME + "+desc"));
+
+        QueryParameter startParam = request.queryParameter("start");
+        assertTrue(startParam.containsValue(String.valueOf(testStart)));
+
+        QueryParameter rowsParam = request.queryParameter("rows");
+        assertTrue(rowsParam.containsValue(String.valueOf(testLimit)));
+    }
+
+    @Test
+    public void testEventSearchWithEventId() throws Exception {
+        stubSolrUrl();
+
+        String testEventId = "b7715c60-74ad-43dd-814a-8a40403a31bc";
+
+        EventSearchCriteria eventSearchCriteria = new EventSearchCriteria.Builder(TEST_APP_ID, TEST_FROM, TEST_TO)
+                .setSearchEventId(testEventId).build();
+        EventSearchResult result = logSearch.searchEvent(eventSearchCriteria);
+        verifyEventSearchResults(result);
+
+        // please note that space should be escaped to '+' since Wiremock doesn't handle it when matching...
+        String dateRangeValue = "%s:[%s+TO+%s]";
+
+        Instant fromInstant = Instant.ofEpochMilli(TEST_FROM);
+        Instant toInstant = Instant.ofEpochMilli(TEST_TO);
+
+        dateRangeValue = String.format(dateRangeValue, COLUMN_NAME_LOG_TIME, fromInstant.toString(), toInstant.toString());
+
+        List<LoggedRequest> requests = wireMockRule.findAll(getRequestedFor(urlPathEqualTo(STUB_REQUEST_API_PATH)));
+        assertEquals(1, requests.size());
+
+        LoggedRequest request = requests.get(0);
+
+        QueryParameter qParam = request.queryParameter("q");
+        assertTrue(qParam.containsValue(COLUMN_NAME_STREAMLINE_EVENT_ID + ":*"));
+
+        QueryParameter fqParam = request.queryParameter("fq");
+        assertTrue(fqParam.containsValue(COLUMN_NAME_TYPE + ":" + COLUMN_VALUE_TYPE_EVENT));
+        assertTrue(fqParam.containsValue(COLUMN_NAME_STREAMLINE_TOPOLOGY_ID + ":" + TEST_APP_ID));
+        assertTrue(fqParam.containsValue(dateRangeValue));
+        assertFalse(fqParam.hasValueMatching(ValuePattern.containing(COLUMN_NAME_STREAMLINE_COMPONENT_NAME)));
+
+        String expectedEventIdQuery = COLUMN_NAME_STREAMLINE_EVENT_ID + ":" + testEventId;
+        expectedEventIdQuery += "+OR+" + COLUMN_NAME_STREAMLINE_EVENT_ROOT_ID_SET + ":*" + testEventId + "*";
+        expectedEventIdQuery += "+OR+" + COLUMN_NAME_STREAMLINE_EVENT_PARENT_ID_SET + ":*" + testEventId + "*";
+        assertTrue(fqParam.containsValue(expectedEventIdQuery));
+
+        QueryParameter sortParam = request.queryParameter("sort");
+        assertTrue(sortParam.containsValue(COLUMN_NAME_LOG_TIME + "+asc"));
+    }
+
+    @Test
+    public void testEventSearchWithKeyValuesQueryAndHeadersQuery() throws Exception {
+        stubSolrUrl();
+
+        String searchQuery = "hello=world";
+
+        EventSearchCriteria eventSearchCriteria = new EventSearchCriteria.Builder(TEST_APP_ID, TEST_FROM, TEST_TO)
+                .setSearchString(searchQuery).build();
+        EventSearchResult result = logSearch.searchEvent(eventSearchCriteria);
+        verifyEventSearchResults(result);
+
+        // please note that space should be escaped to '+' since Wiremock doesn't handle it when matching...
+        String dateRangeValue = "%s:[%s+TO+%s]";
+
+        Instant fromInstant = Instant.ofEpochMilli(TEST_FROM);
+        Instant toInstant = Instant.ofEpochMilli(TEST_TO);
+
+        dateRangeValue = String.format(dateRangeValue, COLUMN_NAME_LOG_TIME, fromInstant.toString(), toInstant.toString());
+
+        List<LoggedRequest> requests = wireMockRule.findAll(getRequestedFor(urlPathEqualTo(STUB_REQUEST_API_PATH)));
+        assertEquals(1, requests.size());
+
+        LoggedRequest request = requests.get(0);
+
+        QueryParameter qParam = request.queryParameter("q");
+        String expectedQuery = COLUMN_NAME_STREAMLINE_EVENT_ID + ":*";
+        expectedQuery += "+AND+(";
+        expectedQuery += COLUMN_NAME_STREAMLINE_EVENT_KEYVALUES + ":" + searchQuery;
+        expectedQuery += "+OR+" + COLUMN_NAME_STREAMLINE_EVENT_HEADERS + ":" + searchQuery;
+        expectedQuery += "+OR+" + COLUMN_NAME_STREAMLINE_EVENT_AUX_KEYVALUES + ":" + searchQuery;
+        expectedQuery += ")";
+
+        assertTrue(qParam.containsValue(expectedQuery));
+
+        QueryParameter fqParam = request.queryParameter("fq");
+        assertTrue(fqParam.containsValue(COLUMN_NAME_TYPE + ":" + COLUMN_VALUE_TYPE_EVENT));
+        assertTrue(fqParam.containsValue(COLUMN_NAME_STREAMLINE_TOPOLOGY_ID + ":" + TEST_APP_ID));
+        assertTrue(fqParam.containsValue(dateRangeValue));
+        assertFalse(fqParam.hasValueMatching(ValuePattern.containing(COLUMN_NAME_STREAMLINE_COMPONENT_NAME)));
+
+        QueryParameter sortParam = request.queryParameter("sort");
+        assertTrue(sortParam.containsValue(COLUMN_NAME_LOG_TIME + "+asc"));
+    }
+
+    private void verifyLogSearchResults(LogSearchResult results) {
         assertEquals(Long.valueOf(1434L), results.getMatchedDocs());
 
         // 5 static rows are presented in pre-stored result for making just test simpler...
@@ -258,11 +446,50 @@ public class AmbariInfraWithStormLogSearchTest {
 
     }
 
+    private void verifyEventSearchResults(EventSearchResult results) {
+        assertEquals(Long.valueOf(1450L), results.getMatchedEvents());
+
+        // 1 static rows are presented in pre-stored result for making just test simpler...
+        // please refer 'ambari-infra-event-search-output.xml'
+        List<EventSearchResult.Event> events = results.getEvents();
+        assertEquals(1, events.size());
+
+        EventSearchResult.Event event = events.get(0);
+        assertEquals("11", event.getAppId());
+        assertEquals("RULE", event.getComponentName());
+        assertEquals("b7715c60-74ad-43dd-814a-8a40403a31bc", event.getEventId());
+        assertTrue(event.getRootIds().contains("8e1bd283-1146-43c9-b7d0-16884beb2011"));
+        assertTrue(event.getParentIds().contains("8e1bd283-1146-43c9-b7d0-16884beb2011"));
+        assertTrue(event.getKeyValues().contains("user_id=Sjb5e5-gKoLXueFDMc2R8Q"));
+        assertTrue(event.getKeyValues().contains("review_id=2_Ru_ASf75kU303rdQjFfQ"));
+        assertTrue(event.getHeaders().contains("sourceComponentName=RULE"));
+        assertNull(event.getAuxKeyValues());
+
+        assertEquals(Instant.parse("2017-12-15T16:46:35.229Z"), Instant.ofEpochMilli(event.getTimestamp()));
+    }
+
     private void stubSolrUrl() throws IOException {
         try (InputStream is = getClass().getResourceAsStream("/ambari-infra-log-search-output.xml")) {
             String body = IOUtils.toString(is, Charset.forName("UTF-8"));
 
-            wireMockRule.stubFor(get(urlPathEqualTo(STUB_REQUEST_API_PATH))
+            UrlMatchingStrategy strategyForWorkerLog = urlPathMatching(STUB_REQUEST_API_PATH + ".+" +
+                    AmbariInfraWithStormLogSearch.COLUMN_NAME_TYPE + "%3A" +
+                    AmbariInfraWithStormLogSearch.COLUMN_VALUE_TYPE_WORKER_LOG + ".+");
+            wireMockRule.stubFor(get(strategyForWorkerLog)
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/xml; charset=UTF-8")
+                            .withHeader("Transfer-Encoding", "chunked")
+                            .withBody(body)));
+        }
+
+        try (InputStream is = getClass().getResourceAsStream("/ambari-infra-event-search-output.xml")) {
+            String body = IOUtils.toString(is, Charset.forName("UTF-8"));
+
+            UrlMatchingStrategy strategyForWorkerLog = urlPathMatching(STUB_REQUEST_API_PATH + ".+" +
+                    AmbariInfraWithStormLogSearch.COLUMN_NAME_TYPE + "%3A" +
+                    AmbariInfraWithStormLogSearch.COLUMN_VALUE_TYPE_EVENT + ".+");
+            wireMockRule.stubFor(get(strategyForWorkerLog)
                     .willReturn(aResponse()
                             .withStatus(200)
                             .withHeader("Content-Type", "application/xml; charset=UTF-8")

--- a/streams/runners/storm/logsearch/src/test/resources/ambari-infra-event-search-output.xml
+++ b/streams/runners/storm/logsearch/src/test/resources/ambari-infra-event-search-output.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+
+    <lst name="responseHeader">
+        <int name="status">0</int>
+        <int name="QTime">9</int>
+        <lst name="params">
+            <str name="q">*:*</str>
+            <str name="indent">on</str>
+            <arr name="fq">
+                <str>type:storm_worker_event</str>
+                <str>sdi_streamline_topology_id:11</str>
+            </arr>
+            <str name="sort">logtime desc</str>
+            <str name="rows">1</str>
+            <str name="wt">xml</str>
+            <str name="_">1511508905220</str>
+        </lst>
+    </lst>
+    <result name="response" numFound="1450" start="0">
+        <doc>
+            <str name="cluster">cl1</str>
+            <str name="sdi_storm_worker_port">6700</str>
+            <str name="level">INFO</str>
+            <long name="event_count">1</long>
+            <str name="ip">8.8.8.8</str>
+            <str name="sdi_storm_topology_id">streamline-11-Simple-YelpReview-11-1513052565</str>
+            <str name="type">storm_worker_event</str>
+            <str name="sdi_streamline_component_name">RULE</str>
+            <long name="seq_num">23076</long>
+            <str name="path">/var/log/storm/workers-artifacts/streamline-11-Simple-YelpReview-11-1513052565/6700/events.log</str>
+            <str name="sdi_streamline_topology_id">11</str>
+            <str name="host">host1</str>
+            <str name="sdi_streamline_topology_name">SimpleTopology</str>
+            <str name="sdi_streamline_event_id">b7715c60-74ad-43dd-814a-8a40403a31bc</str>
+            <str name="sdi_streamline_root_ids">[8e1bd283-1146-43c9-b7d0-16884beb2011]</str>
+            <str name="sdi_streamline_parent_ids">[8e1bd283-1146-43c9-b7d0-16884beb2011]</str>
+            <str name="sdi_streamline_event_fields_and_values">{user_id=Sjb5e5-gKoLXueFDMc2R8Q, review_id=2_Ru_ASf75kU303rdQjFfQ, stars=4, date=2013-04-25, business_id=KayYbHCt-RkbGcPdGOThNg, type=review, votes={funny=0, useful=0, cool=0}}</str>
+            <str name="sdi_streamline_event_headers">{rootIds=[8e1bd283-1146-43c9-b7d0-16884beb2011], parentIds=[8e1bd283-1146-43c9-b7d0-16884beb2011], sourceComponentName=RULE}</str>
+            <str name="id">f2410216-accc-4b20-bd86-fd329a1c0b88</str>
+            <date name="logtime">2017-12-15T16:46:35.229Z</date>
+            <str name="event_md5">1513356395229-1538509141836586162</str>
+            <int name="logfile_line_number">5197</int>
+            <str name="_ttl_">+7DAYS</str>
+            <date name="_expire_at_">2017-12-24T07:09:56.774Z</date>
+            <long name="_version_">1587014110358274051</long></doc>
+    </result>
+</response>

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/StreamsModule.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/StreamsModule.java
@@ -155,7 +155,7 @@ public class StreamsModule implements ModuleRegistration, StorageManagerAware, T
                 new TopologyEditorToolbarResource(authorizer, streamcatalogService, securityCatalogService),
                 new TopologyTestRunResource(streamcatalogService, actionsService),
                 new TopologyEventSamplingResource(authorizer,
-                        new TopologySamplingService(environmentService, subject), streamcatalogService)
+                        new TopologySamplingService(environmentService, subject), logSearchService, streamcatalogService)
         );
     }
 


### PR DESCRIPTION
* introduce new API endpoint: /topologies/:topologyId/events
  * mandatory params
    * topologyId
    * from
    * to
  * optional params
    * componentName
    * searchString
    * searchEventId
    * start
    * limit
    * ascending (true/false)
  * please refer to parameters in "/topologies/:topologyId/logs" (#1002)

`searchString` is applied to keyValues, headers, auxKeyValues (OR query).
`searchEventId` is applied to eventId, rootIds, parentIds (OR query).

This closes #1096 