### PR TITLE
ISSUE-1102 Fix sampling status API to respond status 200 when topology is not running

### DIFF
--- a/streams/runners/storm/common/src/main/java/com/hortonworks/streamline/streams/storm/common/StormTopologyUtil.java
+++ b/streams/runners/storm/common/src/main/java/com/hortonworks/streamline/streams/storm/common/StormTopologyUtil.java
@@ -28,6 +28,10 @@ public class StormTopologyUtil {
         return "streamline-" + topologyId + "-" + topologyName;
     }
 
+    public static String generateStormComponentId(Long componentId, String componentName) {
+        return String.format("%s-%s", componentId, componentName);
+    }
+
     public static String generateUniqueStormTopologyNamePrefix(Long topologyId) {
         return "streamline-" + topologyId + "-";
     }

--- a/streams/runners/storm/sampling/src/main/java/com/hortonworks/streamline/streams/sampling/service/storm/StormTopologySamplingService.java
+++ b/streams/runners/storm/sampling/src/main/java/com/hortonworks/streamline/streams/sampling/service/storm/StormTopologySamplingService.java
@@ -63,19 +63,19 @@ public class StormTopologySamplingService implements TopologySampling {
     @Override
     public SamplingStatus getSamplingStatus(Topology topology, String asUser) {
         String topologyId = StormTopologyUtil.findStormTopologyId(client, topology.getId(), asUser);
+        if (topologyId == null) {
+            return null;
+        }
         return buildSamplingStatus(client.getSamplingStatus(topologyId, asUser));
     }
 
     @Override
     public SamplingStatus getSamplingStatus(Topology topology, TopologyComponent component, String asUser) {
         String topologyId = StormTopologyUtil.findStormTopologyId(client, topology.getId(), asUser);
+        if (topologyId == null) {
+            return null;
+        }
         return buildSamplingStatus(client.getSamplingStatus(topologyId, asUser));
-    }
-
-    @Override
-    public SampledEvents getSampledEvents(Topology topology, TopologyComponent component, EventQueryParams qps, String asUser) {
-        // TODO: implement this based on logsearch
-        return null;
     }
 
     private SamplingStatus buildSamplingStatus(Map result) {

--- a/streams/runners/storm/sampling/src/main/java/com/hortonworks/streamline/streams/sampling/service/storm/StormTopologySamplingService.java
+++ b/streams/runners/storm/sampling/src/main/java/com/hortonworks/streamline/streams/sampling/service/storm/StormTopologySamplingService.java
@@ -14,7 +14,6 @@ import javax.security.auth.Subject;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 public class StormTopologySamplingService implements TopologySampling {
     private static final Logger LOG = LoggerFactory.getLogger(StormTopologySamplingService.class);
@@ -45,7 +44,8 @@ public class StormTopologySamplingService implements TopologySampling {
     @Override
     public boolean enableSampling(Topology topology, TopologyComponent component, int pct, String asUser) {
         String topologyId = StormTopologyUtil.findStormTopologyId(client, topology.getId(), asUser);
-        return client.enableSampling(topologyId, component.getId() + "-" + component.getName(), pct, asUser);
+        String stormComponentId = StormTopologyUtil.generateStormComponentId(component.getId(), component.getName());
+        return client.enableSampling(topologyId, stormComponentId, pct, asUser);
     }
 
     @Override
@@ -57,7 +57,8 @@ public class StormTopologySamplingService implements TopologySampling {
     @Override
     public boolean disableSampling(Topology topology, TopologyComponent component, String asUser) {
         String topologyId = StormTopologyUtil.findStormTopologyId(client, topology.getId(), asUser);
-        return client.disableSampling(topologyId, component.getId() + "-" + component.getName(), asUser);
+        String stormComponentId = StormTopologyUtil.generateStormComponentId(component.getId(), component.getName());
+        return client.disableSampling(topologyId, stormComponentId, asUser);
     }
 
     @Override
@@ -75,7 +76,8 @@ public class StormTopologySamplingService implements TopologySampling {
         if (topologyId == null) {
             return null;
         }
-        return buildSamplingStatus(client.getSamplingStatus(topologyId, asUser));
+        String stormComponentId = StormTopologyUtil.generateStormComponentId(component.getId(), component.getName());
+        return buildSamplingStatus(client.getSamplingStatus(topologyId, stormComponentId, asUser));
     }
 
     private SamplingStatus buildSamplingStatus(Map result) {

--- a/streams/sampling/src/main/java/com/hortonworks/streamline/streams/sampling/service/TopologySampling.java
+++ b/streams/sampling/src/main/java/com/hortonworks/streamline/streams/sampling/service/TopologySampling.java
@@ -1,12 +1,8 @@
 package com.hortonworks.streamline.streams.sampling.service;
 
-import com.fasterxml.jackson.annotation.JsonRawValue;
-import com.hortonworks.streamline.streams.StreamlineEvent;
 import com.hortonworks.streamline.streams.catalog.Topology;
 import com.hortonworks.streamline.streams.catalog.TopologyComponent;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 public interface TopologySampling {
@@ -24,24 +20,8 @@ public interface TopologySampling {
 
     SamplingStatus getSamplingStatus(Topology topology, TopologyComponent component, String asUser);
 
-    SampledEvents getSampledEvents(Topology topology, TopologyComponent component, EventQueryParams qps, String asUser);
-
     interface SamplingStatus {
         Boolean getEnabled();
         Integer getPct();
-    }
-
-    interface SampledEvents {
-        Collection<SampledEvent> getEvents();
-    }
-
-    interface SampledEvent {
-        long getTime();
-        String getEvent();
-    }
-
-    interface EventQueryParams {
-        int count();
-        boolean desc();
     }
 }

--- a/streams/sampling/src/main/java/com/hortonworks/streamline/streams/sampling/service/TopologySamplingService.java
+++ b/streams/sampling/src/main/java/com/hortonworks/streamline/streams/sampling/service/TopologySamplingService.java
@@ -1,13 +1,11 @@
 package com.hortonworks.streamline.streams.sampling.service;
 
-import com.hortonworks.streamline.streams.StreamlineEvent;
 import com.hortonworks.streamline.streams.catalog.Topology;
 import com.hortonworks.streamline.streams.catalog.TopologyComponent;
 import com.hortonworks.streamline.streams.cluster.catalog.Namespace;
 import com.hortonworks.streamline.streams.cluster.service.EnvironmentService;
 
 import javax.security.auth.Subject;
-import java.util.List;
 
 public class TopologySamplingService {
     private final EnvironmentService environmentService;
@@ -47,11 +45,6 @@ public class TopologySamplingService {
     public TopologySampling.SamplingStatus samplingStatus(Topology topology, TopologyComponent component, String asUser) {
         TopologySampling sampling = getSamplingInstance(topology);
         return sampling.getSamplingStatus(topology, component, asUser);
-    }
-
-    public TopologySampling.SampledEvents getSampledEvents(Topology topology, TopologyComponent component, TopologySampling.EventQueryParams qps, String asUser) {
-        TopologySampling sampling = getSamplingInstance(topology);
-        return sampling.getSampledEvents(topology, component, qps, asUser);
     }
 
     private TopologySampling getSamplingInstance(Topology topology) {

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/StreamsModule.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/StreamsModule.java
@@ -137,7 +137,7 @@ public class StreamsModule implements ModuleRegistration, StorageManagerAware, T
                                                      SecurityCatalogService securityCatalogService,
                                                      Subject subject) {
         return Arrays.asList(
-                new TopologyCatalogResource(authorizer, streamcatalogService, actionsService, logSearchService),
+                new TopologyCatalogResource(authorizer, streamcatalogService, actionsService),
                 new TopologyActionResource(authorizer, streamcatalogService, actionsService),
                 new TopologyDashboardResource(authorizer, streamcatalogService, environmentService, actionsService,
                         metricsService, transactionManager),
@@ -155,7 +155,8 @@ public class StreamsModule implements ModuleRegistration, StorageManagerAware, T
                 new TopologyEditorToolbarResource(authorizer, streamcatalogService, securityCatalogService),
                 new TopologyTestRunResource(streamcatalogService, actionsService),
                 new TopologyEventSamplingResource(authorizer,
-                        new TopologySamplingService(environmentService, subject), logSearchService, streamcatalogService)
+                        new TopologySamplingService(environmentService, subject), streamcatalogService),
+                new TopologyLoggingResource(authorizer, streamcatalogService, actionsService, logSearchService)
         );
     }
 

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyLoggingResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyLoggingResource.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.streams.service;
+
+import com.codahale.metrics.annotation.Timed;
+import com.hortonworks.streamline.common.exception.service.exception.request.BadRequestException;
+import com.hortonworks.streamline.common.exception.service.exception.request.EntityNotFoundException;
+import com.hortonworks.streamline.common.util.WSUtils;
+import com.hortonworks.streamline.streams.actions.TopologyActions;
+import com.hortonworks.streamline.streams.actions.topology.service.TopologyActionsService;
+import com.hortonworks.streamline.streams.catalog.Topology;
+import com.hortonworks.streamline.streams.catalog.service.StreamCatalogService;
+import com.hortonworks.streamline.streams.logsearch.EventSearchCriteria;
+import com.hortonworks.streamline.streams.logsearch.LogSearchCriteria;
+import com.hortonworks.streamline.streams.logsearch.topology.service.TopologyLogSearchService;
+import com.hortonworks.streamline.streams.security.Roles;
+import com.hortonworks.streamline.streams.security.SecurityUtil;
+import com.hortonworks.streamline.streams.security.StreamlineAuthorizer;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import java.util.Collections;
+import java.util.List;
+
+import static com.hortonworks.streamline.streams.catalog.Topology.NAMESPACE;
+import static com.hortonworks.streamline.streams.security.Permission.READ;
+import static javax.ws.rs.core.Response.Status.OK;
+
+/**
+ * Resource for log/event search requests for topology
+ */
+@Path("/v1/catalog")
+@Produces(MediaType.APPLICATION_JSON)
+public class TopologyLoggingResource {
+
+    private final StreamlineAuthorizer authorizer;
+    private final StreamCatalogService catalogService;
+    private final TopologyActionsService actionsService;
+    private final TopologyLogSearchService logSearchService;
+
+    public TopologyLoggingResource(StreamlineAuthorizer authorizer, StreamCatalogService catalogService,
+                                   TopologyActionsService actionsService, TopologyLogSearchService logSearchService) {
+        this.authorizer = authorizer;
+        this.catalogService = catalogService;
+        this.actionsService = actionsService;
+        this.logSearchService = logSearchService;
+    }
+
+    @POST
+    @Path("/topologies/{topologyId}/logconfig")
+    @Timed
+    public Response configureLogLevel(@PathParam("topologyId") Long topologyId,
+                                      @QueryParam("targetLogLevel") TopologyActions.LogLevel targetLogLevel,
+                                      @QueryParam("durationSecs") int durationSecs,
+                                      @Context SecurityContext securityContext) throws Exception {
+        SecurityUtil.checkRoleOrPermissions(authorizer, securityContext, Roles.ROLE_TOPOLOGY_USER,
+                NAMESPACE, topologyId, READ);
+
+        Topology topology = catalogService.getTopology(topologyId);
+        if (topology != null) {
+            TopologyActions.LogLevelInformation logInfo = actionsService.configureLogLevel(topology, targetLogLevel,
+                    durationSecs, WSUtils.getUserFromSecurityContext(securityContext));
+            return WSUtils.respondEntity(logInfo, OK);
+        }
+        throw EntityNotFoundException.byId(topologyId.toString());
+    }
+
+    @GET
+    @Path("/topologies/{topologyId}/logconfig")
+    @Timed
+    public Response getLogLevel(@PathParam("topologyId") Long topologyId,
+                                @Context SecurityContext securityContext) throws Exception {
+        SecurityUtil.checkRoleOrPermissions(authorizer, securityContext, Roles.ROLE_TOPOLOGY_USER,
+                NAMESPACE, topologyId, READ);
+
+        Topology topology = catalogService.getTopology(topologyId);
+        if (topology != null) {
+            TopologyActions.LogLevelInformation logInfo = actionsService.getLogLevel(topology, WSUtils.getUserFromSecurityContext(securityContext));
+            if (logInfo == null) {
+                return WSUtils.respondEntity(Collections.emptyMap(), OK);
+            } else {
+                return WSUtils.respondEntity(logInfo, OK);
+            }
+        }
+        throw EntityNotFoundException.byId(topologyId.toString());
+    }
+
+    @GET
+    @Path("/topologies/{topologyId}/logs")
+    @Timed
+    public Response searchTopologyLogs(@PathParam("topologyId") Long topologyId,
+                                       @QueryParam("componentName") List<String> componentNames,
+                                       @QueryParam("logLevel") List<String> logLevels,
+                                       @QueryParam("searchString") String searchString,
+                                       @QueryParam("from") Long from,
+                                       @QueryParam("to") Long to,
+                                       @QueryParam("start") Integer start,
+                                       @QueryParam("limit") Integer limit,
+                                       @Context SecurityContext securityContext) {
+
+        SecurityUtil.checkRoleOrPermissions(authorizer, securityContext, Roles.ROLE_TOPOLOGY_USER,
+                NAMESPACE, topologyId, READ);
+        Topology topology = catalogService.getTopology(topologyId);
+        if (topology != null) {
+            if (from == null) {
+                throw BadRequestException.missingParameter("from");
+            }
+            if (to == null) {
+                throw BadRequestException.missingParameter("to");
+            }
+
+            LogSearchCriteria criteria = new LogSearchCriteria(String.valueOf(topologyId),
+                    componentNames, logLevels, searchString, from, to, start, limit);
+
+            return WSUtils.respondEntity(logSearchService.search(topology, criteria), OK);
+        }
+
+        throw EntityNotFoundException.byId(topologyId.toString());
+    }
+
+    @GET
+    @Path("/topologies/{topologyId}/events")
+    @Timed
+    public Response searchEvents(@PathParam("topologyId") Long topologyId,
+                                 @QueryParam("componentName") List<String> componentNames,
+                                 @QueryParam("searchString") String searchString,
+                                 @QueryParam("searchEventId") String searchEventId,
+                                 @QueryParam("from") Long from,
+                                 @QueryParam("to") Long to,
+                                 @QueryParam("start") Integer start,
+                                 @QueryParam("limit") Integer limit,
+                                 @QueryParam("ascending") Boolean ascending,
+                                 @Context SecurityContext securityContext) throws Exception {
+        SecurityUtil.checkRoleOrPermissions(authorizer, securityContext, Roles.ROLE_TOPOLOGY_USER,
+                NAMESPACE, topologyId, READ);
+        Topology topology = catalogService.getTopology(topologyId);
+        if (topology != null) {
+            if (from == null) {
+                throw BadRequestException.missingParameter("from");
+            }
+            if (to == null) {
+                throw BadRequestException.missingParameter("to");
+            }
+
+            EventSearchCriteria criteria = new EventSearchCriteria(String.valueOf(topologyId),
+                    componentNames, searchString, searchEventId, from, to, start, limit, ascending);
+
+            return WSUtils.respondEntity(logSearchService.searchEvent(topology, criteria), OK);
+        }
+
+        throw EntityNotFoundException.byId(topologyId.toString());
+    }
+
+}


### PR DESCRIPTION
* Response will be changed to HTTP status 200 with success = "false" when topology is not running
* Also refactor a bit based on suggestion (moving methods, API endpoint paths)

> API endpoint path change:

* /api/v1/sampling/topologies/:topologyId(/enable|disable) -> /api/v1/catalog/topologies/:topologyId/sampling(/enable|disable)
* /api/v1/sampling/topologies/:topologyId/component/:componentId(/enable|disable) -> /api/v1/catalog/topologies/:topologyId/component/:componentId/sampling(/enable|disable)
* /api/v1/sampling/topologies/:topologyId/events -> /api/v1/catalog/topologies/:topologyId/events

This closes #1102 