### PR TITLE
ISSUE-1338 Exclude Avro dependency from all possible client paths to not conflict with SR's Avro version

### DIFF
--- a/bootstrap/components/sinks/hbase-sink-topology-component.json
+++ b/bootstrap/components/sinks/hbase-sink-topology-component.json
@@ -6,7 +6,7 @@
   "streamingEngine": "STORM",
   "fieldHintProviderClass": "com.hortonworks.streamline.streams.cluster.bundle.impl.HBaseBundleHintProvider",
   "transformationClass": "com.hortonworks.streamline.streams.layout.storm.HbaseBoltFluxComponent",
-  "mavenDeps": "org.apache.storm:storm-hbase:STORM_VERSION^org.slf4j:slf4j-log4j12^org.apache.curator:curator-client^org.apache.curator:curator-framework",
+  "mavenDeps": "org.apache.storm:storm-hbase:STORM_VERSION^org.slf4j:slf4j-log4j12^org.apache.curator:curator-client^org.apache.curator:curator-framework^org.apache.avro:avro",
   "topologyComponentUISpecification": {
     "fields": [
       {

--- a/bootstrap/components/sinks/hdfs-sink-topology-component.json
+++ b/bootstrap/components/sinks/hdfs-sink-topology-component.json
@@ -6,7 +6,7 @@
   "streamingEngine": "STORM",
   "fieldHintProviderClass": "com.hortonworks.streamline.streams.cluster.bundle.impl.HDFSBundleHintProvider",
   "transformationClass": "com.hortonworks.streamline.streams.layout.storm.HdfsBoltFluxComponent",
-  "mavenDeps": "org.apache.storm:storm-hdfs:STORM_VERSION^org.slf4j:slf4j-log4j12^org.apache.curator:curator-client^org.apache.curator:curator-framework",
+  "mavenDeps": "org.apache.storm:storm-hdfs:STORM_VERSION^org.slf4j:slf4j-log4j12^org.apache.curator:curator-client^org.apache.curator:curator-framework^org.apache.avro:avro",
   "topologyComponentUISpecification": {
     "fields": [
       {

--- a/bootstrap/components/sinks/hive-sink-topology-component.json
+++ b/bootstrap/components/sinks/hive-sink-topology-component.json
@@ -5,7 +5,7 @@
   "builtin": true,
   "streamingEngine": "STORM",
   "transformationClass": "com.hortonworks.streamline.streams.layout.storm.HiveBoltFluxComponent",
-  "mavenDeps": "org.apache.storm:storm-hive:STORM_VERSION^org.slf4j:slf4j-log4j12^org.apache.curator:curator-client^org.apache.curator:curator-framework",
+  "mavenDeps": "org.apache.storm:storm-hive:STORM_VERSION^org.slf4j:slf4j-log4j12^org.apache.curator:curator-client^org.apache.curator:curator-framework^org.apache.hive:hive-exec,org.apache.hive:hive-exec:jar:core:2.1.0^org.apache.avro:avro",
   "topologyComponentUISpecification": {
     "fields": [
       {

--- a/bootstrap/components/sources/hdfs-source-topology-component.json
+++ b/bootstrap/components/sources/hdfs-source-topology-component.json
@@ -6,7 +6,7 @@
   "builtin": true,
   "fieldHintProviderClass": "com.hortonworks.streamline.streams.cluster.bundle.impl.HDFSSpoutBundleHintProvider",
   "transformationClass": "com.hortonworks.streamline.streams.layout.storm.HdfsSpoutFluxComponent",
-  "mavenDeps": "org.apache.storm:storm-hdfs:STORM_VERSION^org.slf4j:slf4j-log4j12",
+  "mavenDeps": "org.apache.storm:storm-hdfs:STORM_VERSION^org.slf4j:slf4j-log4j12^org.apache.avro:avro",
   "topologyComponentUISpecification": {
     "fields": [
       {

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -82,6 +82,10 @@
                     <groupId>javax.servlet.jsp</groupId>
                     <artifactId>jsp-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,8 @@
         <phoenix.version>4.7.0.2.5.0.0-1245</phoenix.version>
         <redis.lettuce.version>3.4.2.Final</redis.lettuce.version>
         <scala.version>2.10.5</scala.version>
-        <schema-registry.version>0.6.0</schema-registry.version>
+        <!-- FIXME: MUST BE FIXED WITH THE VERSION WHICH DOES NOT CONTAIN AVRO 1.7.7 -->
+        <schema-registry.version>0.6.1-SNAPSHOT-ISSUE-540</schema-registry.version>
         <slf4j.version>1.7.12</slf4j.version>
         <storm.version>1.2.2</storm.version>
         <woodstox-core-asl.version>4.4.1</woodstox-core-asl.version>
@@ -446,12 +447,17 @@
                         <groupId>org.apache.hadoop</groupId>
                         <artifactId>hadoop-common</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.avro</groupId>
+                        <artifactId>avro</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.hive</groupId>
                 <artifactId>hive-exec</artifactId>
                 <version>${hive.version}</version>
+                <classifier>core</classifier>
                 <exclusions>
                     <exclusion>
                         <artifactId>log4j-slf4j-impl</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -164,8 +164,8 @@
         <phoenix.version>4.7.0.2.5.0.0-1245</phoenix.version>
         <redis.lettuce.version>3.4.2.Final</redis.lettuce.version>
         <scala.version>2.10.5</scala.version>
-        <!-- FIXME: MUST BE FIXED WITH THE VERSION WHICH DOES NOT CONTAIN AVRO 1.7.7 -->
-        <schema-registry.version>0.6.0</schema-registry.version>
+        <!-- Ideally we need to use official version of SR: wait for new release -->
+        <schema-registry.version>0.6.0.3.4.0.0-145</schema-registry.version>
         <slf4j.version>1.7.12</slf4j.version>
         <storm.version>1.2.2</storm.version>
         <woodstox-core-asl.version>4.4.1</woodstox-core-asl.version>

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
         <redis.lettuce.version>3.4.2.Final</redis.lettuce.version>
         <scala.version>2.10.5</scala.version>
         <!-- FIXME: MUST BE FIXED WITH THE VERSION WHICH DOES NOT CONTAIN AVRO 1.7.7 -->
-        <schema-registry.version>0.6.1-SNAPSHOT-ISSUE-540</schema-registry.version>
+        <schema-registry.version>0.6.0</schema-registry.version>
         <slf4j.version>1.7.12</slf4j.version>
         <storm.version>1.2.2</storm.version>
         <woodstox-core-asl.version>4.4.1</woodstox-core-asl.version>

--- a/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyActionsService.java
+++ b/streams/actions/src/main/java/com/hortonworks/streamline/streams/actions/topology/service/TopologyActionsService.java
@@ -17,10 +17,10 @@ package com.hortonworks.streamline.streams.actions.topology.service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hortonworks.registries.common.transaction.TransactionIsolation;
 import com.hortonworks.registries.common.util.FileStorage;
 import com.hortonworks.registries.storage.TransactionManager;
 import com.hortonworks.registries.storage.transaction.ManagedTransaction;
+import com.hortonworks.registries.storage.transaction.TransactionIsolation;
 import com.hortonworks.streamline.common.configuration.ConfigFileType;
 import com.hortonworks.streamline.common.configuration.ConfigFileWriter;
 import com.hortonworks.streamline.registries.model.client.MLModelRegistryClient;

--- a/streams/catalog/pom.xml
+++ b/streams/catalog/pom.xml
@@ -54,14 +54,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.hive</groupId>
-            <artifactId>hive-metastore</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hive</groupId>
-            <artifactId>hive-exec</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-framework</artifactId>
         </dependency>

--- a/streams/catalog/pom.xml
+++ b/streams/catalog/pom.xml
@@ -54,6 +54,27 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-metastore</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-exec</artifactId>
+            <classifier>core</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-framework</artifactId>
         </dependency>

--- a/streams/cluster/pom.xml
+++ b/streams/cluster/pom.xml
@@ -32,6 +32,12 @@
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-metastore</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jooq</groupId>

--- a/streams/runners/storm/runtime/pom.xml
+++ b/streams/runners/storm/runtime/pom.xml
@@ -104,6 +104,10 @@
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-auth</artifactId>
               </exclusion>
+              <exclusion>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro</artifactId>
+              </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -223,10 +227,16 @@
             </exclusions>
         </dependency>
         <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-common</artifactId>
-          <version>${hadoop.version}</version>
-          <scope>provided</scope>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.hortonworks.registries</groupId>

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/StreamsModule.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/StreamsModule.java
@@ -15,12 +15,12 @@
  **/
 package com.hortonworks.streamline.streams.service;
 
-import com.hortonworks.registries.common.transaction.TransactionIsolation;
 import com.hortonworks.registries.schemaregistry.client.SchemaRegistryClient;
 import com.hortonworks.registries.storage.StorageManagerAware;
 import com.hortonworks.registries.storage.TransactionManager;
 import com.hortonworks.registries.storage.TransactionManagerAware;
 import com.hortonworks.registries.storage.transaction.ManagedTransaction;
+import com.hortonworks.registries.storage.transaction.TransactionIsolation;
 import com.hortonworks.streamline.common.Constants;
 import com.hortonworks.streamline.common.FileEventHandler;
 import com.hortonworks.streamline.common.FileWatcher;

--- a/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyDashboardResource.java
+++ b/streams/service/src/main/java/com/hortonworks/streamline/streams/service/TopologyDashboardResource.java
@@ -2,9 +2,9 @@ package com.hortonworks.streamline.streams.service;
 
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.base.Stopwatch;
-import com.hortonworks.registries.common.transaction.TransactionIsolation;
 import com.hortonworks.registries.storage.TransactionManager;
 import com.hortonworks.registries.storage.transaction.ManagedTransaction;
+import com.hortonworks.registries.storage.transaction.TransactionIsolation;
 import com.hortonworks.streamline.common.exception.service.exception.request.EntityNotFoundException;
 import com.hortonworks.streamline.common.util.ParallelStreamUtil;
 import com.hortonworks.streamline.common.util.WSUtils;


### PR DESCRIPTION
SR depends on Avro 1.8 whereas dependencies in Hadoop ecosystem depend on Avro 1.7 hence conflicted.
This patch fixes the issue to try best to leverage SR's Avro version in runtime topology.

This depends on https://github.com/hortonworks/registry/pull/541 - so we need to update SR's version here in the patch. I just didn't do this because it requires new release of SR.