### PR TITLE
ISSUE-1208 Streamline 'Jar Storage HDFS URL' does not work for Nameno…

### DIFF
--- a/bin/streamline-server-start.sh
+++ b/bin/streamline-server-start.sh
@@ -74,6 +74,10 @@ do
     fi
 done
 
+if [ ! -z "$HADOOP_CONF_DIR" ]; then
+ CLASSPATH=$CLASSPATH:$HADOOP_CONF_DIR;
+fi
+
 echo "CLASSPATH: ${CLASSPATH}"
 
 #JAAS config file params


### PR DESCRIPTION
This fix introduces a new variable called $HADOOP_CONF_DIR which can be used to configure the location of core-site.xml and hdfs-site.xml, which will then be added to streamline classpath during startup. After this patch, Add "export HADOOP_CONF_DIR=/etc/hadoop/conf" in streamline-env to configure NN HA.

