### PR TITLE
ISSUE-1344: Add missing classname argument in download-streamine-artifacts.py

### DIFF
--- a/bootstrap/download-streamine-artifacts.py
+++ b/bootstrap/download-streamine-artifacts.py
@@ -60,6 +60,7 @@ class ConfigStruct:
 
     def build_storm_submit_tool_command(self, artifacts):
         submit_tool_cmd_list = ["java", "-cp", self.get_storm_submit_tool_classpath()]
+        submit_tool_cmd_list.extend(["org.apache.storm.submit.command.DependencyResolverMain"])
         submit_tool_cmd_list.extend(["--artifactRepositories", self.maven_repo_url])
         submit_tool_cmd_list.extend(["--artifacts", artifacts])
         submit_tool_cmd_list.extend(["--mavenLocalRepositoryDirectory", self.maven_local_repository_directory])


### PR DESCRIPTION
While trying to run download-streamine-artifacts.py, it throws below error.

Unrecognized option: --artifactRepositories
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.

It appears that the classname is missing in the java command that the script is trying to execute

#fixes #1344  