### PR TITLE
ISSUE-1260: Changes to discover atlas and enable storm hook to notify

### DIFF
--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/discovery/ambari/ConfigFilePattern.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/discovery/ambari/ConfigFilePattern.java
@@ -23,7 +23,8 @@ public enum ConfigFilePattern {
   CORE_SITE("core-site", "core-site.xml"),
   HDFS_SITE("hdfs-site", "hdfs-site.xml"),
   HIVE_SITE("hive-site", "hive-site.xml"),
-  HBASE_SITE("hbase-site", "hbase-site.xml");
+  HBASE_SITE("hbase-site", "hbase-site.xml"),
+  APPLICATION_PROPERTIES("application-properties", "atlas-application.properties");
 
   private final String confType;
   private final String originFileName;

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/discovery/ambari/SerivceConfigurationFilter.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/discovery/ambari/SerivceConfigurationFilter.java
@@ -1,0 +1,10 @@
+package com.hortonworks.streamline.streams.cluster.discovery.ambari;
+
+import java.util.Map;
+
+/**
+ * Applies required transformation and filters configs.
+ */
+public interface SerivceConfigurationFilter {
+    Map<String, String> filter(Map<String, String> input);
+}

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/discovery/ambari/ServiceConfigurationFilters.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/discovery/ambari/ServiceConfigurationFilters.java
@@ -1,0 +1,57 @@
+package com.hortonworks.streamline.streams.cluster.discovery.ambari;
+
+import com.google.common.collect.Sets;
+import com.hortonworks.streamline.streams.cluster.catalog.Cluster;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public final class ServiceConfigurationFilters {
+
+    private static final String ATLAS_APPLICATION_PROPERTIES = "application-properties";
+    private static final String ATLAS_CLUSTER_NAME_PATTERN = "{{cluster_name}}";
+    private static final Set<String> ATLAS_REQUIRED_CONFIGS = Sets.newHashSet(
+            "atlas.authentication.method.kerberos",
+            "atlas.cluster.name",
+            "atlas.hook.storm.numRetries",
+            "atlas.jaas.KafkaClient.loginModuleControlFlag",
+            "atlas.jaas.KafkaClient.loginModuleName",
+            "atlas.jaas.KafkaClient.option.keyTab",
+            "atlas.jaas.KafkaClient.option.principal",
+            "atlas.jaas.KafkaClient.option.serviceName",
+            "atlas.jaas.KafkaClient.option.storeKey",
+            "atlas.jaas.KafkaClient.option.useKeyTab",
+            "atlas.kafka.bootstrap.servers",
+            "atlas.kafka.hook.group.id",
+            "atlas.kafka.sasl.kerberos.service.name",
+            "atlas.kafka.security.protocol",
+            "atlas.kafka.zookeeper.connect",
+            "atlas.kafka.zookeeper.connection.timeout.ms",
+            "atlas.kafka.zookeeper.session.timeout.ms",
+            "atlas.kafka.zookeeper.sync.time.ms",
+            "atlas.notification.create.topics",
+            "atlas.notification.replicas",
+            "atlas.notification.topics",
+            "atlas.rest.address"
+    );
+
+    public static SerivceConfigurationFilter get(Cluster cluster, String configType) {
+        if (configType.equals(ATLAS_APPLICATION_PROPERTIES)) {
+            return input -> {
+                Map<String, String> result = new HashMap<>();
+                input.forEach((k, v) -> {
+                    if (ATLAS_REQUIRED_CONFIGS.contains(k)) {
+                        if (v.equals(ATLAS_CLUSTER_NAME_PATTERN)) {
+                            v = cluster.getName();
+                        }
+                        result.put(k, v);
+                    }
+                });
+                return result;
+            };
+        }
+
+        return input -> input;
+    }
+}

--- a/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/discovery/ambari/ServiceConfigurations.java
+++ b/streams/cluster/src/main/java/com/hortonworks/streamline/streams/cluster/discovery/ambari/ServiceConfigurations.java
@@ -35,7 +35,8 @@ public enum ServiceConfigurations {
       "hiveserver2-site","hive-site"),
   AMBARI_METRICS("ams-env", "ams-site"),
   DRUID("druid-common", "druid-overlord"),
-  AMBARI_INFRA_SOLR("infra-solr-env");
+  AMBARI_INFRA_SOLR("infra-solr-env"),
+  ATLAS("application-properties");
 
   private final String[] confNames;
 


### PR DESCRIPTION
Discover and enable Storm Atlas notifier plugin if user has selected 'Atlas' in the environment.

This patch does not handle shipping the necessary atlas jars in the storm path. This can be handled in a separate patch by optionally shipping relevant atlas jars via streamline or have Ambari/Atlas to install the storm atlas hook jars in the HDF cluster.

Closes #1260 