### PR TITLE
ISSUE-1353 Upgrade Schema Registry to 0.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,8 +164,7 @@
         <phoenix.version>5.0.0.3.1.0.0-78</phoenix.version>
         <redis.lettuce.version>3.4.2.Final</redis.lettuce.version>
         <scala.version>2.10.5</scala.version>
-        <!-- Ideally we need to use official version of SR: wait for new release -->
-        <schema-registry.version>0.6.0.3.4.0.0-145</schema-registry.version>
+        <schema-registry.version>0.7.0</schema-registry.version>
         <slf4j.version>1.7.12</slf4j.version>
         <storm.version>1.2.2</storm.version>
         <woodstox-core-asl.version>4.4.1</woodstox-core-asl.version>


### PR DESCRIPTION
We've been depending on HDF specific version of SR which was a bit outdated and eventually be removed in nexus.

This patch upgrades SR to 0.7.0 which is newer official release and newer HDF versions are also relying on.