### PR TITLE
ISSUE-1265 Let addOrUpdate be compatible with PostgreSQL under 9.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         <phoenix.version>4.7.0.2.5.0.0-1245</phoenix.version>
         <redis.lettuce.version>3.4.2.Final</redis.lettuce.version>
         <scala.version>2.10.5</scala.version>
-        <schema-registry.version>0.5.1.3.1.1.0-7</schema-registry.version>
+        <schema-registry.version>0.5.0.3.2.0.0-252</schema-registry.version>
         <slf4j.version>1.7.12</slf4j.version>
         <storm.version>1.1.1.3.1.0.0-564</storm.version>
         <woodstox-core-asl.version>4.4.1</woodstox-core-asl.version>


### PR DESCRIPTION
* change Registry version which is compatible with PostgreSQL under 9.5

The commit denotes the version: https://github.com/hortonworks/registry/commit/6af09471ccbef007f724c82f7a718c9e1ba20cc3

This closes #1265 