### PR TITLE
ISSUE-1150 Populate protocol/port for kafka components even listeners with multiple protocols.

### DIFF
--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/discovery/ambari/ComponentPropertyPattern.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/discovery/ambari/ComponentPropertyPattern.java
@@ -48,7 +48,8 @@ public enum ComponentPropertyPattern {
   // KAFKA
   // protocol (plaintext, ssl, kerberos, etc?), host (can be empty), port
   // https://cwiki.apache.org/confluence/display/KAFKA/Multiple+Listeners+for+Kafka+Brokers
-  KAFKA_BROKER("listeners", Pattern.compile("([a-zA-Z]+)://[a-zA-Z0-9_\\-\\\\.]*:([0-9]+)")),
+  // no matching pattern as listeners can contains multiple URIS with different schemes/protocols
+  KAFKA_BROKER("listeners", null),
 
   // AMBARI_METRICS
   METRICS_COLLECTOR("timeline.metrics.service.webapp.address", Pattern.compile("()[a-zA-Z0-9_\\-\\\\.]*:([0-9]+)")),

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/service/metadata/json/KafkaBrokerListeners.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/service/metadata/json/KafkaBrokerListeners.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hortonworks.streamline.streams.cluster.catalog.Component;
 import com.hortonworks.streamline.streams.cluster.catalog.ComponentProcess;
 import com.hortonworks.streamline.streams.cluster.catalog.ServiceConfiguration;
+import org.apache.parquet.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,11 +42,8 @@ public class KafkaBrokerListeners {
 
         brokers.forEach(broker -> {
             String protocol = broker.getProtocol();
-            List<String> hostAndPorts = protocolToHostsWithPort.get(Protocol.find(protocol));
-            if (hostAndPorts == null) {
-                hostAndPorts = new ArrayList<>();
-                protocolToHostsWithPort.put(Protocol.find(protocol), hostAndPorts);
-            }
+            LOG.debug("Protocol [{}] for broker [{}]", protocol, broker);
+            List<String> hostAndPorts = protocolToHostsWithPort.computeIfAbsent(Protocol.find(protocol), k -> new ArrayList<>());
             hostAndPorts.add(broker.getHost() + ":" + broker.getPort());
         });
 
@@ -157,6 +155,7 @@ public class KafkaBrokerListeners {
         }
 
         public static Protocol find(final String alias) {
+            Preconditions.checkNotNull(alias, "alias can not be null");
             return Arrays.stream(Protocol.values()).filter((p) -> p.aliases.contains(alias)).findFirst().get();
         }
 


### PR DESCRIPTION
- Populate protocol/port for kafka components even listeners with multiple protocols.
- Fixed issue to set right protocol when kafka is kerberized though ambari gives wrong information about listener protocol. 