### PR TITLE
ISSUE-1146 Writing failure state while applying topology action should not be rolled back

### DIFF
--- a/common/src/main/java/com/hortonworks/streamline/common/exception/IgnoreTransactionRollbackException.java
+++ b/common/src/main/java/com/hortonworks/streamline/common/exception/IgnoreTransactionRollbackException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2017 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.streamline.common.exception;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * This exception acts as a marker that exception should not incur rolling back transaction.
+ * Caused exception should be provided as well. Passing null to that will throw a NullPointerException.
+ */
+public class IgnoreTransactionRollbackException extends Exception {
+
+    public IgnoreTransactionRollbackException(Exception cause) {
+        super(cause);
+
+        // disallows passing null
+        Preconditions.checkNotNull(cause);
+    }
+}

--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/state/TopologyStates.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/state/TopologyStates.java
@@ -15,6 +15,7 @@
  **/
 package com.hortonworks.streamline.streams.actions.topology.state;
 
+import com.hortonworks.streamline.common.exception.IgnoreTransactionRollbackException;
 import com.hortonworks.streamline.streams.actions.TopologyActions;
 import com.hortonworks.streamline.streams.catalog.CatalogToLayoutConverter;
 import com.hortonworks.streamline.streams.catalog.Topology;
@@ -45,7 +46,7 @@ public final class TopologyStates {
             } catch (Exception ex) {
                 context.setState(TOPOLOGY_STATE_DEPLOYMENT_FAILED);
                 context.setCurrentAction("Topology DAG construction failed due to: " + ex);
-                throw ex;
+                throw new IgnoreTransactionRollbackException(ex);
             }
         }
     };
@@ -62,7 +63,7 @@ public final class TopologyStates {
             } catch (Exception ex) {
                 context.setState(TOPOLOGY_STATE_DEPLOYMENT_FAILED);
                 context.setCurrentAction("Topology DAG validation failed due to: " + ex);
-                throw ex;
+                throw new IgnoreTransactionRollbackException(ex);
             }
         }
     };
@@ -81,7 +82,7 @@ public final class TopologyStates {
                 LOG.error("Error while setting up cluster artifacts", ex);
                 context.setState(TOPOLOGY_STATE_DEPLOYMENT_FAILED);
                 context.setCurrentAction("Cluster artifacts set up failed due to: " + ex);
-                throw ex;
+                throw new IgnoreTransactionRollbackException(ex);
             }
         }
     };
@@ -101,7 +102,7 @@ public final class TopologyStates {
                 LOG.error("Error while setting up extra jars", ex);
                 context.setState(TOPOLOGY_STATE_DEPLOYMENT_FAILED);
                 context.setCurrentAction("Extra jars setup failed due to: " + ex);
-                throw ex;
+                throw new IgnoreTransactionRollbackException(ex);
             }
         }
     };
@@ -128,7 +129,7 @@ public final class TopologyStates {
                 killTopologyIfRunning(context, layout);
                 context.setState(TOPOLOGY_STATE_DEPLOYMENT_FAILED);
                 context.setCurrentAction("Topology submission failed due to: " + ex);
-                throw ex;
+                throw new IgnoreTransactionRollbackException(ex);
             }
         }
 
@@ -162,7 +163,7 @@ public final class TopologyStates {
             } catch (Exception ex) {
                 LOG.error("Error while trying to suspend the topology", ex);
                 context.setCurrentAction("Suspending the topology failed due to: " + ex);
-                throw ex;
+                throw new IgnoreTransactionRollbackException(ex);
             }
         }
     };
@@ -185,7 +186,7 @@ public final class TopologyStates {
             } catch (Exception ex) {
                 LOG.error("Error while trying to resume the topology", ex);
                 context.setCurrentAction("Resuming the topology failed due to: " + ex);
-                throw ex;
+                throw new IgnoreTransactionRollbackException(ex);
             }
         }
     };
@@ -213,7 +214,7 @@ public final class TopologyStates {
         } catch (Exception ex) {
             LOG.error("Error while trying to kill the topology", ex);
             context.setCurrentAction("Killing the topology failed due to: " + ex);
-            throw ex;
+            throw new IgnoreTransactionRollbackException(ex);
         }
     }
 


### PR DESCRIPTION
* add new exception which is marker exception for ignoring rollback transaction
* apply to deploy/kill/suspect/resume

This closes #1146 