### PR TITLE
ISSUE-1275 Allow users to specify maven local repository directory for Storm topology submission

### DIFF
--- a/conf/streamline.yaml
+++ b/conf/streamline.yaml
@@ -18,6 +18,9 @@ modules:
       #customProcessorUploadFailPath: "/tmp/failed"
       #customProcessorUploadSuccessPath: "/tmp/uploaded"
       mavenRepoUrl: "hwx-public^http://repo.hortonworks.com/content/groups/public/,hwx-private^http://nexus-private.hortonworks.com/nexus/content/groups/public/"
+      # directory (absolute path) to use for maven local repository (optional)
+      # in practice it should not under "/tmp" and the account which runs 'streamline' should have read/write permission
+      # mavenLocalRepositoryDirectory: "/tmp/local-repo"
 
 catalogRootUrl: "http://localhost:8080/api/v1/catalog"
 

--- a/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/StormTopologyActionsImpl.java
+++ b/streams/runners/storm/actions/src/main/java/com/hortonworks/streamline/streams/actions/storm/topology/StormTopologyActionsImpl.java
@@ -465,6 +465,12 @@ public class StormTopologyActionsImpl implements TopologyActions {
             args.add("--artifactRepositories");
             args.add((String) conf.get("mavenRepoUrl"));
 
+            String mavenLocalReposDir = (String) conf.get("mavenLocalRepositoryDirectory");
+            if (StringUtils.isNotEmpty(mavenLocalReposDir)) {
+                args.add("--mavenLocalRepositoryDirectory");
+                args.add(mavenLocalReposDir);
+            }
+
             String proxyUrl = (String) conf.get(com.hortonworks.streamline.common.Constants.CONFIG_HTTP_PROXY_URL);
             if (StringUtils.isNotEmpty(proxyUrl)) {
                 args.add("--proxyUrl");


### PR DESCRIPTION
* add new configuration in streams module: "mavenLocalRepositoryDirectory"
  * if it is presented, it is passed to "storm submit"
  * so that transitive dependencies are read and fetched from given directory

The new configuration only works with Storm version which supports custom maven local repository directory (STORM-3069), so please check it first before setting the configuration. 

This closes #1275 