### PR TITLE
ISSUE-1105 Fix log level status API to respond status 200 when topology is not running

### DIFF
--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/TopologyActions.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/TopologyActions.java
@@ -107,18 +107,32 @@ public interface TopologyActions {
 
     class LogLevelInformation {
         private LogLevel logLevel;
-        private long epoch;
+        private Long epoch;
+        private boolean enabled;
 
-        public LogLevelInformation(LogLevel logLevel, long epoch) {
+        private LogLevelInformation(boolean enabled, LogLevel logLevel, Long epoch) {
+            this.enabled = enabled;
             this.logLevel = logLevel;
             this.epoch = epoch;
+        }
+
+        public static LogLevelInformation enabled(LogLevel logLevel, Long epoch) {
+            return new LogLevelInformation(true, logLevel, epoch);
+        }
+
+        public static LogLevelInformation disabled() {
+            return new LogLevelInformation(false, null, null);
+        }
+
+        public boolean isEnabled() {
+            return enabled;
         }
 
         public LogLevel getLogLevel() {
             return logLevel;
         }
 
-        public long getEpoch() {
+        public Long getEpoch() {
             return epoch;
         }
     }

--- a/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/StormTopologyActionsImpl.java
+++ b/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/StormTopologyActionsImpl.java
@@ -395,7 +395,10 @@ public class StormTopologyActionsImpl implements TopologyActions {
 
     @Override
     public LogLevelInformation configureLogLevel(TopologyLayout topology, LogLevel targetLogLevel, int durationSecs, String asUser) throws Exception {
-        String stormTopologyId = getRuntimeTopologyId(topology, asUser);
+        String stormTopologyId = StormTopologyUtil.findStormTopologyId(client, topology.getId(), asUser);
+        if (StringUtils.isEmpty(stormTopologyId)) {
+            return null;
+        }
         LogLevelResponse response = client.configureLog(stormTopologyId, ROOT_LOGGER_NAME, targetLogLevel.name(),
                 durationSecs, asUser);
         return convertLogLevelResponseToLogLevelInformation(response);
@@ -403,7 +406,10 @@ public class StormTopologyActionsImpl implements TopologyActions {
 
     @Override
     public LogLevelInformation getLogLevel(TopologyLayout topology, String asUser) throws Exception {
-        String stormTopologyId = getRuntimeTopologyId(topology, asUser);
+        String stormTopologyId = StormTopologyUtil.findStormTopologyId(client, topology.getId(), asUser);
+        if (StringUtils.isEmpty(stormTopologyId)) {
+            return null;
+        }
         LogLevelResponse response = client.getLogLevel(stormTopologyId, asUser);
         return convertLogLevelResponseToLogLevelInformation(response);
     }
@@ -890,10 +896,10 @@ public class StormTopologyActionsImpl implements TopologyActions {
         Map<String, LogLevelLoggerResponse> namedLoggerLevels = response.getNamedLoggerLevels();
         LogLevelLoggerResponse resp = namedLoggerLevels.get(ROOT_LOGGER_NAME);
         if (resp == null) {
-            return null;
+            return LogLevelInformation.disabled();
         }
 
-        return new LogLevelInformation(LogLevel.valueOf(resp.getTargetLevel()), resp.getTimeoutEpoch());
+        return LogLevelInformation.enabled(LogLevel.valueOf(resp.getTargetLevel()), resp.getTimeoutEpoch());
     }
 
 }


### PR DESCRIPTION
* change response format to be similar with sampling status API

Response format of `/logconfig` (both GET/POST) will contain:
- success (always presented)
- enabled (only when success = true)
- logLevel (only when enabled = true)
- epoch (only when enabled = true)

This format is similar to sampling status API.
