### PR TITLE
ISSUE-1182 Avoid relying on default resolution while querying to Amba…

### DIFF
--- a/streams/runners/storm/metrics/src/main/java/com/hortonworks/streamline/streams/metrics/storm/ambari/AmbariMetricsServiceWithStormQuerier.java
+++ b/streams/runners/storm/metrics/src/main/java/com/hortonworks/streamline/streams/metrics/storm/ambari/AmbariMetricsServiceWithStormQuerier.java
@@ -177,7 +177,7 @@ public class AmbariMetricsServiceWithStormQuerier extends AbstractTimeSeriesQuer
 
     private URI composeQueryParameters(String topologyName, String componentId, String metricName, AggregateFunction aggrFunction,
                                        long from, long to) {
-        String actualMetricName = buildMetricName(topologyName, componentId, metricName);
+        String actualMetricName = buildMetricName(topologyName, componentId, metricName, aggrFunction);
         JerseyUriBuilder uriBuilder = new JerseyUriBuilder();
         Precision precision = determinePrecision(from, to);
         return uriBuilder.uri(collectorApiUri)
@@ -208,7 +208,7 @@ public class AmbariMetricsServiceWithStormQuerier extends AbstractTimeSeriesQuer
         return Precision.DAYS;
     }
 
-    private String buildMetricName(String topologyName, String componentId, String metricName) {
+    private String buildMetricName(String topologyName, String componentId, String metricName, AggregateFunction aggrFunction) {
         String actualMetricName;
 
         if (metricName.startsWith(METRIC_NAME_PREFIX_KAFKA_OFFSET)) {
@@ -222,7 +222,24 @@ public class AmbariMetricsServiceWithStormQuerier extends AbstractTimeSeriesQuer
         }
 
         // since '._' is treat as special character (separator) so it should be replaced
-        return actualMetricName.replace('_', '-');
+        actualMetricName = actualMetricName.replace('_', '-');
+
+        switch (aggrFunction) {
+            case MIN:
+                actualMetricName = actualMetricName + "._min";
+                break;
+            case MAX:
+                actualMetricName = actualMetricName + "._max";
+                break;
+            case SUM:
+                actualMetricName = actualMetricName + "._sum";
+                break;
+            case AVG:
+                actualMetricName = actualMetricName + "._avg";
+                break;
+        }
+
+        return actualMetricName;
     }
 
     private String createKafkaOffsetMetricName(String topologyName, String kafkaOffsetMetricName) {

--- a/streams/runners/storm/metrics/src/test/java/com/hortonworks/streamline/streams/metrics/storm/ambari/AmbariMetricsServiceWithStormQuerierTest.java
+++ b/streams/runners/storm/metrics/src/test/java/com/hortonworks/streamline/streams/metrics/storm/ambari/AmbariMetricsServiceWithStormQuerierTest.java
@@ -67,8 +67,10 @@ public class AmbariMetricsServiceWithStormQuerierTest {
         String componentId = "testComponent";
         String metricName = "__test.metric.name";
         TimeSeriesQuerier.AggregateFunction aggrFunction = TimeSeriesQuerier.AggregateFunction.SUM;
-        long from = 1234L;
-        long to = 5678L;
+
+        // 10 mins: > 1 min but < 7 days
+        long from = 0;
+        long to = 10 * 60 * 1000;
 
         Map<Long, Double> metrics = querier.getMetrics(topologyName, componentId, metricName, aggrFunction, from, to);
         assertResult(metrics);
@@ -77,8 +79,41 @@ public class AmbariMetricsServiceWithStormQuerierTest {
                 .withQueryParam("appId", equalTo(DEFAULT_APP_ID))
                 .withQueryParam("hostname", equalTo(""))
                 .withQueryParam("metricNames", equalTo("topology.testTopology.testComponent.%.--test.metric.name"))
-                .withQueryParam("startTime", equalTo("1234"))
-                .withQueryParam("endTime", equalTo("5678"))
+                .withQueryParam("startTime", equalTo(String.valueOf(from)))
+                .withQueryParam("endTime", equalTo(String.valueOf(to)))
+                .withQueryParam("precision", equalTo(AmbariMetricsServiceWithStormQuerier.Precision.MINUTES.name()))
+                .withQueryParam("seriesAggregateFunction", equalTo("SUM")));
+
+        // 10 days: > 7 days but < 30 days
+        from = 0;
+        to = 10 * 24 * 60 * 60 * 1000;
+
+        metrics = querier.getMetrics(topologyName, componentId, metricName, aggrFunction, from, to);
+        assertResult(metrics);
+
+        verify(getRequestedFor(urlPathEqualTo(TEST_COLLECTOR_API_PATH))
+                .withQueryParam("appId", equalTo(DEFAULT_APP_ID))
+                .withQueryParam("hostname", equalTo(""))
+                .withQueryParam("metricNames", equalTo("topology.testTopology.testComponent.%.--test.metric.name"))
+                .withQueryParam("startTime", equalTo(String.valueOf(from)))
+                .withQueryParam("endTime", equalTo(String.valueOf(to)))
+                .withQueryParam("precision", equalTo(AmbariMetricsServiceWithStormQuerier.Precision.HOURS.name()))
+                .withQueryParam("seriesAggregateFunction", equalTo("SUM")));
+
+        // 40 days: > 30 days
+        from = 0;
+        to = 40L * 24 * 60 * 60 * 1000;
+
+        metrics = querier.getMetrics(topologyName, componentId, metricName, aggrFunction, from, to);
+        assertResult(metrics);
+
+        verify(getRequestedFor(urlPathEqualTo(TEST_COLLECTOR_API_PATH))
+                .withQueryParam("appId", equalTo(DEFAULT_APP_ID))
+                .withQueryParam("hostname", equalTo(""))
+                .withQueryParam("metricNames", equalTo("topology.testTopology.testComponent.%.--test.metric.name"))
+                .withQueryParam("startTime", equalTo(String.valueOf(from)))
+                .withQueryParam("endTime", equalTo(String.valueOf(to)))
+                .withQueryParam("precision", equalTo(AmbariMetricsServiceWithStormQuerier.Precision.DAYS.name()))
                 .withQueryParam("seriesAggregateFunction", equalTo("SUM")));
     }
 
@@ -91,8 +126,8 @@ public class AmbariMetricsServiceWithStormQuerierTest {
         // this is one of metric which needs stream aggregation
         String metricName = "__complete-latency";
         TimeSeriesQuerier.AggregateFunction aggrFunction = TimeSeriesQuerier.AggregateFunction.AVG;
-        long from = 1234L;
-        long to = 5678L;
+        long from = 1234L * 10 * 60;
+        long to = 5678L * 10 * 60;
 
         Map<Long, Double> metrics = querier.getMetrics(topologyName, componentId, metricName, aggrFunction, from, to);
         assertResult(metrics);
@@ -101,8 +136,9 @@ public class AmbariMetricsServiceWithStormQuerierTest {
                 .withQueryParam("appId", equalTo(DEFAULT_APP_ID))
                 .withQueryParam("hostname", equalTo(""))
                 .withQueryParam("metricNames", equalTo("topology.testTopology.testComponent.%.--complete-latency.%"))
-                .withQueryParam("startTime", equalTo("1234"))
-                .withQueryParam("endTime", equalTo("5678"))
+                .withQueryParam("startTime", equalTo(String.valueOf(from)))
+                .withQueryParam("endTime", equalTo(String.valueOf(to)))
+                .withQueryParam("precision", equalTo(AmbariMetricsServiceWithStormQuerier.Precision.MINUTES.name()))
                 .withQueryParam("seriesAggregateFunction", equalTo("AVG")));
     }
 
@@ -112,8 +148,10 @@ public class AmbariMetricsServiceWithStormQuerierTest {
 
         String metricName = "metric";
         String parameters = "precision=seconds,appId=appId";
-        long from = 1234L;
-        long to = 5678L;
+
+        // 10 mins: > 1 min but < 7 days
+        long from = 0;
+        long to = 10 * 60 * 1000;
 
         Map<String, Map<Long, Double>> metrics = querier.getRawMetrics(metricName, parameters, from, to);
         assertResult(metrics.get("metric"));
@@ -121,10 +159,41 @@ public class AmbariMetricsServiceWithStormQuerierTest {
         verify(getRequestedFor(urlPathEqualTo(TEST_COLLECTOR_API_PATH))
                 .withQueryParam("appId", equalTo("appId"))
                 .withQueryParam("metricNames", equalTo("metric"))
-                .withQueryParam("startTime", equalTo("1234"))
-                .withQueryParam("endTime", equalTo("5678")));
-    }
+                .withQueryParam("startTime", equalTo(String.valueOf(from)))
+                .withQueryParam("endTime", equalTo(String.valueOf(to)))
+                .withQueryParam("precision", equalTo(AmbariMetricsServiceWithStormQuerier.Precision.MINUTES.name()))
+        );
 
+        // 10 days: > 7 days but < 30 days
+        from = 0;
+        to = 10 * 24 * 60 * 60 * 1000;
+
+        metrics = querier.getRawMetrics(metricName, parameters, from, to);
+        assertResult(metrics.get("metric"));
+
+        verify(getRequestedFor(urlPathEqualTo(TEST_COLLECTOR_API_PATH))
+                .withQueryParam("appId", equalTo("appId"))
+                .withQueryParam("metricNames", equalTo("metric"))
+                .withQueryParam("startTime", equalTo(String.valueOf(from)))
+                .withQueryParam("endTime", equalTo(String.valueOf(to)))
+                .withQueryParam("precision", equalTo(AmbariMetricsServiceWithStormQuerier.Precision.HOURS.name()))
+        );
+
+        // 40 days: > 30 days
+        from = 0;
+        to = 40L * 24 * 60 * 60 * 1000;
+
+        metrics = querier.getRawMetrics(metricName, parameters, from, to);
+        assertResult(metrics.get("metric"));
+
+        verify(getRequestedFor(urlPathEqualTo(TEST_COLLECTOR_API_PATH))
+                .withQueryParam("appId", equalTo("appId"))
+                .withQueryParam("metricNames", equalTo("metric"))
+                .withQueryParam("startTime", equalTo(String.valueOf(from)))
+                .withQueryParam("endTime", equalTo(String.valueOf(to)))
+                .withQueryParam("precision", equalTo(AmbariMetricsServiceWithStormQuerier.Precision.DAYS.name()))
+        );
+    }
 
     private void stubMetricUrl() {
         stubFor(get(urlPathEqualTo(TEST_COLLECTOR_API_PATH))


### PR DESCRIPTION
…ri Metrics

* provide precision parameter when querying to Ambari Metrics
  * based on AMS default, with some modification
  * https://cwiki.apache.org/confluence/display/AMBARI/Metrics+Collector+API+Specification
  * no seconds
  * minutes: > 1 min, < 7 days
  * hours: >= 7 days, < 30 days
  * days: > 30 days

Change-Id: I621b9d065a09e07d6fb3ec0fab8fcc28d3ccf346

This closes #1182 