### PR TITLE
ISSUE-1256 Fix incorrectly copied bootstrap-storage-initenv.sh

### DIFF
--- a/bootstrap/bootstrap-storage-initenv.sh
+++ b/bootstrap/bootstrap-storage-initenv.sh
@@ -30,7 +30,7 @@ while [ -h "${PRG}" ]; do
 done
 
 BOOTSTRAP_DIR=`dirname ${PRG}`
-CONFIG_FILE_PATH=${BOOTSTRAP_DIR}/../conf/registry.yaml
+CONFIG_FILE_PATH=${BOOTSTRAP_DIR}/../conf/streamline.yaml
 MYSQL_JAR_URL_PATH=https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.40.zip
 
 # Which java to use
@@ -59,4 +59,4 @@ then
 fi
 
 echo "Using Configuration file: ${CONFIG_FILE_PATH}"
-${JAVA} -Dbootstrap.dir=$BOOTSTRAP_DIR -cp ${CLASSPATH} ${INITIALIZER_MAIN_CLASS} -m ${MYSQL_JAR_URL_PATH} -c ${CONFIG_FILE_PATH} -s --admin-jdbc-url ${1} --admin-username ${2} --admin-password ${3} --target-username ${4} --target-password ${5} --target-database ${6}
+${JAVA} -Dbootstrap.dir=$BOOTSTRAP_DIR -cp ${CLASSPATH} ${INITIALIZER_MAIN_CLASS} -m ${MYSQL_JAR_URL_PATH} -c ${CONFIG_FILE_PATH} --admin-jdbc-url ${1} --admin-username ${2} --admin-password ${3} --target-username ${4} --target-password ${5} --target-database ${6}


### PR DESCRIPTION
This is identical with https://github.com/hortonworks/registry/blob/b8787573111eaea80c578e01ed527b37db7650aa/bootstrap/bootstrap-storage-initenv.sh except configuration file, registry.yaml to streamline.yaml.

This closes #1256 