### PR TITLE
ISSUE-1126 Fix transaction lock issue while refreshing cluster

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,7 @@
         <druid.tranquility.version>0.8.2</druid.tranquility.version>
         <spring.version>4.3.6.RELEASE</spring.version>
         <flyway.version>4.2.0</flyway.version>
+        <jool.version>0.9.12</jool.version>
 
         <!-- Runtime Scope Dependencies -->
         <logback.version>1.1.7</logback.version>
@@ -597,6 +598,11 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
                 <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jooq</groupId>
+                <artifactId>jool</artifactId>
+                <version>${jool.version}</version>
             </dependency>
 
             <!-- Project Artifact Dependencies -->

--- a/streams/cluster/pom.xml
+++ b/streams/cluster/pom.xml
@@ -33,6 +33,10 @@
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-metastore</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jooq</groupId>
+            <artifactId>jool</artifactId>
+        </dependency>
         <!-- test -->
         <dependency>
             <groupId>junit</groupId>

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/service/EnvironmentService.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/service/EnvironmentService.java
@@ -69,9 +69,9 @@ public class EnvironmentService {
     private final List<ContainingNamespaceAwareContainer> containers;
     private final ObjectMapper objectMapper;
 
-    public EnvironmentService(StorageManager storageManager, TransactionManager transactionManager) {
+    public EnvironmentService(StorageManager storageManager) {
         this.dao = storageManager;
-        this.clusterImporter = new ClusterImporter(this, transactionManager);
+        this.clusterImporter = new ClusterImporter(this);
         this.containers = new ArrayList<>();
         this.objectMapper = new ObjectMapper();
     }

--- a/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/register/impl/AbstractServiceRegistrarTest.java
+++ b/streams/cluster/src/test/java/com/hortonworks/streamline/streams/cluster/register/impl/AbstractServiceRegistrarTest.java
@@ -49,7 +49,7 @@ public class AbstractServiceRegistrarTest<T extends AbstractServiceRegistrar> {
     protected void resetEnvironmentService() {
         dao = new InMemoryStorageManager();
         transactionManager = new NOOPTransactionManager();
-        environmentService = new EnvironmentService(dao, transactionManager);
+        environmentService = new EnvironmentService(dao);
     }
 
     protected T initializeServiceRegistrar() {

--- a/streams/service/pom.xml
+++ b/streams/service/pom.xml
@@ -63,7 +63,6 @@
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jool</artifactId>
-            <version>0.9.12</version>
         </dependency>
         <dependency>
             <groupId>com.hortonworks.streamline</groupId>

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/StreamsModule.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/StreamsModule.java
@@ -80,7 +80,7 @@ public class StreamsModule implements ModuleRegistration, StorageManagerAware, T
         final Subject subject = (Subject) config.get(Constants.CONFIG_SUBJECT);  // Authorized subject
         MLModelRegistryClient modelRegistryClient = new MLModelRegistryClient(catalogRootUrl, subject);
         final StreamCatalogService streamcatalogService = new StreamCatalogService(storageManager, fileStorage, modelRegistryClient);
-        final EnvironmentService environmentService = new EnvironmentService(storageManager, transactionManager);
+        final EnvironmentService environmentService = new EnvironmentService(storageManager);
         TagClient tagClient = new TagClient(catalogRootUrl);
         final CatalogService catalogService = new CatalogService(storageManager, fileStorage, tagClient);
         final TopologyActionsService topologyActionsService = new TopologyActionsService(streamcatalogService,


### PR DESCRIPTION
* breaks down cluster import logic to two parts
  * fetch service and corresponding components information from Ambari (can be done concurrently)
    * including applying custom logic
  * store information to DB (must be done in same thread)
    * this is to group operations in "a" transaction
    * the transaction includes cleanup operation as well

This closes #1126 

  